### PR TITLE
refactor(app): Refactor of routes and model relationships

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,9 @@ Metrics/BlockLength:
 Layout/LineLength:
   Max: 120
 
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
 RSpec/ContextWording:
   Enabled: False
 

--- a/app/controllers/concerns/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/authenticated_controller_concern.rb
@@ -24,7 +24,10 @@ module AuthenticatedControllerConcern
   end
 
   def authenticate_agent!
-    redirect_to sign_in_path unless logged_in?
+    return if logged_in?
+
+    session[:agent_return_to] = request.env['PATH_INFO']
+    redirect_to sign_in_path
   end
 
   def logged_in?
@@ -32,7 +35,7 @@ module AuthenticatedControllerConcern
   end
 
   def current_agent
-    @current_agent ||= Agent.includes(:department).find_by(id: session[:agent_id])
+    @current_agent ||= Agent.includes(:departments).find_by(id: session[:agent_id])
   end
 
   def pundit_user
@@ -41,6 +44,6 @@ module AuthenticatedControllerConcern
 
   def agent_not_authorized
     flash[:alert] = "Votre compte ne vous permet pas d'effectuer cette action"
-    redirect_to(request.referer || root_path)
+    redirect_to root_path
   end
 end

--- a/app/controllers/departments_controller.rb
+++ b/app/controllers/departments_controller.rb
@@ -1,19 +1,7 @@
 class DepartmentsController < ApplicationController
   skip_before_action :authenticate_agent!, only: [:index]
-  before_action :set_department, only: [:show]
 
   def index
     @departments = Department.all
-  end
-
-  def show
-    authorize @department
-    @configuration = @department.configuration
-  end
-
-  private
-
-  def set_department
-    @department = Department.find(params[:id])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
   def create
     if find_or_create_agent.success?
       set_session(created_agent.id, session_params)
-      render json: { success: true, redirect_path: department_path(current_agent.department) }
+      render json: { success: true, redirect_path: session.delete(:agent_return_to) || root_path }
     else
       render json: { success: false, errors: find_or_create_agent.errors }
     end

--- a/app/javascript/react/actions/createApplicant.js
+++ b/app/javascript/react/actions/createApplicant.js
@@ -1,5 +1,5 @@
-const createApplicant = async (applicant) => {
-  const response = await fetch("/applicants", {
+const createApplicant = async (applicant, departmentId) => {
+  const response = await fetch(`/departments/${departmentId}/applicants`, {
     method: "POST",
     credentials: "same-origin",
     headers: {

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -3,11 +3,11 @@ import Swal from "sweetalert2";
 import createApplicant from "../actions/createApplicant";
 import inviteApplicant from "../actions/inviteApplicant";
 
-export default function Applicant({ applicant, dispatchApplicants }) {
+export default function Applicant({ applicant, dispatchApplicants, department }) {
   const [isLoading, setIsLoading] = useState(false);
 
   const handleApplicantCreation = async () => {
-    const result = await createApplicant(applicant);
+    const result = await createApplicant(applicant, department.id);
     if (result.success) {
       applicant.augmentWith(result.augmented_applicant);
 

--- a/app/javascript/react/components/ApplicantList.jsx
+++ b/app/javascript/react/components/ApplicantList.jsx
@@ -1,8 +1,12 @@
 import React from "react";
 import Applicant from "./Applicant";
 
-export default function ApplicantList({ applicants, dispatchApplicants }) {
+export default function ApplicantList({ applicants, dispatchApplicants, department }) {
   return applicants.map(({ applicant }) => (
-    <Applicant applicant={applicant} dispatchApplicants={dispatchApplicants} />
+    <Applicant
+      applicant={applicant}
+      dispatchApplicants={dispatchApplicants}
+      department={department}
+    />
   ));
 }

--- a/app/javascript/react/pages/Applicants.jsx
+++ b/app/javascript/react/pages/Applicants.jsx
@@ -14,7 +14,7 @@ import Applicant from "../models/Applicant";
 
 const reducer = reducerFactory("Expérimentation RSA");
 
-export default function Department({ department, configuration }) {
+export default function Applicants({ department, configuration }) {
   const SHEET_NAME = configuration.sheet_name;
 
   const [fileSize, setFileSize] = useState(0);
@@ -145,7 +145,11 @@ export default function Department({ department, configuration }) {
                   </tr>
                 </thead>
                 <tbody>
-                  <ApplicantList applicants={applicants} dispatchApplicants={dispatchApplicants} />
+                  <ApplicantList
+                    applicants={applicants}
+                    dispatchApplicants={dispatchApplicants}
+                    department={department}
+                  />
                 </tbody>
               </table>
             </div>

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,6 +1,6 @@
 class Agent < ApplicationRecord
   validates :email, presence: true, uniqueness: true
-  belongs_to :department
+  has_and_belongs_to_many :departments
 
   delegate :rdv_solidarites_organisation_id, to: :department
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,7 +1,7 @@
 class Department < ApplicationRecord
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, :capital, :number, presence: true
-  has_many :agents, dependent: :destroy
+  has_and_belongs_to_many :agents, dependent: :destroy
   has_many :applicants, dependent: :destroy
   has_one :configuration, dependent: :destroy
 

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -1,5 +1,9 @@
 class DepartmentPolicy < ApplicationPolicy
-  def show?
-    pundit_user.department == record
+  def list_applicants?
+    pundit_user.departments.include?(record)
+  end
+
+  def create_applicant?
+    list_applicants?
   end
 end

--- a/app/services/create_applicant.rb
+++ b/app/services/create_applicant.rb
@@ -1,8 +1,8 @@
 class CreateApplicant < BaseService
-  def initialize(applicant_data:, rdv_solidarites_session:, agent:)
+  def initialize(applicant_data:, rdv_solidarites_session:, department:)
     @applicant_data = applicant_data
     @rdv_solidarites_session = rdv_solidarites_session
-    @agent = agent
+    @department = department
   end
 
   def call
@@ -51,7 +51,7 @@ class CreateApplicant < BaseService
   end
 
   def applicant_attributes
-    { department: @agent.department }.merge(
+    { department: @department }.merge(
       @applicant_data.slice(*Applicant.attribute_names.map(&:to_sym)).compact
     )
   end
@@ -73,7 +73,7 @@ class CreateApplicant < BaseService
 
   def rdv_solidarites_user_attributes
     user_attributes = {
-      organisation_ids: [@agent.rdv_solidarites_organisation_id]
+      organisation_ids: [@department.rdv_solidarites_organisation_id]
     }.merge(
       @applicant_data.slice(*RdvSolidaritesUser::USER_ATTRIBUTES).compact
     ).deep_symbolize_keys

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -1,5 +1,5 @@
 <%= react_component(
-  "pages/Department", {
+  "pages/Applicants", {
     department: @department, configuration: @configuration
   }
 ) %>

--- a/app/views/departments/index.html.erb
+++ b/app/views/departments/index.html.erb
@@ -15,7 +15,7 @@
     <div class="col-8">
       <% @departments.each do |department| %>
         <div class="card-container">
-          <%= link_to department_path(department) do %>
+          <%= link_to department_applicants_path(department) do %>
             <div class="card d-flex flex-row justify-content-between align-content-center card-department mb-3">
               <div class="card-body card-department-body">
                 <h4><%= department.name %></h4>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
   root "departments#index"
-  resources :departments, only: [:index, :show]
-  resources :applicants, only: [:create] do
+  resources :departments, only: [:index] do
+    resources :applicants, only: [:index, :create]
+  end
+
+  resources :applicants, only: [] do
     post :search, on: :collection
     resources :invitations, only: [:create]
   end
+
   resources :sessions, only: [:create]
   get '/sign_in', to: "sessions#new"
   delete '/sign_out', to: "sessions#destroy"

--- a/db/migrate/20210902084652_add_department_agents.rb
+++ b/db/migrate/20210902084652_add_department_agents.rb
@@ -1,0 +1,16 @@
+class AddDepartmentAgents < ActiveRecord::Migration[6.1]
+  # from one-to-many to many-to-many
+  def change
+    create_join_table :departments, :agents do |t|
+      t.index [:department_id, :agent_id], unique: true
+    end
+
+    up_only do
+      Agent.all.each do |agent|
+        agent.update(departments: [Department.find(agent.department_id)]) unless agent.department_id.nil?
+      end
+    end
+
+    remove_reference :agents, :department, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,26 +2,30 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_16_143900) do
+ActiveRecord::Schema.define(version: 2021_09_02_084652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "agents", force: :cascade do |t|
     t.string "email"
-    t.bigint "department_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["department_id"], name: "index_agents_on_department_id"
     t.index ["email"], name: "index_agents_on_email", unique: true
+  end
+
+  create_table "agents_departments", id: false, force: :cascade do |t|
+    t.bigint "department_id", null: false
+    t.bigint "agent_id", null: false
+    t.index ["department_id", "agent_id"], name: "index_agents_departments_on_department_id_and_agent_id", unique: true
   end
 
   create_table "applicants", force: :cascade do |t|
@@ -69,7 +73,6 @@ ActiveRecord::Schema.define(version: 2021_07_16_143900) do
     t.index ["applicant_id"], name: "index_invitations_on_applicant_id"
   end
 
-  add_foreign_key "agents", "departments"
   add_foreign_key "applicants", "departments"
   add_foreign_key "configurations", "departments"
   add_foreign_key "invitations", "applicants"

--- a/spec/controllers/departments_controller_spec.rb
+++ b/spec/controllers/departments_controller_spec.rb
@@ -2,7 +2,6 @@ describe DepartmentsController, type: :controller do
   render_views
 
   let!(:department) { create(:department) }
-  let!(:agent) { create(:agent, department: department) }
 
   describe "GET #index" do
     it "returns a success response" do
@@ -14,38 +13,6 @@ describe DepartmentsController, type: :controller do
       get :index
 
       expect(response.body).to match(/#{department.name}/)
-    end
-  end
-
-  describe "GET #show" do
-    before do
-      sign_in(agent)
-    end
-
-    context "when department does not exist" do
-      it "returns an error" do
-        expect do
-          get :show, params: { id: "i-do-not-exist" }
-        end.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "when agent does not belong to the department" do
-      let(:other_department) { create(:department) }
-      let(:agent) { create(:agent, department: other_department) }
-
-      it "redirects the agent" do
-        get :show, params: { id: department.id }
-        expect(response).to redirect_to(root_path)
-        expect(flash[:alert]).to include("Votre compte ne vous permet pas d'effectuer cette action")
-      end
-    end
-
-    context "when agent is authorized" do
-      it "returns a success response" do
-        get :show, params: { id: department.id }
-        expect(response).to be_successful
-      end
     end
   end
 end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -2,7 +2,7 @@ describe InvitationsController, type: :controller do
   describe "#create" do
     let!(:applicant_id) { "24" }
     let!(:department) { create(:department) }
-    let!(:agent) { create(:agent, department: department) }
+    let!(:agent) { create(:agent, departments: [department]) }
     let!(:configuration) { create(:configuration, department: department) }
     let!(:applicant) { create(:applicant, department: department, id: applicant_id) }
     let!(:create_params) { { applicant_id: applicant_id } }

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :agent do
     sequence(:email) { |n| "johndoe#{n}@example.com" }
-    department { create(:department) }
   end
 end

--- a/spec/policies/department_policy_spec.rb
+++ b/spec/policies/department_policy_spec.rb
@@ -4,18 +4,18 @@ describe DepartmentPolicy, type: :policy do
   let(:agent) { create(:agent) }
   let(:department) { create(:department) }
 
-  describe "#show?" do
+  describe "#list_applicants?" do
     context "when the agent belongs to the department" do
-      let(:agent) { create(:agent, department: department) }
+      let(:agent) { create(:agent, departments: [department]) }
 
-      permissions(:show?) { it { is_expected.to permit(agent, department) } }
+      permissions(:list_applicants?) { it { is_expected.to permit(agent, department) } }
     end
 
     context "when the agent does not belong to the department" do
       let(:other_department) { create(:department) }
-      let(:agent) { create(:agent, department: other_department) }
+      let(:agent) { create(:agent, departments: [other_department]) }
 
-      permissions(:show?) { it { is_expected.not_to permit(agent, department) } }
+      permissions(:list_applicants?) { it { is_expected.not_to permit(agent, department) } }
     end
   end
 end

--- a/spec/services/create_applicant_spec.rb
+++ b/spec/services/create_applicant_spec.rb
@@ -2,11 +2,11 @@ describe CreateApplicant, type: :service do
   subject do
     described_class.call(
       applicant_data: applicant_data, rdv_solidarites_session: rdv_solidarites_session,
-      agent: agent
+      department: department
     )
   end
 
-  let(:agent) { create(:agent) }
+  let(:department) { create(:department) }
 
   let(:applicant_data) do
     {
@@ -21,7 +21,7 @@ describe CreateApplicant, type: :service do
 
   describe "#call" do
     let(:applicant_attributes) do
-      { uid: "1234xyz", role: "demandeur", affiliation_number: "aff123", department: agent.department }
+      { uid: "1234xyz", role: "demandeur", affiliation_number: "aff123", department: department }
     end
     let!(:applicant) { build(:applicant, applicant_attributes) }
     let(:rdv_solidarites_client) { instance_double(RdvSolidaritesSession) }
@@ -74,7 +74,7 @@ describe CreateApplicant, type: :service do
           first_name: "john", last_name: "doe",
           address: "16 rue de la tour", email: "johndoe@example.com",
           affiliation_number: "aff123",
-          organisation_ids: [agent.rdv_solidarites_organisation_id]
+          organisation_ids: [department.rdv_solidarites_organisation_id]
         }
       end
 

--- a/spec/services/find_or_create_agent_spec.rb
+++ b/spec/services/find_or_create_agent_spec.rb
@@ -1,17 +1,16 @@
 describe FindOrCreateAgent, type: :service do
   subject { described_class.call(email: agent.email, organisation_ids: organisation_ids) }
 
-  let(:department) { create(:department) }
-  let(:agent) { create(:agent, department: department) }
-  let(:email) { agent.email }
+  let!(:agent) { create(:agent) }
+  let!(:email) { agent.email }
 
-  let(:organisation_ids) { [] }
+  let!(:organisation_ids) { [] }
 
   describe "#call" do
     let(:error_message) { "l'agent n'appartient pas à une organisation liée à un département" }
 
     context "when no organisation_ids are passed" do
-      let(:organisation_ids) { [] }
+      let!(:organisation_ids) { [] }
 
       it "fails with an error" do
         expect(subject.failure?).to eq(true)
@@ -21,8 +20,8 @@ describe FindOrCreateAgent, type: :service do
     end
 
     context "when the organisations does not belong to one department" do
-      let(:department) { create(:department, rdv_solidarites_organisation_id: 31) }
-      let(:organisation_ids) { [39, 52] }
+      let!(:department) { create(:department, rdv_solidarites_organisation_id: 31) }
+      let!(:organisation_ids) { [39, 52] }
 
       it "fails with an error" do
         expect(subject.failure?).to eq(true)
@@ -32,12 +31,12 @@ describe FindOrCreateAgent, type: :service do
     end
 
     context "when department is found" do
-      let(:department) { create(:department, rdv_solidarites_organisation_id: 31) }
-      let(:organisation_ids) { [31, 42] }
+      let!(:department) { create(:department, rdv_solidarites_organisation_id: 31) }
+      let!(:organisation_ids) { [31, 42] }
 
       before do
         allow(Agent).to receive(:find_or_create_by)
-          .with(email: email, department: department)
+          .with(email: email)
           .and_return(agent)
       end
 
@@ -47,12 +46,17 @@ describe FindOrCreateAgent, type: :service do
 
       it "finds or create the agent" do
         expect(Agent).to receive(:find_or_create_by)
-          .with(email: email, department: department)
+          .with(email: email)
         subject
       end
 
       it "returns the agent" do
         expect(subject.agent).to eq(agent)
+      end
+
+      it "updates the agent by assigning the departments" do
+        subject
+        expect(agent.departments).to eq([department])
       end
     end
   end


### PR DESCRIPTION
Cette PR contient plusieurs refactors de l'application existante,  les principaux étant: 

- Changement de la relation entre `agent` et `department` en passant de one-to-one à one-to-many pour être plus iso avec ce qu'il se fait sur Rdv-Solidarités
- Changement de certaines routes et actions pour être plus REST en nestant notamment les actions liées aux `applicants` au sein des `departments`.