### PR TITLE
Feat/Raccourcir le lien d'invitation envoyé au bRSA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 RDV_SOLIDARITES_URL=http://localhost:5000
 RDV_SOLIDARITES_RSA_SERVICE_ID=change_me
+HOST=http://localhost:8000
 
 # Third-party services
 ## SMS

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,6 +1,7 @@
 class InvitationsController < ApplicationController
   before_action :set_applicant, only: [:create]
   before_action :set_invitation, only: [:redirect]
+  skip_before_action :authenticate_agent!, only: [:redirect]
   respond_to :json
 
   def create
@@ -13,6 +14,7 @@ class InvitationsController < ApplicationController
 
   def redirect
     @invitation.seen = true
+    @invitation.save!
     redirect_to @invitation.link
   end
 
@@ -36,6 +38,6 @@ class InvitationsController < ApplicationController
   end
 
   def set_invitation
-    @invitation = Invitation.find_by(token: params[:invitation_token])
+    @invitation = Invitation.find_by(token: params[:token])
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,5 +1,6 @@
 class InvitationsController < ApplicationController
-  before_action :set_applicant
+  before_action :set_applicant, only: [:create]
+  before_action :set_invitation, only: [:redirect]
   respond_to :json
 
   def create
@@ -8,6 +9,11 @@ class InvitationsController < ApplicationController
     else
       render json: { success: false, errors: invite_applicant.errors }
     end
+  end
+
+  def redirect
+    @invitation.seen = true
+    redirect_to @invitation.link
   end
 
   private
@@ -27,5 +33,9 @@ class InvitationsController < ApplicationController
 
   def department
     @applicant.department
+  end
+
+  def set_invitation
+    @invitation = Invitation.find_by(token: params[:invitation_token])
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -14,7 +14,7 @@ class InvitationsController < ApplicationController
 
   def redirect
     @invitation.seen = true
-    @invitation.save!
+    @invitation.save
     redirect_to @invitation.link
   end
 

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -27,7 +27,8 @@ module Invitations
       "Bonjour,\nVous êtes allocataire du RSA. Vous devez bénéficier d'un accompagnement obligatoire dans " \
         "le cadre de vos démarches d'insertion. Le département #{department.number} (#{department.name.capitalize}) " \
         "vous invite à prendre rendez-vous auprès d'un référent afin d'échanger sur votre situation.\n" \
-        "Vous devez prendre rendez-vous en ligne à l'adresse suivante: #{@invitation.link}\n" \
+        "Vous devez prendre rendez-vous en ligne à l'adresse suivante: " \
+        "www.rdv-insertion.fr/invitations/redirect?token=#{@invitation.token}\n" \
         "En cas d'absence, une sanction pourra être prononcée. Pour tout problème, contactez " \
         "le secrétariat au #{department.phone_number}."
     end

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -1,5 +1,7 @@
 module Invitations
   class SendSms < BaseService
+    include Rails.application.routes.url_helpers
+
     def initialize(invitation:, phone_number:)
       @invitation = invitation
       @phone_number = phone_number
@@ -28,7 +30,7 @@ module Invitations
         "le cadre de vos démarches d'insertion. Le département #{department.number} (#{department.name.capitalize}) " \
         "vous invite à prendre rendez-vous auprès d'un référent afin d'échanger sur votre situation.\n" \
         "Vous devez prendre rendez-vous en ligne à l'adresse suivante: " \
-        "www.rdv-insertion.fr/invitations/redirect?token=#{@invitation.token}\n" \
+        "#{redirect_invitations_url(params: { token: @invitation.token }, host: ENV['HOST'])}\n" \
         "En cas d'absence, une sanction pourra être prononcée. Pour tout problème, contactez " \
         "le secrétariat au #{department.phone_number}."
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,7 @@ Rails.application.routes.draw do
   get '/sign_in', to: "sessions#new"
   delete '/sign_out', to: "sessions#destroy"
 
-  get '/invitations/redirect', to: "invitations#redirect"
+  resources :invitations, only: [] do
+    get :redirect, on: :collection
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
   resources :sessions, only: [:create]
   get '/sign_in', to: "sessions#new"
   delete '/sign_out', to: "sessions#destroy"
+
+  get '/invitations/redirect', to: "invitations#redirect"
 end

--- a/db/migrate/20210907172021_add_seen_to_invitations.rb
+++ b/db/migrate/20210907172021_add_seen_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddSeenToInvitations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :invitations, :seen, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_02_131848) do
+ActiveRecord::Schema.define(version: 2021_09_07_172021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 2021_09_02_131848) do
     t.bigint "applicant_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "seen", default: false
     t.index ["applicant_id"], name: "index_invitations_on_applicant_id"
   end
 

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -72,4 +72,22 @@ describe InvitationsController, type: :controller do
       end
     end
   end
+
+  describe "#redirect" do
+    let!(:applicant_id) { "24" }
+    let!(:department) { create(:department) }
+    let!(:applicant) { create(:applicant, department: department, id: applicant_id) }
+    let!(:invitation) { create(:invitation, applicant: applicant) }
+    let!(:invite_params) { { token: invitation.token } }
+
+    it "mark the invitation as seen" do
+      get :redirect, params: invite_params
+      expect(invitation.reload.seen).to eq(true)
+    end
+
+    it "redirects to the invitation link" do
+      get :redirect, params: invite_params
+      expect(response).to redirect_to invitation.link
+    end
+  end
 end

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -1,4 +1,6 @@
 describe Invitations::SendSms, type: :service do
+  include Rails.application.routes.url_helpers
+
   subject do
     described_class.call(
       invitation: invitation,
@@ -28,13 +30,14 @@ describe Invitations::SendSms, type: :service do
         "le cadre de vos démarches d'insertion. Le département 26 (Drôme) " \
         "vous invite à prendre rendez-vous auprès d'un référent afin d'échanger sur votre situation.\n" \
         "Vous devez prendre rendez-vous en ligne à l'adresse suivante: "\
-        "www.rdv-insertion.fr/invitations/redirect?token=123\n" \
+        "#{redirect_invitations_url(params: { token: invitation.token }, host: ENV['HOST'])}\n" \
         "En cas d'absence, une sanction pourra être prononcée. Pour tout problème, contactez " \
         "le secrétariat au 0147200001."
     end
 
     before do
       allow(SendTransactionalSms).to receive(:call)
+      ENV['HOST'] = "http://localhost:8000"
     end
 
     it("is a success") { is_a_success }

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -28,7 +28,7 @@ describe Invitations::SendSms, type: :service do
         "le cadre de vos démarches d'insertion. Le département 26 (Drôme) " \
         "vous invite à prendre rendez-vous auprès d'un référent afin d'échanger sur votre situation.\n" \
         "Vous devez prendre rendez-vous en ligne à l'adresse suivante: "\
-        "https://www.rdv-solidarites.fr/lieux?invitation_token=123\n" \
+        "www.rdv-insertion.fr/invitations/redirect?token=123\n" \
         "En cas d'absence, une sanction pourra être prononcée. Pour tout problème, contactez " \
         "le secrétariat au 0147200001."
     end

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -21,7 +21,7 @@ describe Invitations::SendSms, type: :service do
     )
   end
   let!(:invitation) do
-    create(:invitation, applicant: applicant, link: "https://www.rdv-solidarites.fr/lieux?invitation_token=123")
+    create(:invitation, applicant: applicant, token: "123", link: "https://www.rdv-solidarites.fr/lieux?invitation_token=123")
   end
 
   describe "#call" do
@@ -30,14 +30,14 @@ describe Invitations::SendSms, type: :service do
         "le cadre de vos démarches d'insertion. Le département 26 (Drôme) " \
         "vous invite à prendre rendez-vous auprès d'un référent afin d'échanger sur votre situation.\n" \
         "Vous devez prendre rendez-vous en ligne à l'adresse suivante: "\
-        "#{redirect_invitations_url(params: { token: invitation.token }, host: ENV['HOST'])}\n" \
+        "http://www.rdv-insertion.fr/invitations/redirect?token=123\n" \
         "En cas d'absence, une sanction pourra être prononcée. Pour tout problème, contactez " \
         "le secrétariat au 0147200001."
     end
 
     before do
       allow(SendTransactionalSms).to receive(:call)
-      ENV['HOST'] = "http://localhost:8000"
+      ENV['HOST'] = "www.rdv-insertion.fr"
     end
 
     it("is a success") { is_a_success }


### PR DESCRIPTION
Cette PR vise à permettre l'envoi d'un lien raccourci à l'utilisateur, un problème soulevé dans l'issue #13. Le code ajouté correspond à :
- Créer une nouvelle route GET , qui prend en paramètres le token d'invitation
- Au sein de l'action du controller associée (invitations#redirect), le record d'invitation associé au token est récupéré.
- Ajout d'une colonne seen de type booléen sur la table invitations qui est égale à false par défaut et qui est updatée à true une fois que le record d'invitation est retrouvé au sein de l'action invitations#redirect
- Redirection de l'utilisateur sur le link associé à l'invitation qui redirige vers rdv-solidarités
