### PR TITLE
refactor(yonne): do not notify on rdv update

### DIFF
--- a/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
+++ b/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
@@ -1,7 +1,9 @@
 module FilterRdvSolidaritesWebhooksConcern
   extend ActiveSupport::Concern
 
-  SUPPORTED_MODELS_TYPES = ["Rdv"].freeze
+  SUPPORTED_EVENTS_FOR_MODELS_TYPES = {
+    "Rdv" => %w[created destroyed]
+  }.freeze
 
   included do
     before_action :check_webhook_auth!
@@ -21,7 +23,11 @@ module FilterRdvSolidaritesWebhooksConcern
   end
 
   def webhook_supported?
-    SUPPORTED_MODELS_TYPES.include?(params[:meta][:model])
+    supported_events.present? && supported_events.include?(params[:meta][:event])
+  end
+
+  def supported_events
+    SUPPORTED_EVENTS_FOR_MODELS_TYPES[params[:meta][:model]]
   end
 
   def webhook_correctly_signed?

--- a/app/jobs/notify_applicant_job.rb
+++ b/app/jobs/notify_applicant_job.rb
@@ -27,7 +27,6 @@ class NotifyApplicantJob < ApplicationJob
   def service_class_for_event_type(event_type)
     {
       "created" => Notifications::RdvCreated,
-      "updated" => Notifications::RdvUpdated,
       "destroyed" => Notifications::RdvCancelled
     }[event_type]
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,9 @@
-Rails.logger = Sidekiq.logger unless Rails.env.test?
 Sidekiq.configure_server do |config|
   config.redis = { url: (ENV["REDIS_URL"] || 'redis://localhost:6379/0') }
+  config.logger.level = ::Logger::INFO
+
+  Rails.logger = Sidekiq.logger
+  ActiveRecord::Base.logger = Sidekiq.logger
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
We decided not to notify applicants for the moment when a RDV is updated.
So I added a filter on the update webhooks to not process them anymore. 