### PR TITLE
fix(app): Load invitations along with applicants

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -55,7 +55,7 @@ class ApplicantsController < ApplicationController
   end
 
   def retrieve_applicants
-    @applicants = Applicant.includes(:department)
+    @applicants = Applicant.includes(:department, :invitations)
                            .where(uid: params.require(:applicants).require(:uids))
                            .to_a
   end


### PR DESCRIPTION
We load the applications along with the applicants to avoid querying each invitation afterwards. 