### PR TITLE
fix(drome): format email attribute

### DIFF
--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -146,7 +146,7 @@ export default class Applicant {
       role: this.role,
       affiliation_number: this.affiliationNumber,
       ...(this.phoneNumber && { phone_number: this.phoneNumber }),
-      ...(this.email && { email: this.email }),
+      ...(this.email && this.email.includes("@") && { email: this.email }),
       ...(this.birthDate && { birth_date: this.birthDate }),
       ...(this.birthName && { birth_name: this.birthName }),
       ...(this.customId && { custom_id: this.customId }),


### PR DESCRIPTION
Sur le fichier de la Drôme une "x" est placée quand un email n'est pas présent, ce qui renvoie une erreur lors de la validation de l'email.
Dans cette PR je n'envoie pas aux API les emails s'ils ne contiennent pas un "@". 