### PR TITLE
feat(sentry): Add context to sentry events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'sidekiq'
 # Monitor errors
 gem "sentry-ruby"
 gem "sentry-rails"
+gem "sentry-sidekiq"
 
 # gem needed to be defined explicitely with ruby 3
 gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,9 @@ GEM
     sentry-ruby-core (4.7.2)
       concurrent-ruby
       faraday
+    sentry-sidekiq (4.7.2)
+      sentry-ruby-core (~> 4.7.0)
+      sidekiq (>= 3.0)
     sib-api-v3-sdk (7.5.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
@@ -311,6 +314,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails
   sentry-ruby
+  sentry-sidekiq
   sib-api-v3-sdk
   sidekiq
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,22 @@
 class ApplicationController < ActionController::Base
   include Pundit
   protect_from_forgery with: :exception
+  before_action :set_sentry_context
 
   include AuthenticatedControllerConcern
 
   private
+
+  def set_sentry_context
+    Sentry.set_user(sentry_user)
+  end
+
+  def sentry_user
+    {
+      id: current_agent&.id,
+      email: current_agent&.email
+    }.compact
+  end
 
   def rdv_solidarites_session
     session[:rdv_solidarites]


### PR DESCRIPTION
Dans cette PR j'ajoute un context avec l'id et le mail de l'agent aux erreurs sentry, ainsi que la gem `sentry-sidekiq` pour capturer les erreurs se produisant dans nos workers