### PR TITLE
fix(sms): format sms content

### DIFF
--- a/app/services/send_transactional_sms.rb
+++ b/app/services/send_transactional_sms.rb
@@ -16,6 +16,7 @@ class SendTransactionalSms < BaseService
     api_instance = SibApiV3Sdk::TransactionalSMSApi.new
     api_instance.send_transac_sms(transactional_sms)
   rescue SibApiV3Sdk::ApiError => e
+    Sentry.capture_exception(e, extra: { response_body: e.response_body })
     fail!("une erreur est survenue en envoyant le sms. #{e.message}")
   end
 
@@ -23,8 +24,13 @@ class SendTransactionalSms < BaseService
     SibApiV3Sdk::SendTransacSms.new(
       sender: SENDER_NAME,
       recipient: @phone_number,
-      content: @content,
+      content: formatted_content,
       type: "transactional"
     )
+  end
+
+  def formatted_content
+    @content.gsub("ô", "e")
+            .gsub("ê", "e")
   end
 end


### PR DESCRIPTION
Sendinblue renvoie une erreur depuis ce matin lorsqu'on essaie d'envoyer des SMS.
Le message d'erreur dise  "message trop long" alors qu'il n'apparaissait  pas avant. 
Je vais ouvrir un ticket sur le support de SendInBlue, mais en attendant j'ai vu qu'enlever les accents circonflexes  résolvait le problème. 
J'envoie aussi l'erreur à Sentry pour  être alerté quand ça arrive.