### PR TITLE
fix(sms): format content correctly

### DIFF
--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -19,7 +19,7 @@ module Invitations
 
     def send_sms
       Rails.logger.info(content)
-      return if Rails.env.development?
+      return unless Rails.env.production?
 
       SendTransactionalSms.call(phone_number: phone_number, content: content)
     end

--- a/app/services/send_transactional_sms.rb
+++ b/app/services/send_transactional_sms.rb
@@ -30,7 +30,7 @@ class SendTransactionalSms < BaseService
   end
 
   def formatted_content
-    @content.gsub("ô", "e")
+    @content.gsub("ô", "o")
             .gsub("ê", "e")
   end
 end

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -40,6 +40,7 @@ describe Invitations::SendSms, type: :service do
 
     before do
       allow(SendTransactionalSms).to receive(:call)
+      allow(Rails).to receive_message_chain(:env, :production?).and_return(true)
       ENV['HOST'] = "www.rdv-insertion.fr"
     end
 


### PR DESCRIPTION
Je remplaçais les "ô" par des "e" dans la PR précédente 🤦, cette PR répare ça et assure de n'envoyer des sms que en production. 