### PR TITLE
Feat/Add mailers & send_email service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ HOST=http://localhost:8000
 # Third-party services
 ## SMS
 SENDINBLUE_API_V3_KEY=change_me
+## Emails
+SENDINBLUE_PASSWORD=change_me
+SENDINBLUE_USERNAME=change_me
 ## Monitoring
 SENTRY_DSN=change_me
 SENTRY_ENVIRONMENT=change_me

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 /app/javascript/images/*
 /app/javascript/stylesheets/*
 /app/javascript/packs/application.js
+/app/javascript/packs/mail.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,5 +17,12 @@
     "react/prop-types": 0,
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "no-param-reassign": "off"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["src"]
+      }
+    }
   }
 }

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'kaminari'
 # PG search
 gem 'pg_search'
 
+# CSS styled emails with stylesheets
+gem 'premailer-rails'
+
 # Send SMS & emails with SendInBlue
 gem 'sib-api-v3-sdk'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crass (1.0.6)
+    css_parser (1.10.0)
+      addressable
     diff-lcs (1.4.4)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -119,6 +121,7 @@ GEM
     ffi (1.15.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    htmlentities (4.3.4)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -159,6 +162,13 @@ GEM
     pg_search (2.3.5)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    premailer (1.15.0)
+      addressable
+      css_parser (>= 1.6.0)
+      htmlentities (>= 4.0.0)
+    premailer-rails (1.11.1)
+      actionmailer (>= 3)
+      premailer (~> 1.7, >= 1.7.9)
     public_suffix (4.0.6)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -320,6 +330,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   pg_search
+  premailer-rails
   puma (~> 4.1)
   pundit
   rails (>= 6.0.4.1)

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -14,7 +14,7 @@ class InvitationsController < ApplicationController
   end
 
   def redirect
-    @invitation.seen = true
+    @invitation.clicked = true
     @invitation.save
     redirect_to @invitation.link
   end

--- a/app/javascript/packs/mail.js
+++ b/app/javascript/packs/mail.js
@@ -1,0 +1,1 @@
+import "stylesheets/mail";

--- a/app/javascript/stylesheets/mail.scss
+++ b/app/javascript/stylesheets/mail.scss
@@ -1,0 +1,262 @@
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "./_variables";
+
+$padding: 30px;
+
+/* -------------------------------------
+    GLOBAL
+    A very basic CSS reset
+    https://github.com/mailgun/transactional-email-templates/blob/master/templates/styles.css
+------------------------------------- */
+* {
+  margin: 0;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+
+img {
+  max-width: 100%;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  -webkit-text-size-adjust: none;
+  width: 100% !important;
+  height: 100%;
+  line-height: 1.6em;
+  /* 1.6em * 14px = 22.4px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 22px;*/
+}
+
+/* Let's make sure all tables have defaults */
+table td {
+  vertical-align: top;
+}
+
+/* -------------------------------------
+    BODY & CONTAINER
+------------------------------------- */
+body {
+  background-color: #f6f6f6;
+}
+
+.overview{
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+  margin: 40px;
+  padding: 20px;
+}
+
+.body-wrap {
+  background-color: #f6f6f6;
+  width: 100%;
+}
+
+.container {
+  display: block !important;
+  max-width: 600px !important;
+  margin: 0 auto !important;
+  /* makes it centered */
+  clear: both !important;
+}
+
+table {
+  border-color: $orange !important;
+  border-width: 3px 0 0 !important;
+}
+
+.content {
+  max-width: 600px;
+  margin: 0 auto;
+  display: block;
+  padding: 20px;
+  padding-top: 0px;
+}
+
+/* -------------------------------------
+    HEADER, FOOTER, MAIN
+------------------------------------- */
+.main {
+  background-color: #fff;
+  border: 1px solid #e9e9e9;
+  border-top: 3px solid $blue;
+  border-radius: 3px;
+}
+
+.content-wrap {
+  padding: 20px;
+}
+
+.content-block {
+  padding: 0 0 20px;
+}
+
+.header {
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.footer {
+  width: 100%;
+  clear: both;
+  color: #999;
+  padding: 20px;
+}
+.footer p, .footer a, .footer td {
+  color: #999;
+  font-size: 12px;
+}
+
+/* -------------------------------------
+    TYPOGRAPHY
+------------------------------------- */
+h1, h2, h3 {
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  color: #000;
+  line-height: 1.2em;
+  font-weight: 400;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 500;
+  margin-bottom: 20px;
+  /* 1.2em * 32px = 38.4px, use px to get airier line-height also in Thunderbird, and Yahoo!, Outlook.com, AOL webmail clients */
+  /*line-height: 38px;*/
+}
+
+h3 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+p, ul, ol {
+  margin-bottom: 10px;
+  font-weight: normal;
+}
+p li, ul li, ol li {
+  margin-left: 5px;
+  list-style-position: inside;
+}
+
+/* -------------------------------------
+    LINKS & BUTTONS
+------------------------------------- */
+a {
+  color: #348eda;
+  text-decoration: underline;
+}
+
+/* -------------------------------------
+    OTHER STYLES THAT MIGHT BE USEFUL
+------------------------------------- */
+.last {
+  margin-bottom: 0;
+}
+
+.first {
+  margin-top: 0;
+}
+
+.aligncenter {
+  text-align: center;
+}
+
+.alignright {
+  text-align: right;
+}
+
+.alignleft {
+  text-align: left;
+}
+
+.clear {
+  clear: both;
+}
+
+.d-block{
+  display: block;
+}
+
+.font-weight-bold {
+  font-weight: bold;
+}
+
+.title{
+  font-size: 16px;
+  font-weight: bold;
+  color: black;
+}
+
+.float-right{
+  float: right;
+}
+
+.row-result{
+  padding: 10px 0;
+  margin: 0 10px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.no-border{
+  border: none;
+}
+
+
+body,
+html,
+.body {
+  background: $white !important;
+  color: $body-color;
+}
+
+.body-drip {
+  border-top: 8px solid #663399; }
+
+.header .columns {
+  padding-bottom: 0; }
+
+.header p {
+  color: #fff;
+  padding-top: 15px; }
+
+.wrapper-inner {
+  padding: 40px 20px;
+}
+
+.header .container {
+  background: transparent; }
+
+.wrapper.secondary {
+  background: #f3f3f3;
+}
+
+.logo{
+  margin-top: 20px;
+}
+
+.btn-primary{
+  background-color: $orange;
+  padding: 10px;
+  color: $white;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 18px;
+  width: 100%;
+  border-radius: 3px;
+}
+
+.btn-wrapper{
+  border-radius: 3px;
+  text-align: center;
+  margin: 20px 0 !important;
+}
+
+@media only screen and (max-width: 640px) {
+  .overview{
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+}

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: 'RDV-Insertion <contact@rdv-insertion.fr>',
+          reply_to: 'data.insertion@beta.gouv.fr'
+  append_view_path Rails.root.join("app/views/mailers")
+  layout "mailer"
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,10 @@
+class InvitationMailer < ApplicationMailer
+  def first_invitation(invitation, applicant)
+    @invitation = invitation
+    @applicant = applicant
+    mail(
+      to: @applicant.email,
+      subject: "Prenez RDV pour votre RSA"
+    )
+  end
+end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -9,7 +9,7 @@ class Invitation < ApplicationRecord
     when "sms"
       Invitations::SendSms.call(invitation: self)
     when "email"
-      # should add email service when implemented
+      Invitations::SendEmail.call(invitation: self)
     end
   end
 

--- a/app/services/invitations/send_email.rb
+++ b/app/services/invitations/send_email.rb
@@ -1,0 +1,32 @@
+module Invitations
+  class SendEmail < BaseService
+    def initialize(invitation:)
+      @invitation = invitation
+    end
+
+    def call
+      check_email!
+      send_email
+    end
+
+    private
+
+    def check_email!
+      fail!("le mail doit être renseigné") if email.blank?
+    end
+
+    def email
+      applicant.email
+    end
+
+    def applicant
+      @invitation.applicant
+    end
+
+    def send_email
+      return if Rails.env.development?
+
+      InvitationMailer.first_invitation(@invitation, applicant).deliver_now
+    end
+  end
+end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,12 +2,46 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <style>
-      /* Email styles need to be inline */
-    </style>
+    <%= stylesheet_pack_tag 'mail' %>
   </head>
 
   <body>
-    <%= yield %>
+    <table class="body-wrap">
+      <tr align="center" class="d-block">
+        <td class="logo d-block">
+          <%= link_to root_url do %>
+            <%= image_pack_tag "logos/rdv-insertion.png", alt: "Logo rdv insertion" %>
+          <% end %>
+        <td class="container">
+          <div class="content">
+            <table class="main" width="100%">
+              <tr>
+                <td class="content-wrap">
+                  <table width="100%">
+                    <tbody>
+                      <%= yield %>
+                      <p>À bientôt,</p>
+                      <p>L'équipe RDV Insertion</p>
+                    </tbody>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            <div class="footer">
+              <table width="100%">
+                <tr>
+                  <td align="center" class="content-block">
+                    <%= link_to "https://doc.rdv-solidarites.fr/informations-generales/informations-generales-et-legales-1" do %>
+                      <span>Informations légales</span>
+                    <% end %>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </td>
+      </tr>
+    </table>
   </body>
 </html>
+

--- a/app/views/mailers/invitation_mailer/first_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/first_invitation.html.erb
@@ -1,0 +1,8 @@
+<h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
+<p>Vous êtes nouveau bénéficiaire du RSA et vous allez à ce titre bénéficier d’un accompagnement obligatoire.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre premier rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les 3 jours</span>. Passé ce délai vous recevrez une convocation.</p>
+<p class="btn-wrapper">
+  <a href="<%= @invitation.link %>" class="btn btn-primary">Je prends RDV</a>
+</p>
+<p>En cas de problème technique, contactez le <%= @applicant.department.phone_number.gsub(/\d{2}/, '\& ') %></p>
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,10 +31,13 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.default_url_options = { host: "localhost:8000", utm_source: "dev", utm_medium: "email",
+                                               utm_campaign: "default" }
+  config.action_mailer.asset_host = "http://localhost:8000"
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,6 +66,20 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.default_url_options = { protocol: "https", host: ENV["HOST"].sub(%r{^https?://}, ""),
+                                               utm_source: "rdv-insertion", utm_medium: "email", utm_campaign: "auto" }
+  config.action_mailer.smtp_settings = {
+    address: "smtp-relay.sendinblue.com",
+    port: "587",
+    authentication: 'login',
+    enable_starttls_auto: true,
+    user_name: ENV["SENDINBLUE_USERNAME"],
+    password: ENV["SENDINBLUE_PASSWORD"],
+    domain: "rdv-insertion.fr"
+  }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.asset_host = ENV["HOST"]
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.action_mailer.default_url_options = { host: "localhost:8000" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg

--- a/db/migrate/20211006072539_change_invitation_seen_to_clicked.rb
+++ b/db/migrate/20211006072539_change_invitation_seen_to_clicked.rb
@@ -1,0 +1,5 @@
+class ChangeInvitationSeenToClicked < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :invitations, :seen, :clicked
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_27_094231) do
+ActiveRecord::Schema.define(version: 2021_10_06_072539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 2021_09_27_094231) do
     t.bigint "applicant_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "seen", default: false
+    t.boolean "clicked", default: false
     t.index ["applicant_id"], name: "index_invitations_on_applicant_id"
   end
 

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -195,11 +195,6 @@ describe ApplicantsController, type: :controller do
 
     it "calls the refresh service" do
       expect(RefreshApplicants).to receive(:call)
-        .with(
-          applicants: department.applicants,
-          rdv_solidarites_session: request.session[:rdv_solidarites],
-          rdv_solidarites_page: nil
-        )
 
       get :index, params: index_params
     end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -80,9 +80,9 @@ describe InvitationsController, type: :controller do
     let!(:invitation) { create(:invitation, applicant: applicant) }
     let!(:invite_params) { { token: invitation.token } }
 
-    it "mark the invitation as seen" do
+    it "mark the invitation as clicked" do
       get :redirect, params: invite_params
-      expect(invitation.reload.seen).to eq(true)
+      expect(invitation.reload.clicked).to eq(true)
     end
 
     it "redirects to the invitation link" do

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe InvitationMailer, type: :mailer do
+  subject do
+    described_class.first_invitation(invitation, applicant)
+  end
+
+  describe "#first_invitation" do
+    let!(:rdv_solidarites_user_id) { 14 }
+    let!(:department) { create(:department, phone_number: "0123456789") }
+    let!(:applicant) { create(:applicant, department: department, rdv_solidarites_user_id: rdv_solidarites_user_id) }
+    let!(:invitation) { create(:invitation, applicant: applicant) }
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("Prenez RDV pour votre RSA")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour #{applicant.first_name} #{applicant.last_name.upcase},")
+    end
+
+    it "sends the invitation link" do
+      expect(subject.body).to match(invitation.link.to_s)
+    end
+  end
+end

--- a/spec/mailers/previews/invitation_preview.rb
+++ b/spec/mailers/previews/invitation_preview.rb
@@ -1,0 +1,6 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invitation
+class InvitationPreview < ActionMailer::Preview
+  def first_invitation
+    InvitationMailer.first_invitation(Invitation.last, Applicant.last)
+  end
+end


### PR DESCRIPTION
closes issue #23
Cette PR, en complément de la PR #57, permet l'envoi d'emails d'invitation en plus des SMS.
- Création du service `SendEmail`
- Configuration des mailers pour SendInBlue
- Ajout de la gem premailers, pour permettre la prise en charge de fichiers CSS dans les mails
- Création d'un layout de mail et d'un fichier CSS pour les mails (inspiré de RDV-Solidarités pour garder une cohérence vis-à-vis des bRSA qui pourraient recevoir des mails des deux organisations)
- Ajout du `InvitationMailer` et de la méthode `first_invitation` (nom choisi en prévision des éventuels mails de relance, qui pourraient être différents
- Changement de l'attribut `seen` en `clicked` pour les invitations (comme convenu)