### PR TITLE
refactor(app): create organisations [1/4]

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,11 +1,12 @@
 class InvitationsController < ApplicationController
+  before_action :set_department, only: [:create]
   before_action :set_applicant, only: [:create]
   before_action :set_invitation, only: [:redirect]
   skip_before_action :authenticate_agent!, only: [:redirect]
   respond_to :json
 
   def create
-    authorize @applicant, :invite?
+    authorize @department, :invite_applicant?
     if invite_applicant.success?
       render json: { success: true, invitation: invite_applicant.invitation }
     else
@@ -22,7 +23,7 @@ class InvitationsController < ApplicationController
   private
 
   def set_applicant
-    @applicant = Applicant.includes(:invitations).find(params[:applicant_id])
+    @applicant = @department.applicants.includes(:invitations).find(params[:applicant_id])
   end
 
   def set_invitation
@@ -32,13 +33,14 @@ class InvitationsController < ApplicationController
   def invite_applicant
     @invite_applicant ||= Invitations::InviteApplicant.call(
       applicant: @applicant,
+      department: @department,
       rdv_solidarites_session: rdv_solidarites_session,
       invitation_format: params[:format]
     )
   end
 
-  def department
-    @applicant.department
+  def set_department
+    @department = Department.find(params[:department_id])
   end
 
   def invitation_format

--- a/app/javascript/react/actions/inviteApplicant.js
+++ b/app/javascript/react/actions/inviteApplicant.js
@@ -1,16 +1,19 @@
-const inviteApplicant = async (applicantId, invitationFormat) => {
-  const response = await fetch(`/applicants/${applicantId}/invitations`, {
-    method: "POST",
-    credentials: "same-origin",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "X-CSRF-Token": document.querySelector("meta[name=csrf-token]").content,
-    },
-    body: JSON.stringify({
-      format: invitationFormat,
-    }),
-  });
+const inviteApplicant = async (departmentId, applicantId, invitationFormat) => {
+  const response = await fetch(
+    `/departments/${departmentId}/applicants/${applicantId}/invitations`,
+    {
+      method: "POST",
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector("meta[name=csrf-token]").content,
+      },
+      body: JSON.stringify({
+        format: invitationFormat,
+      }),
+    }
+  );
 
   return response.json();
 };

--- a/app/javascript/react/actions/searchApplicants.js
+++ b/app/javascript/react/actions/searchApplicants.js
@@ -1,6 +1,6 @@
 /* eslint no-await-in-loop: "off" */
-const searchApplicants = async (uids) => {
-  const response = await fetch("/applicants/search", {
+const searchApplicants = async (departmentId, uids) => {
+  const response = await fetch(`/departments/${departmentId}/applicants/search`, {
     method: "POST",
     credentials: "same-origin",
     headers: {

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -54,7 +54,7 @@ export default function Applicant({ applicant, dispatchApplicants, department })
   };
 
   const handleApplicantInvitation = async (invitationFormat) => {
-    const result = await inviteApplicant(applicant.id, invitationFormat);
+    const result = await inviteApplicant(department.id, applicant.id, invitationFormat);
     if (result.success) {
       const { invitation } = result;
       applicant.invitationSentAt = invitation.sent_at;

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -66,7 +66,7 @@ export default function ApplicantsUpload({ department, configuration }) {
   };
 
   const retrieveApplicantsFromApp = async (uids) => {
-    const result = await searchApplicants(uids);
+    const result = await searchApplicants(department.id, uids);
     if (result.success) {
       return result.applicants;
     }

--- a/app/jobs/notify_applicant_job.rb
+++ b/app/jobs/notify_applicant_job.rb
@@ -1,8 +1,9 @@
 class NotificationsJobError < StandardError; end
 
 class NotifyApplicantJob < ApplicationJob
-  def perform(applicant_id, rdv_attributes, event)
+  def perform(applicant_id, department_id, rdv_attributes, event)
     @applicant_id = applicant_id
+    @department_id = department_id
     @rdv_solidarites_rdv = RdvSolidarites::Rdv.new(rdv_attributes)
     @event = event
 
@@ -13,7 +14,11 @@ class NotifyApplicantJob < ApplicationJob
   private
 
   def applicant
-    @applicant ||= Applicant.includes(:department).find(@applicant_id)
+    @applicant ||= Applicant.find(@applicant_id)
+  end
+
+  def department
+    @department ||= Department.find(@department_id)
   end
 
   def already_notified?
@@ -31,7 +36,8 @@ class NotifyApplicantJob < ApplicationJob
   def notify_applicant
     service_class = service_class_for_event_type(@event)
     service_class.call(
-      applicant: applicant, rdv_solidarites_rdv: @rdv_solidarites_rdv
+      applicant: applicant, department:  department,
+      rdv_solidarites_rdv: @rdv_solidarites_rdv
     )
   end
 

--- a/app/jobs/process_rdv_solidarites_webhook_job.rb
+++ b/app/jobs/process_rdv_solidarites_webhook_job.rb
@@ -42,7 +42,7 @@ class ProcessRdvSolidaritesWebhookJob < ApplicationJob
   end
 
   def all_applicants_belongs_to_department?
-    applicants.pluck(:department_id).uniq.length == 1 && applicants.first.department_id == department.id
+    applicants.all? { |a| a.department_ids.include?(department.id) }
   end
 
   def event
@@ -58,7 +58,7 @@ class ProcessRdvSolidaritesWebhookJob < ApplicationJob
   end
 
   def applicants
-    @applicants ||= Applicant.includes(:department).where(rdv_solidarites_user_id: rdv_solidarites_user_ids)
+    @applicants ||= Applicant.where(rdv_solidarites_user_id: rdv_solidarites_user_ids)
   end
 
   def applicant_ids
@@ -85,6 +85,7 @@ class ProcessRdvSolidaritesWebhookJob < ApplicationJob
     applicants.each do |applicant|
       NotifyApplicantJob.perform_async(
         applicant.id,
+        department.id,
         @data,
         event
       )

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -11,7 +11,7 @@ class Applicant < ApplicationRecord
   include HasStatusConcern
   include NotificableConcern
 
-  belongs_to :department
+  has_and_belongs_to_many :departments
   has_many :invitations, dependent: :nullify
   has_and_belongs_to_many :rdvs
 

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -4,9 +4,10 @@ class Department < ApplicationRecord
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, :capital, :number, presence: true
   has_and_belongs_to_many :agents, dependent: :nullify
-  has_many :applicants, dependent: :nullify
+  has_and_belongs_to_many :applicants, dependent: :nullify
   has_one :configuration, dependent: :nullify
   has_many :rdvs, dependent: :nullify
+  has_many :invitations, dependent: :nullify
 
   delegate :notify_applicant?, to: :configuration
   delegate :no_invitation?, to: :configuration

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,6 @@
 class Invitation < ApplicationRecord
   belongs_to :applicant
-  delegate :department, to: :applicant
+  belongs_to :department
 
   enum format: { sms: 0, email: 1, link_only: 2 }, _prefix: :format
   after_commit :set_applicant_status

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -9,6 +9,10 @@ class DepartmentPolicy < ApplicationPolicy
     pundit_user.departments.include?(record)
   end
 
+  def invite_applicant?
+    list_applicants?
+  end
+
   def create_applicant?
     list_applicants?
   end

--- a/app/services/concerns/notifications/rdv_concern.rb
+++ b/app/services/concerns/notifications/rdv_concern.rb
@@ -22,10 +22,6 @@ module Notifications
       @rdv_solidarites_rdv.formatted_start_time
     end
 
-    def department
-      @applicant.department
-    end
-
     def event
       self.class.name.demodulize.underscore
     end

--- a/app/services/create_applicant.rb
+++ b/app/services/create_applicant.rb
@@ -42,7 +42,7 @@ class CreateApplicant < BaseService
   end
 
   def applicant_attributes
-    { department: @department }.merge(
+    { departments: [@department] }.merge(
       @applicant_data.slice(*Applicant.attribute_names.map(&:to_sym)).compact
     )
   end

--- a/app/services/invitations/create.rb
+++ b/app/services/invitations/create.rb
@@ -1,7 +1,8 @@
 module Invitations
   class Create < BaseService
-    def initialize(applicant:, rdv_solidarites_session:, invitation_format:)
+    def initialize(applicant:, department:, rdv_solidarites_session:, invitation_format:)
       @applicant = applicant
+      @department = department
       @rdv_solidarites_session = rdv_solidarites_session
       @invitation_format = invitation_format
     end
@@ -25,6 +26,7 @@ module Invitations
     def invitation
       @invitation ||= Invitation.new(
         applicant: @applicant, format: @invitation_format,
+        department: @department,
         link: link, token: token
       )
     end
@@ -68,7 +70,7 @@ module Invitations
 
     def compute_invitation_link
       @compute_invitation_link ||= Invitations::ComputeLink.call(
-        department: department,
+        department: @department,
         rdv_solidarites_session: @rdv_solidarites_session,
         invitation_token: retrieve_invitation_token.invitation_token
       )
@@ -76,10 +78,6 @@ module Invitations
 
     def rdv_solidarites_user_id
       @applicant.rdv_solidarites_user_id
-    end
-
-    def department
-      @applicant.department
     end
   end
 end

--- a/app/services/invitations/invite_applicant.rb
+++ b/app/services/invitations/invite_applicant.rb
@@ -1,12 +1,14 @@
 module Invitations
   class InviteApplicant < BaseService
-    def initialize(applicant:, rdv_solidarites_session:, invitation_format:)
+    def initialize(applicant:, department:, rdv_solidarites_session:, invitation_format:)
       @applicant = applicant
+      @department = department
       @rdv_solidarites_session = rdv_solidarites_session
       @invitation_format = invitation_format
     end
 
     def call
+      check_applicant_department!
       retrieve_or_create_invitation!
       send_invitation!
       update_invitation_sent_at!
@@ -14,6 +16,12 @@ module Invitations
     end
 
     private
+
+    def check_applicant_department!
+      return if @applicant.department_ids.include?(@department.id)
+
+      fail!("l'allocataire ne peut être invité car il n'appartient pas à l'organisation.")
+    end
 
     def update_invitation_sent_at!
       return if invitation.update(sent_at: Time.zone.now)
@@ -47,6 +55,7 @@ module Invitations
     def retrieve_or_create_invitation
       @retrieve_or_create_invitation ||= Invitations::RetrieveOrCreate.call(
         applicant: @applicant, invitation_format: @invitation_format,
+        department: @department,
         rdv_solidarites_session: @rdv_solidarites_session
       )
     end

--- a/app/services/invitations/retrieve_or_create.rb
+++ b/app/services/invitations/retrieve_or_create.rb
@@ -1,7 +1,8 @@
 module Invitations
   class RetrieveOrCreate < BaseService
-    def initialize(applicant:, rdv_solidarites_session:, invitation_format:)
+    def initialize(applicant:, department:, rdv_solidarites_session:, invitation_format:)
       @applicant = applicant
+      @department = department
       @rdv_solidarites_session = rdv_solidarites_session
       @invitation_format = invitation_format
     end
@@ -18,7 +19,7 @@ module Invitations
     end
 
     def existing_invitation
-      @applicant.invitations.find_by(format: @invitation_format)
+      @applicant.invitations.find_by(format: @invitation_format, department: @department)
     end
 
     def create_invitation!
@@ -31,6 +32,7 @@ module Invitations
     def create_invitation
       @create_invitation ||= Invitations::Create.call(
         applicant: @applicant, invitation_format: @invitation_format,
+        department: @department,
         rdv_solidarites_session: @rdv_solidarites_session
       )
     end

--- a/app/services/notifications/notify_applicant.rb
+++ b/app/services/notifications/notify_applicant.rb
@@ -2,18 +2,26 @@ module Notifications
   class NotifyApplicant < BaseService
     include Notifications::RdvConcern
 
-    def initialize(applicant:, rdv_solidarites_rdv:)
+    def initialize(applicant:, department:, rdv_solidarites_rdv:)
       @applicant = applicant
+      @department = department
       @rdv_solidarites_rdv = rdv_solidarites_rdv
     end
 
     def call
+      check_applicant_department!
       check_phone_number!
       notify_applicant!
       update_notification_sent_at!
     end
 
     protected
+
+    def check_applicant_department!
+      return if @applicant.department_ids.include?(@department.id)
+
+      fail!("l'allocataire ne peut être invité car il n'appartient pas à l'organisation.")
+    end
 
     def check_phone_number!
       fail!("le téléphone n'est pas renseigné") if phone_number.blank?

--- a/app/services/notifications/rdv_cancelled.rb
+++ b/app/services/notifications/rdv_cancelled.rb
@@ -4,7 +4,7 @@ module Notifications
 
     def content
       "#{@applicant.full_name},\nVotre RDV d'orientation RSA a été annulé. " \
-        "Veuillez contacter le #{department.phone_number} pour plus d'informations."
+        "Veuillez contacter le #{@department.phone_number} pour plus d'informations."
     end
   end
 end

--- a/app/services/notifications/rdv_created.rb
+++ b/app/services/notifications/rdv_created.rb
@@ -10,8 +10,8 @@ module Notifications
       "#{@applicant.full_name},\nVous êtes allocataire du RSA. Vous bénéficiez d’un accompagnement pour" \
         " vos démarches d’insertion. Vous êtes attendu(e) le #{formatted_start_date} à " \
         "#{formatted_start_time} ici: #{lieu.name} - #{lieu.address}. Ce RDV est obligatoire. "\
-        "En cas d’empêchement, appelez rapidement le #{department.phone_number}. "\
-        "Le département #{department.number} (#{department.name.capitalize})."
+        "En cas d’empêchement, appelez rapidement le #{@department.phone_number}. "\
+        "Le département #{@department.number} (#{@department.name.capitalize})."
     end
 
     def remote_content
@@ -19,7 +19,7 @@ module Notifications
         " dans le cadre de vos démarches d’insertion. Un travailleur social vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. Ce rendez-vous est obligatoire. "\
         "En cas d’empêchement, merci d’appeler rapidement le " \
-        "#{department.phone_number}. Le département #{department.number} (#{department.name.capitalize})."
+        "#{@department.phone_number}. Le département #{@department.number} (#{@department.name.capitalize})."
     end
   end
 end

--- a/app/services/refresh_applicants.rb
+++ b/app/services/refresh_applicants.rb
@@ -1,8 +1,9 @@
 # Retrieves the RDV-Solidarites users linked to the applicants and updates them
 # if they changed in RDV-Solidarites
 class RefreshApplicants < BaseService
-  def initialize(applicants:, rdv_solidarites_session:)
+  def initialize(applicants:, rdv_solidarites_organisation_id:, rdv_solidarites_session:)
     @applicants = applicants
+    @rdv_solidarites_organisation_id = rdv_solidarites_organisation_id
     @rdv_solidarites_session = rdv_solidarites_session
   end
 
@@ -44,7 +45,7 @@ class RefreshApplicants < BaseService
   def retrieve_rdv_solidarites_users
     @retrieve_rdv_solidarites_users ||= RetrieveRdvSolidaritesResources.call(
       rdv_solidarites_session: @rdv_solidarites_session,
-      organisation_id: @applicants.first.rdv_solidarites_organisation_id,
+      organisation_id: @rdv_solidarites_organisation_id,
       resource_name: "users",
       additional_args: @applicants.pluck(:rdv_solidarites_user_id)
     )

--- a/app/views/mailers/invitation_mailer/first_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/first_invitation.html.erb
@@ -4,5 +4,5 @@
 <p class="btn-wrapper">
   <a href="<%= redirect_invitations_url(params: { token: @invitation.token, format: "email" }, host: ENV['HOST']) %>" class="btn btn-primary">Je prends RDV</a>
 </p>
-<p>En cas de problème technique, contactez le <%= @applicant.department.phone_number.gsub(/\d{2}/, '\& ') %></p>
+<p>En cas de problème technique, contactez le <%= @invitation.department.phone_number.gsub(/\d{2}/, '\& ') %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,13 +16,10 @@ Rails.application.routes.draw do
     resources :applicants, only: [:index, :create] do
       collection do
         resources :uploads, only: [:new]
+        post :search
       end
+      resources :invitations, only: [:create]
     end
-  end
-
-  resources :applicants, only: [] do
-    post :search, on: :collection
-    resources :invitations, only: [:create]
   end
 
   resources :invitations, only: [] do

--- a/db/migrate/20211020141004_add_department_applicants.rb
+++ b/db/migrate/20211020141004_add_department_applicants.rb
@@ -1,0 +1,24 @@
+class AddDepartmentApplicants < ActiveRecord::Migration[6.1]
+  # from one-to-many to many-to-many
+  def up
+    create_join_table :departments, :applicants do |t|
+      t.index [:department_id, :applicant_id], unique: true
+    end
+
+    Applicant.find_each do |applicant|
+      applicant.update!(departments: [Department.find(applicant.department_id)]) unless applicant.department_id.nil?
+    end
+
+    remove_reference :applicants, :department, null: false, foreign_key: true
+  end
+
+  def down
+    add_reference :applicants, :department, foreign_key: true
+
+    Applicant.find_each do |applicant|
+      applicant.update!(department_id: applicant.department_ids.first) unless applicant.department_ids.empty?
+    end
+
+    drop_join_table :departments, :applicants
+  end
+end

--- a/db/migrate/20211020145820_add_department_to_invitation.rb
+++ b/db/migrate/20211020145820_add_department_to_invitation.rb
@@ -1,0 +1,13 @@
+class AddDepartmentToInvitation < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :invitations, :department, foreign_key: true
+    up_only do
+      Invitation.find_each do |invitation|
+        department = invitation.applicant.departments.first
+        next unless department
+
+        invitation.update!(department_id: department.id)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_13_143756) do
+ActiveRecord::Schema.define(version: 2021_10_20_145820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 2021_10_13_143756) do
     t.integer "rdv_solidarites_user_id"
     t.string "affiliation_number"
     t.integer "role"
-    t.bigint "department_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "custom_id"
@@ -46,10 +45,15 @@ ActiveRecord::Schema.define(version: 2021_10_13_143756) do
     t.date "birth_date"
     t.date "invitation_accepted_at"
     t.integer "status", default: 0
-    t.index ["department_id"], name: "index_applicants_on_department_id"
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true
     t.index ["status"], name: "index_applicants_on_status"
     t.index ["uid"], name: "index_applicants_on_uid", unique: true
+  end
+
+  create_table "applicants_departments", id: false, force: :cascade do |t|
+    t.bigint "department_id", null: false
+    t.bigint "applicant_id", null: false
+    t.index ["department_id", "applicant_id"], name: "index_applicants_departments_on_department_id_and_applicant_id", unique: true
   end
 
   create_table "applicants_rdvs", id: false, force: :cascade do |t|
@@ -90,7 +94,9 @@ ActiveRecord::Schema.define(version: 2021_10_13_143756) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "clicked", default: false
+    t.bigint "department_id"
     t.index ["applicant_id"], name: "index_invitations_on_applicant_id"
+    t.index ["department_id"], name: "index_invitations_on_department_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -124,9 +130,9 @@ ActiveRecord::Schema.define(version: 2021_10_13_143756) do
     t.index ["status"], name: "index_rdvs_on_status"
   end
 
-  add_foreign_key "applicants", "departments"
   add_foreign_key "configurations", "departments"
   add_foreign_key "invitations", "applicants"
+  add_foreign_key "invitations", "departments"
   add_foreign_key "notifications", "applicants"
   add_foreign_key "rdvs", "departments"
 end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -1,23 +1,33 @@
 describe InvitationsController, type: :controller do
   describe "#create" do
     let!(:applicant_id) { "24" }
-    let!(:department) { create(:department) }
+    let!(:department_id) { "22" }
+    let!(:department) { create(:department, id: department_id) }
     let!(:agent) { create(:agent, departments: [department]) }
-    let!(:applicant) { create(:applicant, department: department, id: applicant_id) }
-    let!(:create_params) { { applicant_id: applicant_id, format: "sms" } }
+    let!(:applicant) { create(:applicant, departments: [department], id: applicant_id) }
+    let!(:create_params) { { department_id: department.id, applicant_id: applicant_id, format: "sms" } }
 
     before do
       sign_in(agent)
       set_rdv_solidarites_session
       allow(Invitations::InviteApplicant).to receive(:call)
         .and_return(OpenStruct.new)
-      allow(Applicant).to receive(:includes).and_return(Applicant)
-      allow(Applicant).to receive(:find)
+      allow(Department).to receive(:find)
+        .with(department_id)
+        .and_return(department)
+      allow(department).to receive_message_chain(:applicants, :includes, :find)
+        .with(applicant_id)
         .and_return(applicant)
     end
 
+    it "retrieves the department" do
+      expect(Department).to receive(:find)
+        .with(department_id)
+      post :create, params: create_params
+    end
+
     it "retrieves the applicant" do
-      expect(Applicant).to receive(:find)
+      expect(department).to receive_message_chain(:applicants, :includes, :find)
         .with(applicant_id)
       post :create, params: create_params
     end
@@ -27,13 +37,14 @@ describe InvitationsController, type: :controller do
         .with(
           applicant: applicant,
           rdv_solidarites_session: request.session[:rdv_solidarites],
+          department: department,
           invitation_format: "sms"
         )
       post :create, params: create_params
     end
 
     context "when the service succeeds" do
-      let(:invitation) { create(:invitation, applicant: applicant) }
+      let(:invitation) { create(:invitation, applicant: applicant, department: department) }
 
       before do
         allow(Invitations::InviteApplicant).to receive(:call)
@@ -78,9 +89,9 @@ describe InvitationsController, type: :controller do
 
     let!(:applicant_id) { "24" }
     let!(:department) { create(:department) }
-    let!(:applicant) { create(:applicant, department: department, id: applicant_id) }
-    let!(:invitation) { create(:invitation, applicant: applicant, format: "sms") }
-    let!(:invitation2) { create(:invitation, applicant: applicant, format: "email") }
+    let!(:applicant) { create(:applicant, departments: [department], id: applicant_id) }
+    let!(:invitation) { create(:invitation, department: department, applicant: applicant, format: "sms") }
+    let!(:invitation2) { create(:invitation, department: department, applicant: applicant, format: "email") }
 
     context "when format is not specified" do
       let!(:invite_params) { { token: invitation.token } }
@@ -112,8 +123,8 @@ describe InvitationsController, type: :controller do
       end
     end
 
-    context "when no invitation is retrieved" do
-      let!(:invitation) { create(:invitation, applicant: applicant, format: "email") }
+    context "when no invitation matches the format" do
+      let!(:invitation) { create(:invitation, applicant: applicant, department: department, format: "email") }
       let!(:invite_params) { { token: invitation.token } }
 
       it "raises an error" do

--- a/spec/factories/applicant.rb
+++ b/spec/factories/applicant.rb
@@ -11,8 +11,6 @@ FactoryBot.define do
     address { "27 avenue de Ségur 75007 Paris" }
     phone_number_formatted { "+33782605941" }
     status { "not_invited" }
-    department { create(:department) }
-
     after(:build) do |a|
       # https://github.com/thoughtbot/factory_bot/issues/931#issuecomment-307542965
       a.class.skip_callback(:save, :before, :set_status, raise: false)

--- a/spec/factories/invitation.rb
+++ b/spec/factories/invitation.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     token { "some_token" }
     link { "https://www.rdv_solidarites.com/some_params" }
     format { :sms }
+    department { create(:department) }
   end
 end

--- a/spec/jobs/notify_applicant_job_spec.rb
+++ b/spec/jobs/notify_applicant_job_spec.rb
@@ -1,14 +1,16 @@
 describe NotifyApplicantJob, type: :job do
   subject do
-    described_class.new.perform(applicant_id, rdv_attributes, event)
+    described_class.new.perform(applicant_id, department_id, rdv_attributes, event)
   end
 
   let!(:applicant_id) { 23 }
+  let!(:department_id) { 26 }
   let!(:rdv_attributes) { { id: 12, lieu: lieu, motif: motif, starts_at: starts_at } }
   let!(:lieu) { { name: "DINUM", address: "20 avenue de Ségur" } }
   let!(:motif) { { location_type: "public_office" } }
   let!(:starts_at) { "2021-09-08 12:00:00 UTC" }
   let!(:applicant) { create(:applicant, id: applicant_id) }
+  let!(:department) { create(:department, id: department_id) }
   let!(:event) { "created" }
   let!(:rdv_solidarites_rdv) { OpenStruct.new(id: 12) }
 
@@ -18,7 +20,8 @@ describe NotifyApplicantJob, type: :job do
         .with(rdv_attributes)
         .and_return(rdv_solidarites_rdv)
       allow(Notification).to receive(:find_by).and_return(nil)
-      allow(Applicant).to receive_message_chain(:includes, :find).and_return(applicant)
+      allow(Applicant).to receive(:find).with(applicant_id).and_return(applicant)
+      allow(Department).to receive(:find).with(department_id).and_return(department)
       [Notifications::RdvCreated, Notifications::RdvUpdated, Notifications::RdvCancelled].each do |klass|
         allow(klass).to receive(:call)
           .and_return(OpenStruct.new(success?: true))
@@ -27,7 +30,7 @@ describe NotifyApplicantJob, type: :job do
 
     it "calls the appropriate service" do
       expect(Notifications::RdvCreated).to receive(:call)
-        .with(applicant: applicant, rdv_solidarites_rdv: rdv_solidarites_rdv)
+        .with(applicant: applicant, department: department, rdv_solidarites_rdv: rdv_solidarites_rdv)
       subject
     end
 

--- a/spec/jobs/process_rdv_solidarites_webhook_job_spec.rb
+++ b/spec/jobs/process_rdv_solidarites_webhook_job_spec.rb
@@ -30,8 +30,8 @@ describe ProcessRdvSolidaritesWebhookJob, type: :job do
 
   let!(:rdv_solidarites_rdv) { OpenStruct.new(id: rdv_solidarites_rdv_id, user_ids: user_ids) }
 
-  let!(:applicant) { create(:applicant, department: department, id: 3) }
-  let!(:applicant2) { create(:applicant, department: department, id: 4) }
+  let!(:applicant) { create(:applicant, departments: [department], id: 3) }
+  let!(:applicant2) { create(:applicant, departments: [department], id: 4) }
 
   let!(:configuration) { create(:configuration, department: department, notify_applicant: true) }
   let!(:department) { create(:department, rdv_solidarites_organisation_id: organisation_id) }
@@ -90,7 +90,7 @@ describe ProcessRdvSolidaritesWebhookJob, type: :job do
 
     context "when there is a mismatch between one applicant and the department" do
       let!(:another_department) { create(:department) }
-      let!(:applicant) { create(:applicant, id: 242, department: another_department) }
+      let!(:applicant) { create(:applicant, id: 242, departments: [another_department]) }
 
       it "raises an error" do
         expect { subject }.to raise_error(
@@ -151,9 +151,9 @@ describe ProcessRdvSolidaritesWebhookJob, type: :job do
 
       it "calls the notify applicant job" do
         expect(NotifyApplicantJob).to receive(:perform_async)
-          .with(applicant.id, data, "created")
+          .with(applicant.id, department.id, data, "created")
         expect(NotifyApplicantJob).to receive(:perform_async)
-          .with(applicant2.id, data, "created")
+          .with(applicant2.id, department.id, data, "created")
         subject
       end
     end

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe InvitationMailer, type: :mailer do
   describe "#first_invitation" do
     let!(:rdv_solidarites_user_id) { 14 }
     let!(:department) { create(:department, phone_number: "0123456789") }
-    let!(:applicant) { create(:applicant, department: department, rdv_solidarites_user_id: rdv_solidarites_user_id) }
-    let!(:invitation) { create(:invitation, applicant: applicant) }
+    let!(:applicant) { create(:applicant, departments: [department], rdv_solidarites_user_id: rdv_solidarites_user_id) }
+    let!(:invitation) { create(:invitation, department: department, applicant: applicant) }
 
     it "renders the headers" do
       expect(subject.to).to eq([applicant.email])

--- a/spec/services/create_applicant_spec.rb
+++ b/spec/services/create_applicant_spec.rb
@@ -20,7 +20,7 @@ describe CreateApplicant, type: :service do
   end
 
   describe "#call" do
-    let!(:applicant_attributes) { applicant_data.merge(department: department) }
+    let!(:applicant_attributes) { applicant_data.merge(departments: [department]) }
 
     let!(:applicant) { build(:applicant, applicant_attributes) }
     let(:rdv_solidarites_client) { instance_double(RdvSolidaritesSession) }

--- a/spec/services/invitations/create_spec.rb
+++ b/spec/services/invitations/create_spec.rb
@@ -1,7 +1,8 @@
 describe Invitations::Create, type: :service do
   subject do
     described_class.call(
-      applicant: applicant, rdv_solidarites_session: rdv_solidarites_session,
+      applicant: applicant, department: department,
+      rdv_solidarites_session: rdv_solidarites_session,
       invitation_format: invitation_format
     )
   end
@@ -9,12 +10,12 @@ describe Invitations::Create, type: :service do
   let!(:invitation_format) { "sms" }
   let!(:rdv_solidarites_user_id) { 14 }
   let!(:department) { create(:department) }
-  let!(:applicant) { create(:applicant, department: department, rdv_solidarites_user_id: rdv_solidarites_user_id) }
+  let!(:applicant) { create(:applicant, departments: [department], rdv_solidarites_user_id: rdv_solidarites_user_id) }
   let!(:rdv_solidarites_session) do
     { client: "client", uid: "johndoe@example.com", access_token: "token" }
   end
   let!(:token) { "token123" }
-  let!(:invitation) { create(:invitation, applicant: applicant, token: token) }
+  let!(:invitation) { create(:invitation, department: department, applicant: applicant, token: token) }
 
   describe "#call" do
     let!(:invitation_link) { "https://www.rdv_solidarites.com/some_params" }
@@ -34,6 +35,10 @@ describe Invitations::Create, type: :service do
 
     it "creates an invitation" do
       expect(Invitation).to receive(:new)
+        .with(
+          applicant: applicant, department: department,
+          link: invitation_link, token: token, format: invitation_format
+        )
       expect(invitation).to receive(:save)
       subject
     end
@@ -150,7 +155,7 @@ describe Invitations::Create, type: :service do
         it "creates the invitation with the link and token" do
           expect(Invitation).to receive(:new)
             .with(
-              applicant: applicant, format: invitation_format,
+              applicant: applicant, department: department, format: invitation_format,
               token: token, link: invitation_link
             )
           expect(invitation).to receive(:save)

--- a/spec/services/invitations/retrieve_or_create_spec.rb
+++ b/spec/services/invitations/retrieve_or_create_spec.rb
@@ -1,7 +1,7 @@
 describe Invitations::RetrieveOrCreate, type: :service do
   subject do
     described_class.call(
-      applicant: applicant, rdv_solidarites_session: rdv_solidarites_session,
+      applicant: applicant, department: department, rdv_solidarites_session: rdv_solidarites_session,
       invitation_format: invitation_format
     )
   end
@@ -9,11 +9,11 @@ describe Invitations::RetrieveOrCreate, type: :service do
   let!(:invitation_format) { "sms" }
   let!(:rdv_solidarites_user_id) { 14 }
   let!(:department) { create(:department) }
-  let!(:applicant) { create(:applicant, department: department, rdv_solidarites_user_id: rdv_solidarites_user_id) }
+  let!(:applicant) { create(:applicant, departments: [department], rdv_solidarites_user_id: rdv_solidarites_user_id) }
   let!(:rdv_solidarites_session) do
     { client: "client", uid: "johndoe@example.com", access_token: "token" }
   end
-  let!(:invitation) { create(:invitation, applicant: applicant) }
+  let!(:invitation) { create(:invitation, department: department, applicant: applicant) }
 
   describe "#call" do
     before do
@@ -33,12 +33,13 @@ describe Invitations::RetrieveOrCreate, type: :service do
 
     context "invitation creation" do
       context "when the user has no invitation with the requested format" do
-        let!(:invitation) { create(:invitation, applicant: applicant, format: "email") }
+        let!(:invitation) { create(:invitation, department: department, applicant: applicant, format: "email") }
 
         it "tries to create an invitation" do
           expect(Invitations::Create).to receive(:call)
             .with(
               applicant: applicant,
+              department: department,
               invitation_format: invitation_format,
               rdv_solidarites_session: rdv_solidarites_session
             )
@@ -65,7 +66,11 @@ describe Invitations::RetrieveOrCreate, type: :service do
         end
       end
 
-      context "when the user has already an invitation with the requested format" do
+      context "when the user has already an invitation from that department with the requested format" do
+        let!(:invitation) do
+          create(:invitation, department: department, applicant: applicant, format: invitation_format)
+        end
+
         it "does not try to create an invitation" do
           expect(Invitations::Create).not_to receive(:call)
           subject

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -9,7 +9,7 @@ describe Invitations::SendSms, type: :service do
   let!(:applicant) do
     create(
       :applicant,
-      phone_number_formatted: phone_number_formatted, department: department,
+      phone_number_formatted: phone_number_formatted,
       first_name: "John", last_name: "Doe", title: "monsieur"
     )
   end
@@ -26,7 +26,7 @@ describe Invitations::SendSms, type: :service do
   let!(:invitation) do
     create(
       :invitation,
-      applicant: applicant, token: "123", link: "https://www.rdv-solidarites.fr/lieux?invitation_token=123",
+      applicant: applicant, department: department, token: "123", link: "https://www.rdv-solidarites.fr/lieux?invitation_token=123",
       format: "sms"
     )
   end

--- a/spec/services/notifications/rdv_cancelled_spec.rb
+++ b/spec/services/notifications/rdv_cancelled_spec.rb
@@ -1,7 +1,8 @@
 describe Notifications::RdvCancelled, type: :service do
   subject do
     described_class.call(
-      applicant: applicant, rdv_solidarites_rdv: rdv_solidarites_rdv
+      applicant: applicant, rdv_solidarites_rdv: rdv_solidarites_rdv,
+      department: department
     )
   end
 
@@ -13,7 +14,7 @@ describe Notifications::RdvCancelled, type: :service do
       first_name: "john",
       last_name: "doe",
       title: "monsieur",
-      department: department
+      departments: [department]
     )
   end
   let!(:rdv_solidarites_rdv_id) { 23 }

--- a/spec/services/notifications/rdv_created_spec.rb
+++ b/spec/services/notifications/rdv_created_spec.rb
@@ -1,7 +1,7 @@
 describe Notifications::RdvCreated, type: :service do
   subject do
     described_class.call(
-      applicant: applicant, rdv_solidarites_rdv: rdv_solidarites_rdv
+      applicant: applicant, rdv_solidarites_rdv: rdv_solidarites_rdv, department: department
     )
   end
 
@@ -13,7 +13,7 @@ describe Notifications::RdvCreated, type: :service do
       first_name: "john",
       last_name: "doe",
       title: "monsieur",
-      department: department
+      departments: [department]
     )
   end
   let!(:rdv_solidarites_rdv_id) { 23 }

--- a/spec/services/refresh_applicants_spec.rb
+++ b/spec/services/refresh_applicants_spec.rb
@@ -2,7 +2,8 @@ describe RefreshApplicants, type: :service do
   subject do
     described_class.call(
       applicants: applicants,
-      rdv_solidarites_session: rdv_solidarites_session
+      rdv_solidarites_session: rdv_solidarites_session,
+      rdv_solidarites_organisation_id: rdv_solidarites_organisation_id
     )
   end
 
@@ -10,10 +11,10 @@ describe RefreshApplicants, type: :service do
   let(:applicant) do
     create(
       :applicant, first_name: "Bernard", last_name: "Lama",
-                  rdv_solidarites_user_id: rdv_solidarites_user_id, department: department
+                  rdv_solidarites_user_id: rdv_solidarites_user_id
     )
   end
-  let(:department) { create(:department, rdv_solidarites_organisation_id: 42) }
+  let!(:rdv_solidarites_organisation_id) { 42 }
   let(:applicants) { [applicant] }
   let(:rdv_solidarites_session) do
     { client: "client", uid: "johndoe@example.com", access_token: "token" }
@@ -55,7 +56,7 @@ describe RefreshApplicants, type: :service do
         expect(RetrieveRdvSolidaritesResources).to receive(:call)
           .with(
             additional_args: [51], rdv_solidarites_session: rdv_solidarites_session,
-            organisation_id: 42, resource_name: "users"
+            organisation_id: rdv_solidarites_organisation_id, resource_name: "users"
           )
         subject
       end


### PR DESCRIPTION
Dans la 1ere partie de la refacto liée à #75 , je change la relation entre la table `departments` et `applicants`.
Pour se faire je crée une join table pour que la relation passe de 1:many à many:many.
Je lie également les invitations aux departments pour garder le lien entre les 2.