### PR TITLE
Fix/Alternate home when logged in

### DIFF
--- a/app/controllers/concerns/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/authenticated_controller_concern.rb
@@ -34,7 +34,7 @@ module AuthenticatedControllerConcern
 
   def redirect_not_authorized
     flash[:alert] = "Votre compte ne vous permet pas d'effectuer cette action"
-    redirect_to root_path
+    redirect_to home_path
   end
 
   def render_not_authorized

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,13 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_agent!, only: [:welcome]
+  skip_before_action :authenticate_agent!, only: [:home, :welcome]
 
   def welcome; end
+
+  def home
+    if logged_in?
+      redirect_to(departments_path)
+    else
+      redirect_to(root_path)
+    end
+  end
 end

--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -1,6 +1,6 @@
 <header>
   <nav class="navbar px-3 navbar-expand-lg">
-    <%= link_to root_path do  %>
+    <%= link_to home_path do  %>
       <%= image_pack_tag "logos/rdv-insertion.png", class: "rdvi-logo", alt: "Logo rdv insertion" %>
     <% end %>
     <div class="nav justify-content-around">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ end
 
 Rails.application.routes.draw do
   root "static_pages#welcome"
+  get '/home', to: "static_pages#home", as: :home
   resources :departments, only: [:index] do
     resources :applicants, only: [:index, :create] do
       collection do

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,10 +1,33 @@
 describe StaticPagesController, type: :controller do
   render_views
 
+  let!(:department) { create(:department) }
+  let!(:agent) { create(:agent, departments: [department]) }
+
   describe "GET #welcome" do
     it "returns a success response" do
       get :welcome
       expect(response).to be_successful
+    end
+  end
+
+  describe "GET #home" do
+    context "when the user is not logged in" do
+      it "redirects to the root_path" do
+        get :home
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the user is logged in" do
+      before do
+        sign_in(agent)
+      end
+
+      it "redirects to the departments_path" do
+        get :home
+        expect(response).to redirect_to(departments_path)
+      end
     end
   end
 end

--- a/spec/controllers/uploads_controller_spec.rb
+++ b/spec/controllers/uploads_controller_spec.rb
@@ -21,7 +21,7 @@ describe UploadsController, type: :controller do
 
       it "redirects the agent" do
         get :new, params: { department_id: department.id }
-        expect(response).to redirect_to(root_path)
+        expect(response).to redirect_to(home_path)
         expect(flash[:alert]).to include("Votre compte ne vous permet pas d'effectuer cette action")
       end
     end


### PR DESCRIPTION
Le bug : lorsqu'un utilisateur est loggé et qu'il clique sur le logo rdv-insertion pour revenir à la home, il ne peut plus retrouver l'interface de gestion des utilisateurs.

Solution proposée : ajout d'un home_path, qui redirige en fonction du statut `logged_in?` soit vers le `root_path`, soit vers le `departments_path`

Principale hésitation sur l'implémentation : si la solution proposée convient, on pourrait préférer mettre le `home_path` en root, et la page `#welcome` sur le chemin `/welcome`. Avantage : cela rend la redirection moins visible dans l'url (mais je pense que personne ne regarde). Inconvénient : on n'a plus vraiment de root_page sur `/`, ce qui est moins esthétique + la root_page est cachée derrière une redirection, ce qui est mauvais pour le référencement et la performance.