### PR TITLE
refactor(app): Create organisations [3/4]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ Layout/LineLength:
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+Rails/BulkChangeTable:
+  Enabled: false
+
 RSpec/ContextWording:
   Enabled: False
 

--- a/db/migrate/20211102161424_change_department_table.rb
+++ b/db/migrate/20211102161424_change_department_table.rb
@@ -1,0 +1,44 @@
+class ChangeDepartmentTable < ActiveRecord::Migration[6.1]
+  def up
+    add_reference :organisations, :department, foreign_key: true
+
+    Organisation.find_each do |organisation|
+      department = Department.find_by(rdv_solidarites_organisation_id: organisation.rdv_solidarites_organisation_id)
+      organisation.department_id = department.id
+      organisation.save!
+    end
+
+    remove_column :departments, :rdv_solidarites_organisation_id
+    remove_column :departments, :phone_number
+    drop_table :applicants_departments
+    drop_table :agents_departments
+  end
+
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def down
+    create_join_table :departments, :agents do |t|
+      t.index [:department_id, :agent_id], unique: true
+    end
+
+    create_join_table :departments, :applicants do |t|
+      t.index [:department_id, :applicant_id], unique: true
+    end
+
+    add_column :departments, :rdv_solidarites_organisation_id, :bigint
+
+    add_column :departments, :phone_number, :string
+
+    Department.find_each do |department|
+      organisation = Organisation.find_by(department_id: department.id)
+      department.rdv_solidarites_organisation_id = organisation.rdv_solidarites_organisation_id
+      department.phone_number = organisation.phone_number
+      department.applicant_ids = organisation.applicant_ids
+      department.agent_ids = organisation.agent_ids
+
+      department.save!
+    end
+
+    remove_reference :organisations, :department, null: false, foreign_key: true
+  end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_21_190749) do
+ActiveRecord::Schema.define(version: 2021_11_02_161424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,12 +20,6 @@ ActiveRecord::Schema.define(version: 2021_10_21_190749) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_agents_on_email", unique: true
-  end
-
-  create_table "agents_departments", id: false, force: :cascade do |t|
-    t.bigint "department_id", null: false
-    t.bigint "agent_id", null: false
-    t.index ["department_id", "agent_id"], name: "index_agents_departments_on_department_id_and_agent_id", unique: true
   end
 
   create_table "agents_organisations", id: false, force: :cascade do |t|
@@ -56,12 +50,6 @@ ActiveRecord::Schema.define(version: 2021_10_21_190749) do
     t.index ["uid"], name: "index_applicants_on_uid", unique: true
   end
 
-  create_table "applicants_departments", id: false, force: :cascade do |t|
-    t.bigint "department_id", null: false
-    t.bigint "applicant_id", null: false
-    t.index ["department_id", "applicant_id"], name: "index_applicants_departments_on_department_id_and_applicant_id", unique: true
-  end
-
   create_table "applicants_organisations", id: false, force: :cascade do |t|
     t.bigint "organisation_id", null: false
     t.bigint "applicant_id", null: false
@@ -89,12 +77,9 @@ ActiveRecord::Schema.define(version: 2021_10_21_190749) do
     t.string "name"
     t.string "number"
     t.string "capital"
-    t.integer "rdv_solidarites_organisation_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "region"
-    t.string "phone_number"
-    t.index ["rdv_solidarites_organisation_id"], name: "index_departments_on_rdv_solidarites_organisation_id", unique: true
   end
 
   create_table "invitations", force: :cascade do |t|
@@ -131,6 +116,8 @@ ActiveRecord::Schema.define(version: 2021_10_21_190749) do
     t.integer "rdv_solidarites_organisation_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "department_id"
+    t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
   end
 
@@ -159,5 +146,6 @@ ActiveRecord::Schema.define(version: 2021_10_21_190749) do
   add_foreign_key "invitations", "applicants"
   add_foreign_key "invitations", "organisations"
   add_foreign_key "notifications", "applicants"
+  add_foreign_key "organisations", "departments"
   add_foreign_key "rdvs", "organisations"
 end

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe InvitationMailer, type: :mailer do
     let!(:applicant) do
       create(:applicant, organisations: [organisation], rdv_solidarites_user_id: rdv_solidarites_user_id)
     end
+
     let!(:invitation) { create(:invitation, organisation: organisation, applicant: applicant) }
 
     it "renders the headers" do

--- a/spec/services/invitations/create_spec.rb
+++ b/spec/services/invitations/create_spec.rb
@@ -10,9 +10,13 @@ describe Invitations::Create, type: :service do
   let!(:invitation_format) { "sms" }
   let!(:rdv_solidarites_user_id) { 14 }
   let!(:organisation) { create(:organisation) }
+<<<<<<< HEAD
   let!(:applicant) do
     create(:applicant, organisations: [organisation], rdv_solidarites_user_id: rdv_solidarites_user_id)
   end
+=======
+  let!(:applicant) { create(:applicant, organisations: [organisation], rdv_solidarites_user_id: rdv_solidarites_user_id) }
+>>>>>>> 48016c7 (refactor(app): Create and populate organisations table)
   let!(:rdv_solidarites_session) do
     { client: "client", uid: "johndoe@example.com", access_token: "token" }
   end

--- a/spec/services/invitations/create_spec.rb
+++ b/spec/services/invitations/create_spec.rb
@@ -10,13 +10,11 @@ describe Invitations::Create, type: :service do
   let!(:invitation_format) { "sms" }
   let!(:rdv_solidarites_user_id) { 14 }
   let!(:organisation) { create(:organisation) }
-<<<<<<< HEAD
+
   let!(:applicant) do
     create(:applicant, organisations: [organisation], rdv_solidarites_user_id: rdv_solidarites_user_id)
   end
-=======
-  let!(:applicant) { create(:applicant, organisations: [organisation], rdv_solidarites_user_id: rdv_solidarites_user_id) }
->>>>>>> 48016c7 (refactor(app): Create and populate organisations table)
+
   let!(:rdv_solidarites_session) do
     { client: "client", uid: "johndoe@example.com", access_token: "token" }
   end


### PR DESCRIPTION
3eme partie de la refacto liée à #75 .
Cette PR vient après #107 .
Dans cette PR j'enlève les liens qui reliait la table `departments` aux tables `agents` et `applicants` et j'ajoute un lien 1:many entre la table `departments` et `organisations`.