### PR TITLE
refactor(app): Create organisations [4/4]

### DIFF
--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -15,7 +15,7 @@ import Applicant from "../models/Applicant";
 
 const reducer = reducerFactory("Expérimentation RSA");
 
-export default function ApplicantsUpload({ organisation, configuration }) {
+export default function ApplicantsUpload({ organisation, configuration, department }) {
   const SHEET_NAME = configuration.sheet_name;
   const columnNames = configuration.column_names;
 
@@ -52,7 +52,7 @@ export default function ApplicantsUpload({ organisation, configuration }) {
               birthName: columnNames.birth_name && row[columnNames.birth_name],
               customId: columnNames.custom_id && row[columnNames.custom_id],
             },
-            organisation.number,
+            department.number,
             configuration
           );
           applicantsFromList.push(applicant);

--- a/app/javascript/stylesheets/components/_card.scss
+++ b/app/javascript/stylesheets/components/_card.scss
@@ -1,6 +1,9 @@
 .card-container {
   a {
-    color: white;
+    color: $dark-blue;
+  }
+  a:hover {
+    color: $dark-blue-dim;
   }
 }
 
@@ -20,10 +23,6 @@
   img {
     height: 100;
     padding: 10px 20px 10px 20px
-  }
-
-  &:hover {
-    top: -2px;
   }
 }
 

--- a/app/javascript/stylesheets/components/_title.scss
+++ b/app/javascript/stylesheets/components/_title.scss
@@ -5,9 +5,9 @@
   margin-bottom: 20px;
 
   h1 {
-  font-size: 44px;
-  line-height: 60px;
-  font-weight: 700;
+    font-size: 44px;
+    line-height: 60px;
+    font-weight: 700;
   }
 }
 

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,16 +1,7 @@
 class Department < ApplicationRecord
-  TIME_TO_ACCEPT_INVITATION = 3.days
-
-  validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, :capital, :number, presence: true
-  has_and_belongs_to_many :agents, dependent: :nullify
-  has_and_belongs_to_many :applicants, dependent: :nullify
-  has_one :configuration, dependent: :nullify
-  has_many :rdvs, dependent: :nullify
-  has_many :invitations, dependent: :nullify
 
-  delegate :notify_applicant?, to: :configuration
-  delegate :no_invitation?, to: :configuration
+  has_many :organisations, dependent: :nullify
 
   def name_with_region
     "#{name}, #{region}"

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,7 +2,9 @@ class Organisation < ApplicationRecord
   TIME_TO_ACCEPT_INVITATION = 3.days
 
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
-  validates :name, :capital, :number, presence: true
+  validates :name, presence: true
+
+  belongs_to :department
   has_and_belongs_to_many :agents, dependent: :nullify
   has_and_belongs_to_many :applicants, dependent: :nullify
   has_one :configuration, dependent: :nullify
@@ -11,8 +13,5 @@ class Organisation < ApplicationRecord
 
   delegate :notify_applicant?, to: :configuration
   delegate :no_invitation?, to: :configuration
-
-  def name_with_region
-    "#{name}, #{region}"
-  end
+  delegate :name, :name_with_region, :number, to: :department, prefix: true
 end

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -30,8 +30,8 @@ module Invitations
     def link_with_motif(motif)
       params = {
         search: {
-          departement: @organisation.number,
-          where: @organisation.name_with_region,
+          departement: @organisation.department_number,
+          where: @organisation.department_name_with_region,
           motif_name_with_location_type: "#{motif['name']}-#{motif['location_type']}",
           service: ENV['RDV_SOLIDARITES_RSA_SERVICE_ID']
         }
@@ -40,9 +40,9 @@ module Invitations
     end
 
     def link_without_motif
-      params = { where: @organisation.name_with_region }
-      "#{ENV['RDV_SOLIDARITES_URL']}/departement/#{@organisation.number}/#{ENV['RDV_SOLIDARITES_RSA_SERVICE_ID']}" \
-        "?#{params.to_query}"
+      params = { where: @organisation.department_name_with_region }
+      "#{ENV['RDV_SOLIDARITES_URL']}/departement/#{@organisation.department_number}/" \
+        "#{ENV['RDV_SOLIDARITES_RSA_SERVICE_ID']}?#{params.to_query}"
     end
 
     def motifs

--- a/app/services/notifications/rdv_created.rb
+++ b/app/services/notifications/rdv_created.rb
@@ -11,7 +11,7 @@ module Notifications
         " vos démarches d’insertion. Vous êtes attendu(e) le #{formatted_start_date} à " \
         "#{formatted_start_time} ici: #{lieu.name} - #{lieu.address}. Ce RDV est obligatoire. "\
         "En cas d’empêchement, appelez rapidement le #{@organisation.phone_number}. "\
-        "Le département #{@organisation.number} (#{@organisation.name.capitalize})."
+        "Le département #{@organisation.department_number} (#{@organisation.department_name.capitalize})."
     end
 
     def remote_content
@@ -19,7 +19,8 @@ module Notifications
         " dans le cadre de vos démarches d’insertion. Un travailleur social vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. Ce rendez-vous est obligatoire. "\
         "En cas d’empêchement, merci d’appeler rapidement le " \
-        "#{@organisation.phone_number}. Le département #{@organisation.number} (#{@organisation.name.capitalize})."
+        "#{@organisation.phone_number}. Le département #{@organisation.department_number} "\
+        "(#{@organisation.department_name.capitalize})."
     end
   end
 end

--- a/app/services/notifications/rdv_updated.rb
+++ b/app/services/notifications/rdv_updated.rb
@@ -6,7 +6,7 @@ module Notifications
       "#{@applicant.full_name},\nVotre RDV d'orientation RSA a été modifié. " +
         rdv_instructions +
         " En cas d’absence, vous risquez une suspension de votre allocation RSA. " \
-        "Le département #{organisation.number} (#{organisation.name.capitalize})."
+        "Le département #{organisation.department_number} (#{organisation.department_name.capitalize})."
     end
 
     def rdv_instructions

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -7,8 +7,8 @@
       <div class="row">
         <h5 class="text-center">
           <%= @organisation.name %>
-          <% if image_compiled?("maps/#{@organisation.name.parameterize}.svg") %>
-            <%= image_pack_tag("maps/#{@organisation.name.parameterize}.svg", alt: @organisation.name.parameterize, width: 50, height: 50) %>
+          <% if image_compiled?("maps/#{@organisation.department_name.parameterize}.svg") %>
+            <%= image_pack_tag("maps/#{@organisation.department_name.parameterize}.svg", alt: @organisation.department_name.parameterize, width: 50, height: 50) %>
           <% end %>
         </h5>
       </div>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5">
   <div class="row mt-5 justify-content-center">
     <div class="col-8">
-      <p>Sélectionnez votre département:</p>
+      <p>Sélectionnez votre organisation:</p>
     </div>
   </div>
 
@@ -13,10 +13,9 @@
             <div class="card d-flex flex-row justify-content-between align-content-center card-organisation mb-3">
               <div class="card-body card-organisation-body">
                 <h4><%= organisation.name %></h4>
-                <p>Good morning <%= organisation.capital %>!</p>
               </div>
-              <% if image_compiled?("maps/#{organisation.name.parameterize}.svg") %>
-                <%= image_pack_tag("maps/#{organisation.name.parameterize}.svg", alt: organisation.name.parameterize) %>
+              <% if image_compiled?("maps/#{organisation.department_name.parameterize}.svg") %>
+                <%= image_pack_tag("maps/#{organisation.department_name.parameterize}.svg", alt: organisation.name.parameterize) %>
               <% end %>
             </div>
           <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -7,18 +7,24 @@
 
   <div class="row justify-content-center">
     <div class="col-8">
-      <% @organisations.each do |organisation| %>
+      <% @organisations.group_by(&:department).each do |department, organisations| %>
         <div class="card-container">
-          <%= link_to organisation_applicants_path(organisation) do %>
             <div class="card d-flex flex-row justify-content-between align-content-center card-organisation mb-3">
               <div class="card-body card-organisation-body">
-                <h4><%= organisation.name %></h4>
+                <h4 class="mb-2"><%= department.number %> - <%= department.name %></h4>
+                <ul class="mt-2">
+                  <% organisations.each do |organisation| %>
+                    <%= link_to organisation_applicants_path(organisation) do %>
+                      <li class="my-3"><%= organisation.name %></li>
+                    <% end %>
+                  <% end %>
+                </ul>
               </div>
-              <% if image_compiled?("maps/#{organisation.department_name.parameterize}.svg") %>
-                <%= image_pack_tag("maps/#{organisation.department_name.parameterize}.svg", alt: organisation.name.parameterize) %>
+
+              <% if image_compiled?("maps/#{department.name.parameterize}.svg") %>
+                <%= image_pack_tag("maps/#{department.name.parameterize}.svg", alt: department.name.parameterize) %>
               <% end %>
             </div>
-          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,5 +1,5 @@
 <%= react_component(
   "pages/ApplicantsUpload", {
-    organisation: @organisation, configuration: @configuration
+    organisation: @organisation, configuration: @configuration, department: @organisation.department
   }
 ) %>

--- a/db/migrate/20211102171611_change_organisations.rb
+++ b/db/migrate/20211102171611_change_organisations.rb
@@ -1,0 +1,28 @@
+class ChangeOrganisations < ActiveRecord::Migration[6.1]
+  def up
+    Organisation.find_each do |organisation|
+      organisation.name = "Conseil départemental - #{organisation.department.name}"
+      organisation.save!
+    end
+
+    remove_column :organisations, :number
+    remove_column :organisations, :capital
+    remove_column :organisations, :region
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def down
+    add_column :organisations, :number, :string
+    add_column :organisations, :capital, :string
+    add_column :organisations, :region, :string
+
+    Organisation.find_each do |organisation|
+      organisation.name = organisation.department.name
+      organisation.number = organisation.department.number
+      organisation.capital = organisation.department.capital
+      organisation.region = organisation.department.region
+      organisation.save!
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_02_161424) do
+ActiveRecord::Schema.define(version: 2021_11_02_171611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,9 +108,6 @@ ActiveRecord::Schema.define(version: 2021_11_02_161424) do
 
   create_table "organisations", force: :cascade do |t|
     t.string "name"
-    t.string "number"
-    t.string "capital"
-    t.string "region"
     t.string "phone_number"
     t.string "email"
     t.integer "rdv_solidarites_organisation_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,17 +1,15 @@
 puts "Creating organisations..."
 
-Organisation.create!(
+Department.create!(
   number: '08',
   name: 'Ardennes',
   capital: 'Charlevilles-Mézières'
 )
 
 Organisation.create!(
-  number: '26',
-  name: 'Drôme',
-  capital: 'Valence',
-  region: "Auvergne-Rhône-Alpes",
-  phone_number: "0147200001"
+  name: "Plateforme mutualisée d'orientation",
+  phone_number: "0147200001",
+  department: Department.last.id
   # rdv_solidarites_organisation_id: insérez l'id de l'organisation correspondante sur RDV-Solidarites
 )
 

--- a/spec/factories/department.rb
+++ b/spec/factories/department.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :department do
     sequence(:name) { |n| "Departement n°#{n}" }
     sequence(:number)
-    sequence(:rdv_solidarites_organisation_id)
     sequence(:capital) { |n| "Capitale n°#{n}" }
   end
 end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -1,10 +1,9 @@
 FactoryBot.define do
   factory :organisation do
     sequence(:name) { |n| "Departement n°#{n}" }
-    sequence(:number)
     sequence(:rdv_solidarites_organisation_id)
-    sequence(:capital) { |n| "Capitale n°#{n}" }
 
+    department { create(:department) }
     after(:create) do |organisation|
       organisation.configuration ||= create(:configuration, organisation: organisation)
     end

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -6,13 +6,20 @@ describe Invitations::ComputeLink, type: :service do
     )
   end
 
+  let!(:department) do
+    create(
+      :department,
+      number: "26",
+      name: "Drôme",
+      region: "Auvergne-Rhône-Alpes"
+    )
+  end
+
   let!(:organisation) do
     create(
       :organisation,
       rdv_solidarites_organisation_id: 27,
-      number: "26",
-      name: "Drôme",
-      region: "Auvergne-Rhône-Alpes"
+      department: department
     )
   end
 

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -13,14 +13,20 @@ describe Invitations::SendSms, type: :service do
       first_name: "John", last_name: "Doe", title: "monsieur"
     )
   end
+  let!(:department) do
+    create(
+      :department,
+      number: "26",
+      name: "Drôme",
+      region: "Auvergne-Rhône-Alpes"
+    )
+  end
   let!(:organisation) do
     create(
       :organisation,
       rdv_solidarites_organisation_id: 27,
-      number: "26",
-      name: "Drôme",
-      region: "Auvergne-Rhône-Alpes",
-      phone_number: "0147200001"
+      phone_number: "0147200001",
+      department: department
     )
   end
   let!(:invitation) do

--- a/spec/services/notifications/rdv_cancelled_spec.rb
+++ b/spec/services/notifications/rdv_cancelled_spec.rb
@@ -21,8 +21,10 @@ describe Notifications::RdvCancelled, type: :service do
   let!(:rdv_solidarites_rdv) do
     OpenStruct.new(id: rdv_solidarites_rdv_id)
   end
+  let!(:department) { create(:department, name: "Yonne", number: "89") }
+
   let!(:organisation) do
-    create(:organisation, phone_number: "0147200001", name: "Yonne", number: "89")
+    create(:organisation, phone_number: "0147200001", department: department)
   end
   let!(:notification) { create(:notification, applicant: applicant) }
 

--- a/spec/services/notifications/rdv_created_spec.rb
+++ b/spec/services/notifications/rdv_created_spec.rb
@@ -24,8 +24,9 @@ describe Notifications::RdvCreated, type: :service do
       formatted_start_time: starts_at.to_datetime.strftime('%H:%M')
     )
   end
+  let!(:department) { create(:department, name: "Yonne", number: "89") }
   let!(:organisation) do
-    create(:organisation, phone_number: "0147200001", name: "Yonne", number: "89")
+    create(:organisation, phone_number: "0147200001", department: department)
   end
   let!(:notification) { create(:notification, applicant: applicant) }
   let!(:lieu) { OpenStruct.new(name: "DINUM", address: "20 avenue de Ségur 75011 PARIS") }


### PR DESCRIPTION
4eme et dernière  partie de la refacto liée à #75 .
Cette PR vient après #112 .
Dans cette PR j'enlève les attributs de la table `organisations` qui ne se retrouvent qu'au niveau des `departments` (`region`, `number`, `capital`).
Je fais les changements associées pour récupérer ces attributs sur les `departments` et non plus sur les `organisations` dans le code.

L'index des organisations devient semblable à celui de RDVS: 
![image](https://user-images.githubusercontent.com/7602809/140071025-0d2c73a4-9fe6-468f-85cc-826514c58893.png)
