### PR TITLE
Bug/Responsive logo for header

### DIFF
--- a/app/javascript/stylesheets/components/_image.scss
+++ b/app/javascript/stylesheets/components/_image.scss
@@ -6,7 +6,7 @@
   height: 100px;
 }
 
-@media (max-width: 350px) {
+@media (max-width: 370px) {
   .rdvi-logo{
     width: 150px;
   }


### PR DESCRIPTION
Sur certains mobiles, Android notamment, le bouton connexion dépassait du header sur la page d'accueil. Cette PR corrige ce souci.