### PR TITLE
feat(invitations): add geolocalisation attributes to invitations

### DIFF
--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -1,15 +1,17 @@
 module Invitations
   class ComputeLink < BaseService
-    def initialize(organisation:, rdv_solidarites_session:, invitation_token:)
+    def initialize(organisation:, rdv_solidarites_session:, invitation_token:, applicant:)
       @organisation = organisation
       @rdv_solidarites_session = rdv_solidarites_session
       @invitation_token = invitation_token
+      @applicant = applicant
     end
 
     def call
       retrieve_organisation_motifs!
       check_motifs_presence!
-      result.invitation_link = redirect_link + "&invitation_token=#{@invitation_token}"
+      retrieve_geolocalisation
+      result.invitation_link = redirect_link
     end
 
     private
@@ -26,6 +28,23 @@ module Invitations
         rdv_solidarites_session: @rdv_solidarites_session,
         organisation: @organisation
       )
+    end
+
+    def retrieve_geolocalisation
+      @retrieve_geolocalisation ||= RetrieveGeolocalisation.call(
+        address: @applicant.address, department: @organisation.department
+      )
+    end
+
+    def geo_attributes
+      return {} unless retrieve_geolocalisation.success?
+
+      {
+        longitude: retrieve_geolocalisation.longitude,
+        latitude: retrieve_geolocalisation.latitude,
+        city_code: retrieve_geolocalisation.city_code,
+        street_ban_id: retrieve_geolocalisation.street_ban_id
+      }
     end
 
     def check_motifs_presence!
@@ -46,23 +65,28 @@ module Invitations
       end
     end
 
+    def link_params
+      {
+        departement: @organisation.department_number,
+        where: where,
+        invitation_token: @invitation_token
+      }.merge(geo_attributes)
+    end
+
     def link_with_motif(motif)
-      params = {
-        search: {
-          departement: @organisation.department_number,
-          where: @organisation.department_name_with_region,
-          motif_name_with_location_type: motif.name_with_location_type,
-          # Agents and motifs can be on "Service Social" and not in "Service RSA"
-          service: @organisation.rsa_agents_service_id
-        }
-      }
-      "#{ENV['RDV_SOLIDARITES_URL']}/lieux?#{params.to_query}"
+      "#{ENV['RDV_SOLIDARITES_URL']}/external_invitations/organisations/" \
+        "#{@organisation.rdv_solidarites_organisation_id}/services/"\
+        "#{@organisation.rsa_agents_service_id}/motifs/#{motif.id}/lieux?#{link_params.to_query}"
+    end
+
+    def where
+      @applicant.address.presence || @organisation.department_name_with_region
     end
 
     def link_without_motif
-      params = { where: @organisation.department_name_with_region }
-      "#{ENV['RDV_SOLIDARITES_URL']}/departement/#{@organisation.department_number}/" \
-        "#{@organisation.rsa_agents_service_id}?#{params.to_query}"
+      "#{ENV['RDV_SOLIDARITES_URL']}/external_invitations/organisations/" \
+        "#{@organisation.rdv_solidarites_organisation_id}/services/" \
+        "#{@organisation.rsa_agents_service_id}/motifs?#{link_params.to_query}"
     end
   end
 end

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -58,7 +58,7 @@ module Invitations
     end
 
     def redirect_link
-      "#{ENV['RDV_SOLIDARITES_URL']}/prendre-rdv?#{link_params.to_query}"
+      "#{ENV['RDV_SOLIDARITES_URL']}/prendre_rdv?#{link_params.to_query}"
     end
 
     def link_params

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -58,35 +58,23 @@ module Invitations
     end
 
     def redirect_link
-      if motifs.length == 1
-        link_with_motif(motifs.first)
-      else
-        link_without_motif
-      end
+      "#{ENV['RDV_SOLIDARITES_URL']}/prendre-rdv?#{link_params.to_query}"
     end
 
     def link_params
       {
         departement: @organisation.department_number,
-        where: where,
-        invitation_token: @invitation_token
-      }.merge(geo_attributes)
+        address: address,
+        invitation_token: @invitation_token,
+        organisation_id: @organisation.rdv_solidarites_organisation_id,
+        service_id: @organisation.rsa_agents_service_id
+      }
+        .merge(geo_attributes)
+        .merge(motifs.length == 1 ? { motif_id: motifs.first.id } : {})
     end
 
-    def link_with_motif(motif)
-      "#{ENV['RDV_SOLIDARITES_URL']}/external_invitations/organisations/" \
-        "#{@organisation.rdv_solidarites_organisation_id}/services/"\
-        "#{@organisation.rsa_agents_service_id}/motifs/#{motif.id}/lieux?#{link_params.to_query}"
-    end
-
-    def where
+    def address
       @applicant.address.presence || @organisation.department_name_with_region
-    end
-
-    def link_without_motif
-      "#{ENV['RDV_SOLIDARITES_URL']}/external_invitations/organisations/" \
-        "#{@organisation.rdv_solidarites_organisation_id}/services/" \
-        "#{@organisation.rsa_agents_service_id}/motifs?#{link_params.to_query}"
     end
   end
 end

--- a/app/services/invitations/create.rb
+++ b/app/services/invitations/create.rb
@@ -72,7 +72,8 @@ module Invitations
       @compute_invitation_link ||= Invitations::ComputeLink.call(
         organisation: @organisation,
         rdv_solidarites_session: @rdv_solidarites_session,
-        invitation_token: retrieve_invitation_token.invitation_token
+        invitation_token: retrieve_invitation_token.invitation_token,
+        applicant: @applicant
       )
     end
 

--- a/app/services/retrieve_geolocalisation.rb
+++ b/app/services/retrieve_geolocalisation.rb
@@ -1,0 +1,64 @@
+class RetrieveGeolocalisation < BaseService
+  API_ADRESSE_URL = "https://api-adresse.data.gouv.fr/search/".freeze
+
+  def initialize(address:, department:)
+    @address = address
+    @department = department
+  end
+
+  def call
+    check_address_presence!
+    request_geo_api!
+    retrieve_geolocalisation!
+  end
+
+  private
+
+  def check_address_presence!
+    fail!("an address must be passed!") if @address.blank?
+  end
+
+  def request_geo_api!
+    return if geo_api_response.success?
+
+    fail!("something happened while requesting geo coordinates")
+  end
+
+  def geo_api_response
+    @geo_api_response ||= Faraday.get(API_ADRESSE_URL, { q: @address }, { "Content-Type" => "application/json" })
+  end
+
+  def response_body
+    JSON.parse(geo_api_response.body)
+  end
+
+  def retrieve_geolocalisation!
+    fail!("coordinates could not be found") if selected_feature.nil?
+
+    result.longitude, result.latitude = coordinates
+    result.city_code = city_code
+    result.street_ban_id = street_ban_id
+  end
+
+  def city_code
+    selected_feature["properties"]["citycode"]
+  end
+
+  def coordinates
+    selected_feature["geometry"]["coordinates"]
+  end
+
+  def street_ban_id
+    # like in RDVS: 5 chars for city insee code, 1 for _, 4 for street fantoir
+    selected_feature["properties"]["id"].first(10)
+  end
+
+  def selected_feature
+    # we take the first result that checks that it is in the right department
+    response_body["features"].find do |f|
+      context = f["properties"]["context"].downcase
+
+      context.include?(@department.name.downcase) || context.include?(@department.number)
+    end
+  end
+end

--- a/app/services/retrieve_geolocalisation.rb
+++ b/app/services/retrieve_geolocalisation.rb
@@ -15,13 +15,13 @@ class RetrieveGeolocalisation < BaseService
   private
 
   def check_address_presence!
-    fail!("an address must be passed!") if @address.blank?
+    fail!("l'addresse doit être renseignée") if @address.blank?
   end
 
   def request_geo_api!
     return if geo_api_response.success?
 
-    fail!("something happened while requesting geo coordinates")
+    fail!("la requête pour récupérer les coordonnées a échoué")
   end
 
   def geo_api_response
@@ -33,7 +33,7 @@ class RetrieveGeolocalisation < BaseService
   end
 
   def retrieve_geolocalisation!
-    fail!("coordinates could not be found") if selected_feature.nil?
+    fail!("les coordonnées n'ont pas pu être retrouvées") if selected_feature.nil?
 
     result.longitude, result.latitude = coordinates
     result.city_code = city_code

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -138,9 +138,8 @@ describe Invitations::ComputeLink, type: :service do
 
         it "does not add the attributes to the link" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/external_invitations/"\
-            "organisations/27/services/12/motifs/16/lieux?departement=75&"\
-            "invitation_token=sometoken&where=20+avenue+de+s%C3%A9gur+75007+Paris"
+            "https://www.rdv-solidarites.fr/prendre-rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+            "departement=75&invitation_token=sometoken&motif_id=16&organisation_id=27&service_id=12"
           )
         end
       end
@@ -148,11 +147,11 @@ describe Invitations::ComputeLink, type: :service do
 
     context "computes the link" do
       context "when only one motif is found" do
-        it "redirects to the lieux page with the motif id" do
+        it "adds the motif id to the url" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/external_invitations/organisations/27/services/12/motifs/16/lieux?" \
-            "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&longitude=2.308628&" \
-            "street_ban_id=75107_8909&where=20+avenue+de+s%C3%A9gur+75007+Paris" \
+            "https://www.rdv-solidarites.fr/prendre-rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+            "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&" \
+            "longitude=2.308628&motif_id=16&organisation_id=27&service_id=12&street_ban_id=75107_8909"
           )
         end
       end
@@ -177,12 +176,11 @@ describe Invitations::ComputeLink, type: :service do
           ]
         end
 
-        it "redirects to the motifs selection page" do
-          puts subject.invitation_link
+        it "does not add a motif id in the url" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/external_invitations/organisations/27/services/12/motifs?" \
-            "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&longitude=2.308628&"\
-            "street_ban_id=75107_8909&where=20+avenue+de+s%C3%A9gur+75007+Paris" \
+            "https://www.rdv-solidarites.fr/prendre-rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+            "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&" \
+            "longitude=2.308628&organisation_id=27&service_id=12&street_ban_id=75107_8909"
           )
         end
       end

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -2,16 +2,16 @@ describe Invitations::ComputeLink, type: :service do
   subject do
     described_class.call(
       organisation: organisation, rdv_solidarites_session: rdv_solidarites_session,
-      invitation_token: invitation_token
+      invitation_token: invitation_token, applicant: applicant
     )
   end
 
   let!(:department) do
     create(
       :department,
-      number: "26",
-      name: "Drôme",
-      region: "Auvergne-Rhône-Alpes"
+      number: "75",
+      name: "Paris",
+      region: "Ile-de-France"
     )
   end
 
@@ -22,6 +22,12 @@ describe Invitations::ComputeLink, type: :service do
       department: department,
       rsa_agents_service_id: "12"
     )
+  end
+
+  let(:address) { "20 avenue de ségur 75007 Paris" }
+
+  let!(:applicant) do
+    create(:applicant, address: address)
   end
 
   let!(:invitation_token) { "sometoken" }
@@ -48,6 +54,14 @@ describe Invitations::ComputeLink, type: :service do
           organisation: organisation
         )
         .and_return(OpenStruct.new(success?: true, motifs: motifs))
+      allow(RetrieveGeolocalisation).to receive(:call)
+        .with(address: address, department: department)
+        .and_return(
+          OpenStruct.new(
+            success?: true, longitude: 2.308628, latitude: 48.850699, city_code: "75107",
+            street_ban_id: "75107_8909"
+          )
+        )
       allow(ENV).to receive(:[])
         .with('RDV_SOLIDARITES_URL')
         .and_return('https://www.rdv-solidarites.fr')
@@ -100,15 +114,45 @@ describe Invitations::ComputeLink, type: :service do
       end
     end
 
+    context "retrieves geolocalisation" do
+      it "tries to retrieve the geolocalisation" do
+        expect(RetrieveGeolocalisation).to receive(:call)
+          .with(
+            address: address,
+            department: department
+          )
+        subject
+      end
+
+      context "when it fails" do
+        before do
+          allow(RetrieveGeolocalisation).to receive(:call)
+            .with(
+              address: address,
+              department: department
+            )
+            .and_return(OpenStruct.new(success?: false))
+        end
+
+        it("still succeeds") { is_a_success }
+
+        it "does not add the attributes to the link" do
+          expect(subject.invitation_link).to eq(
+            "https://www.rdv-solidarites.fr/external_invitations/"\
+            "organisations/27/services/12/motifs/16/lieux?departement=75&"\
+            "invitation_token=sometoken&where=20+avenue+de+s%C3%A9gur+75007+Paris"
+          )
+        end
+      end
+    end
+
     context "computes the link" do
       context "when only one motif is found" do
-        it "redirects to the lieux page with the motif params" do
+        it "redirects to the lieux page with the motif id" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/lieux?" \
-            "search%5Bdepartement%5D=26&" \
-            "search%5Bmotif_name_with_location_type%5D=RSA+-+Orientation+%3A+rdv+sur+site-public_office"\
-            "&search%5Bservice%5D=12&search%5Bwhere%5D=Dr%C3%B4me%2C+Auvergne-Rh%C3%B4ne-Alpes" \
-            "&invitation_token=sometoken"
+            "https://www.rdv-solidarites.fr/external_invitations/organisations/27/services/12/motifs/16/lieux?" \
+            "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&longitude=2.308628&" \
+            "street_ban_id=75107_8909&where=20+avenue+de+s%C3%A9gur+75007+Paris" \
           )
         end
       end
@@ -134,9 +178,11 @@ describe Invitations::ComputeLink, type: :service do
         end
 
         it "redirects to the motifs selection page" do
+          puts subject.invitation_link
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/departement/26/12?where=Dr%C3%B4me%2C+Auvergne-Rh%C3%B4ne-Alpes" \
-            "&invitation_token=sometoken"
+            "https://www.rdv-solidarites.fr/external_invitations/organisations/27/services/12/motifs?" \
+            "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&longitude=2.308628&"\
+            "street_ban_id=75107_8909&where=20+avenue+de+s%C3%A9gur+75007+Paris" \
           )
         end
       end

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -138,7 +138,7 @@ describe Invitations::ComputeLink, type: :service do
 
         it "does not add the attributes to the link" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/prendre-rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+            "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
             "departement=75&invitation_token=sometoken&motif_id=16&organisation_id=27&service_id=12"
           )
         end
@@ -149,7 +149,7 @@ describe Invitations::ComputeLink, type: :service do
       context "when only one motif is found" do
         it "adds the motif id to the url" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/prendre-rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+            "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
             "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&" \
             "longitude=2.308628&motif_id=16&organisation_id=27&service_id=12&street_ban_id=75107_8909"
           )
@@ -178,7 +178,7 @@ describe Invitations::ComputeLink, type: :service do
 
         it "does not add a motif id in the url" do
           expect(subject.invitation_link).to eq(
-            "https://www.rdv-solidarites.fr/prendre-rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+            "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
             "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&" \
             "longitude=2.308628&organisation_id=27&service_id=12&street_ban_id=75107_8909"
           )

--- a/spec/services/invitations/create_spec.rb
+++ b/spec/services/invitations/create_spec.rb
@@ -114,7 +114,8 @@ describe Invitations::Create, type: :service do
             .with(
               rdv_solidarites_session: rdv_solidarites_session,
               invitation_token: token,
-              organisation: organisation
+              organisation: organisation,
+              applicant: applicant
             )
           subject
         end

--- a/spec/services/retrieve_geolocalisation_spec.rb
+++ b/spec/services/retrieve_geolocalisation_spec.rb
@@ -65,7 +65,7 @@ describe RetrieveGeolocalisation, type: :service do
       it("is a failure") { is_a_failure }
 
       it "returns the error message" do
-        expect(subject.errors).to eq(["an address must be passed!"])
+        expect(subject.errors).to eq(["l'addresse doit être renseignée"])
       end
     end
 
@@ -82,7 +82,7 @@ describe RetrieveGeolocalisation, type: :service do
       it("is a failure") { is_a_failure }
 
       it "returns the error message" do
-        expect(subject.errors).to eq(["something happened while requesting geo coordinates"])
+        expect(subject.errors).to eq(["la requête pour récupérer les coordonnées a échoué"])
       end
     end
 
@@ -121,7 +121,7 @@ describe RetrieveGeolocalisation, type: :service do
       it("is a failure") { is_a_failure }
 
       it "returns the error message" do
-        expect(subject.errors).to eq(["coordinates could not be found"])
+        expect(subject.errors).to eq(["les coordonnées n'ont pas pu être retrouvées"])
       end
     end
   end

--- a/spec/services/retrieve_geolocalisation_spec.rb
+++ b/spec/services/retrieve_geolocalisation_spec.rb
@@ -1,0 +1,128 @@
+describe RetrieveGeolocalisation, type: :service do
+  subject do
+    described_class.call(address: address, department: department)
+  end
+
+  let(:address) { "20 Avenue de Ségur, 75007 Paris" }
+  let(:department) { create(:department, name: "Paris", number: "75", region: "Île-de-France") }
+  let(:response_body) do
+    {
+      "type" => "FeatureCollection",
+      "version" => "draft",
+      "features" => [
+        {
+          "type" => "Feature",
+          "geometry" => {
+            "type" => "Point",
+            "coordinates" => [
+              2.308628,
+              48.850699
+            ]
+          },
+          "properties" => {
+            "label" => "20 Avenue de Ségur 75007 Paris",
+            "score" => 0.8470354545454546,
+            "housenumber" => "20",
+            "id" => "75107_8909_00020",
+            "name" => "20 Avenue de Ségur",
+            "postcode" => "75007",
+            "citycode" => "75107",
+
+            "city" => "Paris",
+            "district" => "Paris 7e Arrondissement",
+            "context" => "75, Paris, Île-de-France",
+            "type" => "housenumber",
+            "importance" => 0.69239,
+            "street" => "Avenue de Ségur"
+          }
+        }
+      ]
+    }
+  end
+
+  describe "#call" do
+    before do
+      allow(Faraday).to receive(:get)
+        .with(
+          "https://api-adresse.data.gouv.fr/search/",
+          { q: address }, { "Content-Type" => "application/json" }
+        )
+        .and_return(OpenStruct.new(success?: true, body: response_body.to_json))
+    end
+
+    it("is a success") { is_a_success }
+
+    it "retrieves the geolocalisation attributes" do
+      expect(subject.longitude).to eq(2.308628)
+      expect(subject.latitude).to eq(48.850699)
+      expect(subject.city_code).to eq("75107")
+      expect(subject.street_ban_id).to eq("75107_8909")
+    end
+
+    context "when no address is passed" do
+      let(:address) { "" }
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error message" do
+        expect(subject.errors).to eq(["an address must be passed!"])
+      end
+    end
+
+    context "when the request to the api address fails" do
+      before do
+        allow(Faraday).to receive(:get)
+          .with(
+            "https://api-adresse.data.gouv.fr/search/",
+            { q: address }, { "Content-Type" => "application/json" }
+          )
+          .and_return(OpenStruct.new(success?: false))
+      end
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error message" do
+        expect(subject.errors).to eq(["something happened while requesting geo coordinates"])
+      end
+    end
+
+    context "when no matching coordinates are found" do
+      let(:response_body) do
+        {
+          "type" => "FeatureCollection",
+          "version" => "draft",
+          "features" => [
+            {
+              "type" => "Feature",
+              "geometry" => {
+                "type" => "Point",
+                "coordinates" => [
+                  2.308628,
+                  48.850699
+                ]
+              },
+              "properties" => {
+                "label" => "Avenue de la Résistance 26150 Die",
+                "score" => 0.6414745454545454,
+                "id" => "26113_1104",
+                "name" => "Avenue de la Résistance",
+                "postcode" => "26150",
+                "citycode" => "26113",
+                "city" => "Die",
+                "context" => "26, Drôme, Auvergne-Rhône-Alpes",
+                "type" => "street",
+                "importance" => 0.45622
+              }
+            }
+          ]
+        }
+      end
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error message" do
+        expect(subject.errors).to eq(["coordinates could not be found"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dans cette PR j'introduis un service qui récupère les attributs géographiques (`latitude`, `longitude`, `city_code` et `street_ban_id`) liés à l'utilisateur à partir de son adresse en requêtant [l'API Adresse](https://adresse.data.gouv.fr/api-doc/adresse).
Je mets ces attributs (lorsqu'ils sont retrouvés avec succès) dans le lien d'invitation vers RDV-Solidarités envoyé à l'utilisateur.
Je change également les liens d'invitations suite à un changement dans RDV-Solidarités (voir https://github.com/betagouv/rdv-solidarites.fr/pull/1865). Cette PR ne doit donc pas être déployé avant celle concernant RDV-Solidarités.