### PR TITLE
fix(notifications): Do not raise when no phone

### DIFF
--- a/app/services/notifications/notify_applicant.rb
+++ b/app/services/notifications/notify_applicant.rb
@@ -9,8 +9,9 @@ module Notifications
     end
 
     def call
+      return if phone_number.blank?
+
       check_applicant_organisation!
-      check_phone_number!
       notify_applicant!
       update_notification_sent_at!
     end
@@ -21,10 +22,6 @@ module Notifications
       return if @applicant.organisation_ids.include?(@organisation.id)
 
       fail!("l'allocataire ne peut être invité car il n'appartient pas à l'organisation.")
-    end
-
-    def check_phone_number!
-      fail!("le téléphone n'est pas renseigné") if phone_number.blank?
     end
 
     def notify_applicant!

--- a/app/views/applicants/_search_form.html.erb
+++ b/app/views/applicants/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with method: :get, local: true, url: organisation_applicants_path(@organisation) do  |form| %>
   <%= form.text_field :search_query, placeholder: "Prénom, nom, email, numéro allocataire...", class: "form-control mb-1" %>
   <div class="d-flex justify-content-between">
-    <%= form.submit "Rechercher", class: "btn btn-blue-out" %>
+    <%= form.submit "Rechercher", name: nil, class: "btn btn-blue-out" %>
     <% if display_back_to_list_button? %>
       <div class="d-flex justify-content-start">
         <%= link_to organisation_applicants_path(@organisation), class: "btn btn-blue-out" do %>

--- a/spec/services/notifications/notify_applicant_spec.rb
+++ b/spec/services/notifications/notify_applicant_spec.rb
@@ -31,10 +31,16 @@ describe Notifications::NotifyApplicant, type: :service do
     context "when the phone number is missing" do
       let!(:applicant) { create(:applicant, organisations: [organisation], phone_number_formatted: "") }
 
-      it("is a failure") { is_a_failure }
+      it("is a success") { is_a_success }
 
-      it "stores the errors message" do
-        expect(subject.errors).to eq(["le téléphone n'est pas renseigné"])
+      it "does not create a notification" do
+        expect(Notification).not_to receive(:find_or_initialize_by)
+        subject
+      end
+
+      it "does not send a sms" do
+        expect(SendTransactionalSms).not_to receive(:call)
+        subject
       end
     end
 


### PR DESCRIPTION
Cette PR fait suite au mail de Guillaume Faure.
Lorsqu'un RDV est pris sur RDVS pour un allocataire qui n'a pas de téléphone pour des raisons d'agenda, on ne procède pas à la notification mais on ne considère pas que c'est un échec (cf. https://sentry.io/organizations/betagouv-f7/issues/2730054987).