### PR TITLE
Fix/Translate rdv-solidarites errors in french

### DIFF
--- a/app/services/rdv_solidarites_api/base.rb
+++ b/app/services/rdv_solidarites_api/base.rb
@@ -10,6 +10,11 @@ module RdvSolidaritesApi
       JSON.parse(rdv_solidarites_response.body)
     end
 
+    def fail_with_response_errors
+      result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
+      fail!
+    end
+
     def rdv_solidarites_response
       raise NotImplementedError
     end

--- a/app/services/rdv_solidarites_api/create_user.rb
+++ b/app/services/rdv_solidarites_api/create_user.rb
@@ -6,17 +6,15 @@ module RdvSolidaritesApi
     end
 
     def call
-      create_user_in_rdv_solidarites
+      create_user_in_rdv_solidarites!
     end
 
     private
 
-    def create_user_in_rdv_solidarites
-      if rdv_solidarites_response.success?
-        result.rdv_solidarites_user = RdvSolidarites::User.new(rdv_solidarites_response_body["user"])
-      else
-        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
-      end
+    def create_user_in_rdv_solidarites!
+      fail_with_response_errors unless rdv_solidarites_response.success?
+
+      result.rdv_solidarites_user = RdvSolidarites::User.new(rdv_solidarites_response_body["user"])
     end
 
     def rdv_solidarites_response

--- a/app/services/rdv_solidarites_api/create_user.rb
+++ b/app/services/rdv_solidarites_api/create_user.rb
@@ -15,7 +15,7 @@ module RdvSolidaritesApi
       if rdv_solidarites_response.success?
         result.rdv_solidarites_user = RdvSolidarites::User.new(rdv_solidarites_response_body["user"])
       else
-        result.errors << "erreur RDV-Solidarités: #{rdv_solidarites_response_body['errors']}"
+        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
       end
     end
 

--- a/app/services/rdv_solidarites_api/retrieve_invitation_token.rb
+++ b/app/services/rdv_solidarites_api/retrieve_invitation_token.rb
@@ -15,7 +15,7 @@ module RdvSolidaritesApi
       if rdv_solidarites_response.success?
         result.invitation_token = rdv_solidarites_response_body['invitation_token']
       else
-        result.errors << "erreur RDV-Solidarités: #{rdv_solidarites_response_body['errors']}"
+        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
       end
     end
 

--- a/app/services/rdv_solidarites_api/retrieve_invitation_token.rb
+++ b/app/services/rdv_solidarites_api/retrieve_invitation_token.rb
@@ -6,17 +6,15 @@ module RdvSolidaritesApi
     end
 
     def call
-      retrieve_invitation_token
+      retrieve_invitation_token!
     end
 
     private
 
-    def retrieve_invitation_token
-      if rdv_solidarites_response.success?
-        result.invitation_token = rdv_solidarites_response_body['invitation_token']
-      else
-        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
-      end
+    def retrieve_invitation_token!
+      fail_with_response_errors unless rdv_solidarites_response.success?
+
+      result.invitation_token = rdv_solidarites_response_body['invitation_token']
     end
 
     def rdv_solidarites_response

--- a/app/services/rdv_solidarites_api/retrieve_motifs.rb
+++ b/app/services/rdv_solidarites_api/retrieve_motifs.rb
@@ -15,7 +15,7 @@ module RdvSolidaritesApi
       if rdv_solidarites_response.success?
         result.motifs = rdv_solidarites_response_body['motifs'].map { RdvSolidarites::Motif.new(_1) }
       else
-        result.errors << "erreur RDV-Solidarités: #{rdv_solidarites_response_body['errors']}"
+        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
       end
     end
 

--- a/app/services/rdv_solidarites_api/retrieve_motifs.rb
+++ b/app/services/rdv_solidarites_api/retrieve_motifs.rb
@@ -6,17 +6,15 @@ module RdvSolidaritesApi
     end
 
     def call
-      retrieve_motifs
+      retrieve_motifs!
     end
 
     private
 
-    def retrieve_motifs
-      if rdv_solidarites_response.success?
-        result.motifs = rdv_solidarites_response_body['motifs'].map { RdvSolidarites::Motif.new(_1) }
-      else
-        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
-      end
+    def retrieve_motifs!
+      fail_with_response_errors unless rdv_solidarites_response.success?
+
+      result.motifs = rdv_solidarites_response_body['motifs'].map { RdvSolidarites::Motif.new(_1) }
     end
 
     def rdv_solidarites_response

--- a/app/services/rdv_solidarites_api/retrieve_resources.rb
+++ b/app/services/rdv_solidarites_api/retrieve_resources.rb
@@ -30,7 +30,7 @@ module RdvSolidaritesApi
       return if response.success?
 
       parsed_reponse_body = JSON.parse(response.body)
-      fail!("erreur RDV-Solidarités: #{parsed_reponse_body['errors']}")
+      fail!("Erreur RDV-Solidarités: #{parsed_reponse_body['error_messages']&.join(',')}")
     end
 
     def retrieve_resources(page)

--- a/app/services/rdv_solidarites_api/retrieve_user.rb
+++ b/app/services/rdv_solidarites_api/retrieve_user.rb
@@ -6,17 +6,15 @@ module RdvSolidaritesApi
     end
 
     def call
-      retrieve_user
+      retrieve_user!
     end
 
     private
 
-    def retrieve_user
-      if rdv_solidarites_response.success?
-        result.user = RdvSolidarites::User.new(rdv_solidarites_response_body['user'].deep_symbolize_keys)
-      else
-        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
-      end
+    def retrieve_user!
+      fail_with_response_errors unless rdv_solidarites_response.success?
+
+      result.user = RdvSolidarites::User.new(rdv_solidarites_response_body['user'].deep_symbolize_keys)
     end
 
     def rdv_solidarites_response

--- a/app/services/rdv_solidarites_api/retrieve_user.rb
+++ b/app/services/rdv_solidarites_api/retrieve_user.rb
@@ -15,7 +15,7 @@ module RdvSolidaritesApi
       if rdv_solidarites_response.success?
         result.user = RdvSolidarites::User.new(rdv_solidarites_response_body['user'].deep_symbolize_keys)
       else
-        result.errors << "erreur RDV-Solidarités: #{rdv_solidarites_response_body['errors']}"
+        result.errors << "Erreur RDV-Solidarités: #{rdv_solidarites_response_body['error_messages']&.join(',')}"
       end
     end
 

--- a/spec/services/rdv_solidarites_api/create_user_spec.rb
+++ b/spec/services/rdv_solidarites_api/create_user_spec.rb
@@ -57,7 +57,7 @@ describe RdvSolidaritesApi::CreateUser, type: :service do
     end
 
     context "when the response is unsuccessful" do
-      let(:response_body) { { errors: ['some error'] }.to_json }
+      let(:response_body) { { error_messages: ['some error'] }.to_json }
 
       before do
         allow(rdv_solidarites_client).to receive(:create_user)
@@ -70,7 +70,7 @@ describe RdvSolidaritesApi::CreateUser, type: :service do
       end
 
       it "stores the error" do
-        expect(subject.errors).to eq(["erreur RDV-Solidarités: [\"some error\"]"])
+        expect(subject.errors).to eq(["Erreur RDV-Solidarités: some error"])
       end
     end
   end

--- a/spec/services/rdv_solidarites_api/retrieve_invitation_token_spec.rb
+++ b/spec/services/rdv_solidarites_api/retrieve_invitation_token_spec.rb
@@ -41,13 +41,13 @@ describe RdvSolidaritesApi::RetrieveInvitationToken, type: :service do
     context "when it fails" do
       before do
         allow(rdv_solidarites_client).to receive(:invite_user)
-          .and_return(OpenStruct.new(success?: false, body: { 'errors' => ['some error'] }.to_json))
+          .and_return(OpenStruct.new(success?: false, body: { error_messages: ['some error'] }.to_json))
       end
 
       it("is a failure") { is_a_failure }
 
       it "returns the error" do
-        expect(subject.errors).to eq(["erreur RDV-Solidarités: [\"some error\"]"])
+        expect(subject.errors).to eq(["Erreur RDV-Solidarités: some error"])
       end
     end
   end

--- a/spec/services/rdv_solidarites_api/retrieve_motifs_spec.rb
+++ b/spec/services/rdv_solidarites_api/retrieve_motifs_spec.rb
@@ -48,13 +48,13 @@ describe RdvSolidaritesApi::RetrieveMotifs, type: :service do
     context "when it fails" do
       before do
         allow(rdv_solidarites_client).to receive(:get_motifs)
-          .and_return(OpenStruct.new(success?: false, body: { 'errors' => ['some error'] }.to_json))
+          .and_return(OpenStruct.new(success?: false, body: { error_messages: ['some error'] }.to_json))
       end
 
       it("is a failure") { is_a_failure }
 
       it "returns the error" do
-        expect(subject.errors).to eq(["erreur RDV-Solidarités: [\"some error\"]"])
+        expect(subject.errors).to eq(["Erreur RDV-Solidarités: some error"])
       end
     end
   end

--- a/spec/services/rdv_solidarites_api/retrieve_resources_spec.rb
+++ b/spec/services/rdv_solidarites_api/retrieve_resources_spec.rb
@@ -61,13 +61,13 @@ describe RdvSolidaritesApi::RetrieveResources, type: :service do
     context "when response is unsuccessful" do
       before do
         allow(rdv_solidarites_client).to receive(:get_users)
-          .and_return(OpenStruct.new(success?: false, body: { errors: ["KO"] }.to_json))
+          .and_return(OpenStruct.new(success?: false, body: { error_messages: ['some error'] }.to_json))
       end
 
       it("is a failure") { is_a_failure }
 
       it "stores the error message" do
-        expect(subject.errors).to eq(["erreur RDV-Solidarités: [\"KO\"]"])
+        expect(subject.errors).to eq(["Erreur RDV-Solidarités: some error"])
       end
     end
   end

--- a/spec/services/rdv_solidarites_api/retrieve_user_spec.rb
+++ b/spec/services/rdv_solidarites_api/retrieve_user_spec.rb
@@ -45,13 +45,13 @@ describe RdvSolidaritesApi::RetrieveUser, type: :service do
     context "when it fails" do
       before do
         allow(rdv_solidarites_client).to receive(:get_user)
-          .and_return(OpenStruct.new(success?: false, body: { 'errors' => ['some error'] }.to_json))
+          .and_return(OpenStruct.new(success?: false, body: { error_messages: ['some error'] }.to_json))
       end
 
       it("is a failure") { is_a_failure }
 
       it "returns the error" do
-        expect(subject.errors).to eq(["erreur RDV-Solidarités: [\"some error\"]"])
+        expect(subject.errors).to eq(["Erreur RDV-Solidarités: some error"])
       end
     end
   end


### PR DESCRIPTION
close #109 

Pour permettre un affichage des erreurs envoyées par l'API de RDV-Solidarités, cette PR substitue les `errors` par les `error_messages`