### PR TITLE
fix(job): fix for retrieve_and_save_organisation_rdvs

### DIFF
--- a/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
+++ b/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
@@ -23,7 +23,7 @@ module Migrations
     end
 
     def retrieve_applicants_ids(user_ids)
-      Applicant.where(rdv_solidarites_user_id: user_ids, organisation_id: organisation.id).pluck(:id)
+      Applicant.where(rdv_solidarites_user_id: user_ids).pluck(:id)
     end
 
     def retrieve_rdv_solidarites_rdvs!


### PR DESCRIPTION
`organisation_id` n'existe pas pour `Applicant`, `organisation` n'est pas définie dans cette méthode.
Je pense que de toute façon  on peut se passer de ce where, car l'autorisation de visualiser des applicants est déjà vérifiée avec les policy.