### PR TITLE
fix(stats): hide stats for notify_applicant departments + temp hiding of Ardennes

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -19,13 +19,14 @@ class StatsController < ApplicationController
   end
 
   def filter_stats_by_department
-    @department_number = params[:department_number]
-    return if @department_number.blank?
+    return if params[:department_number].blank?
 
-    @applicants = Department.find_by(number: @department_number).applicants
-    @agents = Department.find_by(number: @department_number).agents
-    @invitations = Department.find_by(number: @department_number).invitations
-    @rdvs = Department.find_by(number: @department_number).rdvs
-    @organisations = Department.find_by(number: @department_number).organisations
+    @department = Department.find_by(number: params[:department_number])
+    @applicants = @department.applicants
+    @agents = @department.agents
+    @invitations = @department.invitations
+    @rdvs = @department.rdvs
+    @organisations = @department.organisations
+    @display_all_stats = !@organisations.all?(&:notify_applicant?)
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -11,22 +11,24 @@ class StatsController < ApplicationController
   private
 
   def collect_datas
-    @applicants = Applicant.all
+    @organisations = Organisation.all
+    @applicants = Applicant.includes(:rdvs, :invitations).all
     @agents = Agent.all
     @invitations = Invitation.all
     @rdvs = Rdv.all
-    @organisations = Organisation.all
   end
 
   def filter_stats_by_department
     return if params[:department_number].blank?
 
-    @department = Department.find_by(number: params[:department_number])
-    @applicants = @department.applicants
+    @department = Department.includes(organisations: [:rdvs, :applicants, :invitations, :agents])
+                            .find_by!(number: params[:department_number])
+    @applicants = @department.applicants.includes(:rdvs, :invitations)
     @agents = @department.agents
     @invitations = @department.invitations
     @rdvs = @department.rdvs
     @organisations = @department.organisations
-    @display_all_stats = !@organisations.all?(&:notify_applicant?)
+    # We can
+    @display_all_stats = @organisations.none?(&:notify_applicant?)
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -1,6 +1,10 @@
 module StatsHelper
   def options_for_department_select
-    Department.all.order(:number).map { |d| ["#{d.number} - #{d.name}", d.number] }
+    ardennes = Department.find_by(name: "Ardennes")
+    Department.all
+              .order(:number)
+              .excluding(ardennes)
+              .map { |d| ["#{d.number} - #{d.name}", d.number] }
               .unshift(["Tous les départements", "0"])
   end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -69,7 +69,7 @@ class Applicant < ApplicationRecord
   end
 
   def orientation_date
-    rdvs.seen.first&.starts_at
+    rdvs.find(&:seen?)&.starts_at
   end
 
   def oriented?

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -19,42 +19,44 @@
       <p>bénéficiaires du RSA<br/>gérés dans RDV-Insertion</p>
     </div>
     <div class="text-center col-10 col-md-5">
-      <p class="highlight-stat"><%= @stats.sent_invitations.count %></p>
-      <p>bénéficiaires invités par mail et SMS</p>
-    </div>
-  </div>
-  <div class="row d-flex justify-content-center">
-    <div class="text-center col-10 col-md-5">
       <p class="highlight-stat"><%= @stats.rdvs.count %></p>
       <p>rendez-vous pris</p>
     </div>
-    <div class="text-center col-10 col-md-5">
-      <p class="highlight-stat"><%= @stats.percentage_of_no_show.round %> %</p>
-      <p>seulement de rendez-vous<br/>non honorés avec RDV-Insertion</p>
-    </div>
   </div>
-  <div class="row d-flex justify-content-center">
-    <div class="text-center col-10 col-md-5">
-      <p class="highlight-stat"><%= @stats.percentage_of_applicants_oriented_in_time.round %> %</p>
-      <p>de bénéficiaires <strong>orientés en - de 30 jours</strong></p>
+  <% if @department && @display_all_stats %>
+    <div class="row d-flex justify-content-center">
+      <div class="text-center col-10 col-md-5">
+        <p class="highlight-stat"><%= @stats.sent_invitations.count %></p>
+        <p>bénéficiaires invités par mail et SMS</p>
+      </div>
+      <div class="text-center col-10 col-md-5">
+        <p class="highlight-stat"><%= @stats.percentage_of_no_show.round %> %</p>
+        <p>seulement de rendez-vous<br/>non honorés avec RDV-Insertion</p>
+      </div>
     </div>
-    <div class="text-center col-10 col-md-5">
-      <p class="highlight-stat"><%= @stats.average_orientation_delay_in_days.round %> jours</p>
-      <p>délai d'orientation moyen<br/>d'un bénéficiaire avec RDV-Insertion</p>
+    <div class="row d-flex justify-content-center">
+      <div class="text-center col-10 col-md-5">
+        <p class="highlight-stat"><%= @stats.percentage_of_applicants_oriented_in_time.round %> %</p>
+        <p>de bénéficiaires <strong>orientés en - de 30 jours</strong></p>
+      </div>
+      <div class="text-center col-10 col-md-5">
+        <p class="highlight-stat"><%= @stats.average_orientation_delay_in_days.round %> jours</p>
+        <p>délai d'orientation moyen<br/>d'un bénéficiaire avec RDV-Insertion</p>
+      </div>
     </div>
-  </div>
-  <div class="row d-flex justify-content-center">
-    <div class="text-center col-10 col-md-5">
-      <p class="highlight-stat"><%= @stats.average_rdv_delay_in_days.round %> jours</p>
-      <p>délai moyen entre la prise<br/>d'un rendez-vous et sa tenue</p>
+    <div class="row d-flex justify-content-center">
+      <div class="text-center col-10 col-md-5">
+        <p class="highlight-stat"><%= @stats.average_rdv_delay_in_days.round %> jours</p>
+        <p>délai moyen entre la prise<br/>d'un rendez-vous et sa tenue</p>
+      </div>
+      <div class="text-center col-10 col-md-5 mb-4">
+        <p class="highlight-stat"><%= @stats.agents.count %> agents</p>
+        <% if @department %>
+          <p>utilisent RDV-Insertion</p>
+        <% else %>
+          <p>travaillant pour <strong><%= Department.count %> départements</strong><br/> utilisent RDV-Insertion</p>
+        <% end %>
+      </div>
     </div>
-    <div class="text-center col-10 col-md-5 mb-4">
-      <p class="highlight-stat"><%= @stats.agents.count %> agents</p>
-      <% if @department_number %>
-        <p>utilisent RDV-Insertion</p>
-      <% else %>
-        <p>travaillant pour <strong><%= Department.count %> départements</strong><br/> utilisent RDV-Insertion</p>
-      <% end %>
-    </div>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Cette PR vise à limiter l'affichage des statistiques pour les départements qui n'utilisent RDV-I que pour envoyer des convocations.

En attendant son intégration à RDV-I, le département des Ardennes est temporairement masqué pour éviter d'afficher des stats vides.