### PR TITLE
feat(invitations): change sender name + sms wording

### DIFF
--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -26,15 +26,15 @@ module Invitations
       Rails.logger.info(content)
       return unless Rails.env.production?
 
-      SendTransactionalSms.call(phone_number: phone_number, content: content)
+      SendTransactionalSms.call(phone_number: phone_number, sender_name: sender_name, content: content)
     end
 
     def content
-      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous allez à ce titre bénéficier " \
-        "d'un accompagnement obligatoire. Pour pouvoir choisir la date et l'horaire de votre premier RDV, " \
+      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous " \
+        "d’accompagnement. Pour choisir la date et l'horaire de votre premier RDV, " \
         "cliquez sur le lien suivant dans les 3 jours: " \
         "#{redirect_invitations_url(params: { token: @invitation.token }, host: ENV['HOST'])}\n" \
-        "Passé ce délai, vous recevrez une convocation. En cas de problème technique, contactez le "\
+        "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
         "#{organisation.phone_number}."
     end
 
@@ -48,6 +48,14 @@ module Invitations
 
     def applicant
       @invitation.applicant
+    end
+
+    def department
+      organisation.department
+    end
+
+    def sender_name
+      "Dept#{department.number}"
     end
   end
 end

--- a/app/services/notifications/notify_applicant.rb
+++ b/app/services/notifications/notify_applicant.rb
@@ -51,7 +51,7 @@ module Notifications
     end
 
     def send_sms
-      @send_sms ||= SendTransactionalSms.call(phone_number: phone_number, content: content)
+      @send_sms ||= SendTransactionalSms.call(phone_number: phone_number, sender_name: sender_name, content: content)
     end
 
     def notification
@@ -67,6 +67,14 @@ module Notifications
 
       result.errors << notification.errors.full_messages.to_sentence
       fail!
+    end
+
+    def department
+      @organisation.department
+    end
+
+    def sender_name
+      "Dept#{department.number}"
     end
   end
 end

--- a/app/services/send_transactional_sms.rb
+++ b/app/services/send_transactional_sms.rb
@@ -1,8 +1,9 @@
 class SendTransactionalSms < BaseService
   SENDER_NAME = "RdvRSA".freeze
 
-  def initialize(phone_number:, content:)
+  def initialize(phone_number:, sender_name:, content:)
     @phone_number = phone_number
+    @sender_name = sender_name
     @content = content
   end
 
@@ -29,7 +30,7 @@ class SendTransactionalSms < BaseService
 
   def transactional_sms
     SibApiV3Sdk::SendTransacSms.new(
-      sender: SENDER_NAME,
+      sender: @sender_name,
       recipient: @phone_number,
       content: formatted_content,
       type: "transactional"

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -39,10 +39,10 @@ describe Invitations::SendSms, type: :service do
 
   describe "#call" do
     let!(:content) do
-      "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous allez à ce titre bénéficier d'un "\
-        "accompagnement obligatoire. Pour pouvoir choisir la date et l'horaire de votre premier RDV, "\
-        "cliquez sur le lien suivant dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?token=123\n"\
-        "Passé ce délai, vous recevrez une convocation. En cas de problème technique, contactez le 0147200001."
+      "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
+        "d’accompagnement. Pour choisir la date et l'horaire de votre premier RDV, cliquez sur le lien suivant "\
+        "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?token=123\n"\
+        "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le 0147200001."
     end
 
     before do
@@ -55,7 +55,7 @@ describe Invitations::SendSms, type: :service do
 
     it "calls the send transactional service" do
       expect(SendTransactionalSms).to receive(:call)
-        .with(phone_number: phone_number, content: content)
+        .with(phone_number: phone_number, sender_name: "Dept#{department.number}", content: content)
       subject
     end
 

--- a/spec/services/notifications/notify_applicant_spec.rb
+++ b/spec/services/notifications/notify_applicant_spec.rb
@@ -15,7 +15,8 @@ describe Notifications::NotifyApplicant, type: :service do
   let!(:rdv_solidarites_rdv) do
     OpenStruct.new(id: rdv_solidarites_rdv_id)
   end
-  let!(:organisation) { create(:organisation) }
+  let!(:department) { create(:department) }
+  let!(:organisation) { create(:organisation, department: department) }
   let!(:rdv_solidarites_rdv_id) { 23 }
   let!(:applicant) { create(:applicant, phone_number: phone_number, organisations: [organisation]) }
   let!(:notification) { create(:notification, applicant: applicant) }
@@ -53,7 +54,7 @@ describe Notifications::NotifyApplicant, type: :service do
 
     it "sends the sms" do
       expect(SendTransactionalSms).to receive(:call)
-        .with(phone_number: phone_number, content: "test")
+        .with(phone_number: phone_number, sender_name: "Dept#{department.number}", content: "test")
       subject
     end
 

--- a/spec/services/notifications/rdv_cancelled_spec.rb
+++ b/spec/services/notifications/rdv_cancelled_spec.rb
@@ -50,7 +50,7 @@ describe Notifications::RdvCancelled, type: :service do
 
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
-          .with(phone_number: phone_number, content: content)
+          .with(phone_number: phone_number, sender_name: "Dept#{department.number}", content: content)
         subject
       end
     end

--- a/spec/services/notifications/rdv_created_spec.rb
+++ b/spec/services/notifications/rdv_created_spec.rb
@@ -62,7 +62,7 @@ describe Notifications::RdvCreated, type: :service do
 
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
-          .with(phone_number: phone_number, content: content)
+          .with(phone_number: phone_number, sender_name: "Dept#{department.number}", content: content)
         subject
       end
     end
@@ -81,7 +81,7 @@ describe Notifications::RdvCreated, type: :service do
 
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
-          .with(phone_number: phone_number, content: content)
+          .with(phone_number: phone_number, sender_name: "Dept#{department.number}", content: content)
         subject
       end
     end

--- a/spec/services/send_transactional_sms_spec.rb
+++ b/spec/services/send_transactional_sms_spec.rb
@@ -3,7 +3,6 @@ describe SendTransactionalSms, type: :service do
     described_class.call(phone_number_formatted: phone_number_formatted, sender_name: sender_name, content: content)
   end
 
-  let(:phone_number) { "+33648498119" }
   let(:sender_name) { "Dept26" }
   let(:phone_number_formatted) { "+33648498119" }
   let(:content) { "Bienvenue sur RDV-Solidarités" }

--- a/spec/services/send_transactional_sms_spec.rb
+++ b/spec/services/send_transactional_sms_spec.rb
@@ -1,9 +1,10 @@
 describe SendTransactionalSms, type: :service do
   subject do
-    described_class.call(phone_number: phone_number, content: content)
+    described_class.call(phone_number: phone_number, sender_name: sender_name, content: content)
   end
 
   let(:phone_number) { "+33648498119" }
+  let(:sender_name) { "Dept26" }
   let(:content) { "Bienvenue sur RDV-Solidarités" }
   let(:sib_api_mock) { instance_double(SibApiV3Sdk::TransactionalSMSApi) }
   let(:send_transac_mock) { instance_double(SibApiV3Sdk::SendTransacSms) }
@@ -13,7 +14,7 @@ describe SendTransactionalSms, type: :service do
       allow(SibApiV3Sdk::TransactionalSMSApi).to receive(:new).and_return(sib_api_mock)
       allow(SibApiV3Sdk::SendTransacSms).to receive(:new)
         .with(
-          sender: "RdvRSA",
+          sender: sender_name,
           recipient: phone_number,
           content: content,
           type: "transactional"


### PR DESCRIPTION
Dans cette PR, j'ajoute un argument `sender_name` au call de `SendTransactionalSms` afin de personnaliser l'émetteur en fonction du CD.
Le texte du SMS a également été amendé pour respecter les changements vus avec la Drôme.