### PR TITLE
fix(applicant): do not store parsed phone numbers

### DIFF
--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -3,15 +3,16 @@ module HasPhoneNumberConcern
 
   included do
     validate :validate_phone_number
-    before_save :format_phone_number
   end
+
+  def phone_number_formatted
+    Phonelib.parse(phone_number).e164
+  end
+
+  private
 
   def validate_phone_number
     errors.add(:phone_number, :invalid) if phone_number.present? && !phone_number_is_valid?
-  end
-
-  def format_phone_number
-    self.phone_number = phone_number_is_valid? ? Phonelib.parse(phone_number).e164 : nil
   end
 
   def phone_number_is_valid?

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -19,14 +19,14 @@ module Invitations
     end
 
     def check_phone_number!
-      fail!("le téléphone doit être renseigné") if phone_number.blank?
+      fail!("le téléphone doit être renseigné") if applicant.phone_number.blank?
     end
 
     def send_sms
       Rails.logger.info(content)
       return unless Rails.env.production?
 
-      SendTransactionalSms.call(phone_number: phone_number, content: content)
+      SendTransactionalSms.call(phone_number_formatted: phone_number_formatted, content: content)
     end
 
     def content
@@ -42,8 +42,8 @@ module Invitations
       @invitation.organisation
     end
 
-    def phone_number
-      applicant.phone_number
+    def phone_number_formatted
+      applicant.phone_number_formatted
     end
 
     def applicant

--- a/app/services/notifications/notify_applicant.rb
+++ b/app/services/notifications/notify_applicant.rb
@@ -9,7 +9,7 @@ module Notifications
     end
 
     def call
-      return if phone_number.blank?
+      return if @applicant.phone_number.blank?
 
       check_applicant_organisation!
       notify_applicant!
@@ -38,8 +38,8 @@ module Notifications
       fail!
     end
 
-    def phone_number
-      @applicant.phone_number
+    def phone_number_formatted
+      @applicant.phone_number_formatted
     end
 
     def send_sms!
@@ -51,7 +51,7 @@ module Notifications
     end
 
     def send_sms
-      @send_sms ||= SendTransactionalSms.call(phone_number: phone_number, content: content)
+      @send_sms ||= SendTransactionalSms.call(phone_number_formatted: phone_number_formatted, content: content)
     end
 
     def notification

--- a/app/services/send_transactional_sms.rb
+++ b/app/services/send_transactional_sms.rb
@@ -1,8 +1,8 @@
 class SendTransactionalSms < BaseService
   SENDER_NAME = "RdvRSA".freeze
 
-  def initialize(phone_number:, content:)
-    @phone_number = phone_number
+  def initialize(phone_number_formatted:, content:)
+    @phone_number_formatted = phone_number_formatted
     @content = content
   end
 
@@ -20,7 +20,7 @@ class SendTransactionalSms < BaseService
       e,
       extra: {
         response_body: e.response_body,
-        phone_number: @phone_number,
+        phone_number: @phone_number_formatted,
         content: formatted_content
       }
     )
@@ -30,7 +30,7 @@ class SendTransactionalSms < BaseService
   def transactional_sms
     SibApiV3Sdk::SendTransacSms.new(
       sender: SENDER_NAME,
-      recipient: @phone_number,
+      recipient: @phone_number_formatted,
       content: formatted_content,
       type: "transactional"
     )

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -5,7 +5,8 @@ describe Invitations::SendSms, type: :service do
     )
   end
 
-  let!(:phone_number) { "+33782605941" }
+  let!(:phone_number) { "0782605941" }
+  let!(:phone_number_formatted) { "+33782605941" }
   let!(:applicant) do
     create(
       :applicant,
@@ -55,7 +56,7 @@ describe Invitations::SendSms, type: :service do
 
     it "calls the send transactional service" do
       expect(SendTransactionalSms).to receive(:call)
-        .with(phone_number: phone_number, content: content)
+        .with(phone_number_formatted: phone_number_formatted, content: content)
       subject
     end
 

--- a/spec/services/notifications/notify_applicant_spec.rb
+++ b/spec/services/notifications/notify_applicant_spec.rb
@@ -11,7 +11,8 @@ describe Notifications::NotifyApplicant, type: :service do
     )
   end
 
-  let!(:phone_number) { "+33782605941" }
+  let!(:phone_number) { "0782605941" }
+  let!(:phone_number_formatted) { "+33782605941" }
   let!(:rdv_solidarites_rdv) do
     OpenStruct.new(id: rdv_solidarites_rdv_id)
   end
@@ -53,7 +54,7 @@ describe Notifications::NotifyApplicant, type: :service do
 
     it "sends the sms" do
       expect(SendTransactionalSms).to receive(:call)
-        .with(phone_number: phone_number, content: "test")
+        .with(phone_number_formatted: phone_number_formatted, content: "test")
       subject
     end
 

--- a/spec/services/notifications/rdv_cancelled_spec.rb
+++ b/spec/services/notifications/rdv_cancelled_spec.rb
@@ -6,7 +6,8 @@ describe Notifications::RdvCancelled, type: :service do
     )
   end
 
-  let!(:phone_number) { "+33782605941" }
+  let!(:phone_number_formatted) { "+33782605941" }
+  let!(:phone_number) { "0782605941" }
   let!(:applicant) do
     create(
       :applicant,
@@ -50,7 +51,7 @@ describe Notifications::RdvCancelled, type: :service do
 
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
-          .with(phone_number: phone_number, content: content)
+          .with(phone_number_formatted: phone_number_formatted, content: content)
         subject
       end
     end

--- a/spec/services/notifications/rdv_created_spec.rb
+++ b/spec/services/notifications/rdv_created_spec.rb
@@ -5,7 +5,8 @@ describe Notifications::RdvCreated, type: :service do
     )
   end
 
-  let!(:phone_number) { "+33782605941" }
+  let!(:phone_number) { "0782605941" }
+  let!(:phone_number_formatted) { "+33782605941" }
   let!(:applicant) do
     create(
       :applicant,
@@ -62,7 +63,7 @@ describe Notifications::RdvCreated, type: :service do
 
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
-          .with(phone_number: phone_number, content: content)
+          .with(phone_number_formatted: phone_number_formatted, content: content)
         subject
       end
     end
@@ -81,7 +82,7 @@ describe Notifications::RdvCreated, type: :service do
 
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
-          .with(phone_number: phone_number, content: content)
+          .with(phone_number_formatted: phone_number_formatted, content: content)
         subject
       end
     end

--- a/spec/services/send_transactional_sms_spec.rb
+++ b/spec/services/send_transactional_sms_spec.rb
@@ -1,9 +1,9 @@
 describe SendTransactionalSms, type: :service do
   subject do
-    described_class.call(phone_number: phone_number, content: content)
+    described_class.call(phone_number_formatted: phone_number_formatted, content: content)
   end
 
-  let(:phone_number) { "+33648498119" }
+  let(:phone_number_formatted) { "+33648498119" }
   let(:content) { "Bienvenue sur RDV-Solidarités" }
   let(:sib_api_mock) { instance_double(SibApiV3Sdk::TransactionalSMSApi) }
   let(:send_transac_mock) { instance_double(SibApiV3Sdk::SendTransacSms) }
@@ -14,7 +14,7 @@ describe SendTransactionalSms, type: :service do
       allow(SibApiV3Sdk::SendTransacSms).to receive(:new)
         .with(
           sender: "RdvRSA",
-          recipient: phone_number,
+          recipient: phone_number_formatted,
           content: content,
           type: "transactional"
         )


### PR DESCRIPTION
Cette PR a pour effet de ne plus formater le numéro de téléphone avant de le stocker en DB, mais seulement au moment d'envoyer un SMS.
La motivation derrière ce changement est qu'avec [la méthode de validation actuelle](https://github.com/betagouv/rdv-insertion/blob/dd8abe10409b044e7cac545fc71d280be7414554/app/models/concerns/has_phone_number_concern.rb#L17), il arrive qu'un numéro de téléphone non parsé soit valide alors que ce même numéro parsé ne l'est pas, ce qui pose problème.
De plus, cela est plus homogène avec ce qui se fait sur RDV-S (`phone_number` <=> `phone_number`). 