### PR TITLE
feat(applicants): add allocation_starting_date

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,7 +1,7 @@
 class ApplicantsController < ApplicationController
   PERMITTED_PARAMS = [
     :uid, :role, :first_name, :last_name, :birth_date, :email, :phone_number,
-    :birth_name, :address, :affiliation_number, :custom_id, :title, :status
+    :birth_name, :address, :affiliation_number, :custom_id, :title, :status, :allocation_starting_date
   ].freeze
   before_action :set_organisation, only: [:index, :create, :show, :search, :update, :edit, :new]
   before_action :retrieve_applicants, only: [:search]

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,7 +1,7 @@
 class ApplicantsController < ApplicationController
   PERMITTED_PARAMS = [
     :uid, :role, :first_name, :last_name, :birth_date, :email, :phone_number,
-    :birth_name, :address, :affiliation_number, :custom_id, :title, :status, :allocation_starting_date
+    :birth_name, :address, :affiliation_number, :custom_id, :title, :status, :rights_opening_date
   ].freeze
   before_action :set_organisation, only: [:index, :create, :show, :update, :edit, :new]
   before_action :retrieve_applicants, only: [:search]

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -43,6 +43,7 @@ export default function Applicant({ applicant, dispatchApplicants, organisation 
       {applicant.shouldDisplay("email") && <td>{applicant.email ?? " - "}</td>}
       {applicant.shouldDisplay("phone_number") && <td>{applicant.phoneNumber ?? " - "}</td>}
       {applicant.shouldDisplay("custom_id") && <td>{applicant.customId ?? " - "}</td>}
+      {applicant.shouldDisplay("allocation_starting_date") && <td>{applicant.allocationStartingDate ?? " - "}</td>}
       <td>
         {applicant.createdAt ? (
           <i className="fas fa-check green-check" />

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -59,7 +59,7 @@ export default function Applicant({ applicant, dispatchApplicants }) {
       {applicant.shouldDisplay("email") && <td>{applicant.email ?? " - "}</td>}
       {applicant.shouldDisplay("phone_number") && <td>{applicant.phoneNumber ?? " - "}</td>}
       {applicant.shouldDisplay("custom_id") && <td>{applicant.customId ?? " - "}</td>}
-      {applicant.shouldDisplay("allocation_starting_date") && <td>{applicant.allocationStartingDate ?? " - "}</td>}
+      {applicant.shouldDisplay("rights_opening_date") && <td>{applicant.rightsOpeningDate ?? " - "}</td>}
       <td>
         {applicant.createdAt ? (
           <i className="fas fa-check green-check" />

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -30,6 +30,7 @@ export default class Applicant {
     this.postalCode = formattedAttributes.postalCode;
     this.fullAddress = formattedAttributes.fullAddress || this.formatAddress();
     this.customId = formattedAttributes.customId;
+    this.allocationStartingDate = formattedAttributes.allocationStartingDate;
     this.affiliationNumber = this.formatAffiliationNumber(formattedAttributes.affiliationNumber);
     this.phoneNumber = formatPhoneNumber(formattedAttributes.phoneNumber);
     // CONJOINT/CONCUBIN/PACSE => conjoint
@@ -162,6 +163,7 @@ export default class Applicant {
       ...(this.birthDate && { birth_date: this.birthDate }),
       ...(this.birthName && { birth_name: this.birthName }),
       ...(this.customId && { custom_id: this.customId }),
+      ...(this.allocationStartingDate && { allocation_starting_date: this.allocationStartingDate }),
     };
   }
 }

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -30,7 +30,7 @@ export default class Applicant {
     this.postalCode = formattedAttributes.postalCode;
     this.fullAddress = formattedAttributes.fullAddress || this.formatAddress();
     this.customId = formattedAttributes.customId;
-    this.allocationStartingDate = formattedAttributes.allocationStartingDate;
+    this.rightsOpeningDate = formattedAttributes.rightsOpeningDate;
     this.affiliationNumber = this.formatAffiliationNumber(formattedAttributes.affiliationNumber);
     this.phoneNumber = formatPhoneNumber(formattedAttributes.phoneNumber);
     // CONJOINT/CONCUBIN/PACSE => conjoint
@@ -169,7 +169,7 @@ export default class Applicant {
       ...(this.birthDate && { birth_date: this.birthDate }),
       ...(this.birthName && { birth_name: this.birthName }),
       ...(this.customId && { custom_id: this.customId }),
-      ...(this.allocationStartingDate && { allocation_starting_date: this.allocationStartingDate }),
+      ...(this.rightsOpeningDate && { rights_opening_date: this.rightsOpeningDate }),
     };
   }
 }

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -93,6 +93,8 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                   && row[parameterizedColumnNames.birth_name],
                 customId: parameterizedColumnNames.custom_id
                   && row[parameterizedColumnNames.custom_id],
+                allocationStartingDate: parameterizedColumnNames.allocation_starting_date
+                  && row[parameterizedColumnNames.allocation_starting_date],
               },
               department.number,
               configuration
@@ -207,6 +209,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                     {parameterizedColumnNames.email && <th scope="col">Email</th>}
                     {parameterizedColumnNames.phone_number && <th scope="col">Téléphone</th>}
                     {parameterizedColumnNames.custom_id && <th scope="col">ID Editeur</th>}
+                    {parameterizedColumnNames.allocation_starting_date && <th scope="col">Date d&apos;entrée flux</th>}
                     <th scope="col" style={{ whiteSpace: "nowrap" }}>
                       Création compte
                     </th>

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -103,8 +103,8 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                   && row[parameterizedColumnNames.birth_name],
                 customId: parameterizedColumnNames.custom_id
                   && row[parameterizedColumnNames.custom_id],
-                allocationStartingDate: parameterizedColumnNames.allocation_starting_date
-                  && row[parameterizedColumnNames.allocation_starting_date],
+                rightsOpeningDate: parameterizedColumnNames.rights_opening_date
+                  && row[parameterizedColumnNames.rights_opening_date],
               },
               department.number,
               organisation,
@@ -230,7 +230,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                     {parameterizedColumnNames.email && <th scope="col">Email</th>}
                     {parameterizedColumnNames.phone_number && <th scope="col">Téléphone</th>}
                     {parameterizedColumnNames.custom_id && <th scope="col">ID Editeur</th>}
-                    {parameterizedColumnNames.allocation_starting_date && <th scope="col">Date d&apos;entrée flux</th>}
+                    {parameterizedColumnNames.rights_opening_date && <th scope="col">Date d&apos;entrée flux</th>}
                     <th scope="col" style={{ whiteSpace: "nowrap" }}>
                       Création compte
                     </th>

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -80,7 +80,7 @@ class Applicant < ApplicationRecord
   def orientation_delay_in_days
     return unless oriented?
 
-    starting_date = created_at - 3.days
+    starting_date = allocation_starting_date || created_at - 3.days
     orientation_date.to_datetime.mjd - starting_date.to_datetime.mjd
   end
 

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -80,7 +80,7 @@ class Applicant < ApplicationRecord
   def orientation_delay_in_days
     return unless oriented?
 
-    starting_date = allocation_starting_date || created_at - 3.days
+    starting_date = rights_opening_date || (created_at - 3.days)
     orientation_date.to_datetime.mjd - starting_date.to_datetime.mjd
   end
 

--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -11,20 +11,27 @@
   <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Civilité*</h4>
-        <p><%= f.input :title, as: :select, collection: ["monsieur", "madame"] %></p>
-      </div>
-      <div class="col-10 col-md-5">
-      </div>
-    </div>
-    <div class="row d-flex justify-content-around flex-wrap">
-      <div class="col-10 col-md-5">
         <h4 class="attribute-title">Nom</h4>
         <p><%= f.input :last_name %></p>
       </div>
       <div class="col-10 col-md-5">
         <h4 class="attribute-title">Prénom</h4>
         <p><%= f.input :first_name %></p>
+      </div>
+    </div>
+    <div class="row d-flex justify-content-around flex-wrap">
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Civilité*</h4>
+        <p><%= f.input :title, as: :select, collection: ["monsieur", "madame"] %></p>
+      </div>
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Date d'entrée flux</h4>
+        <p><%= f.input :allocation_starting_date,
+                        input_html: { class: "date-select" },
+                        as: :date, start_year: Date.today.year - 100,
+                        end_year: Date.today.year,
+                        include_blank: true,
+                        order: [:day, :month, :year] %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">

--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -26,9 +26,9 @@
       </div>
       <div class="col-10 col-md-5">
         <h4 class="attribute-title">Date d'entrée flux</h4>
-        <p><%= f.input :allocation_starting_date,
+        <p><%= f.input :rights_opening_date,
                         input_html: { class: "date-select" },
-                        as: :date, start_year: Date.today.year - 100,
+                        as: :date, start_year: Date.today.year - 10,
                         end_year: Date.today.year,
                         include_blank: true,
                         order: [:day, :month, :year] %></p>

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -32,6 +32,16 @@
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Civilité</h4>
+        <p><%= display_attribute @applicant.title %></p>
+      </div>
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Date d'entrée flux</h4>
+        <p><%= display_attribute format_date(@applicant.allocation_starting_date) %></p>
+      </div>
+    </div>
+    <div class="row d-flex justify-content-around flex-wrap">
+      <div class="col-10 col-md-5">
         <h4 class="attribute-title">Numéro allocataire</h4>
         <p><%= display_attribute @applicant.affiliation_number %></p>
       </div>

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -37,7 +37,7 @@
       </div>
       <div class="col-10 col-md-5">
         <h4 class="attribute-title">Date d'entrée flux</h4>
-        <p><%= display_attribute format_date(@applicant.allocation_starting_date) %></p>
+        <p><%= display_attribute format_date(@applicant.rights_opening_date) %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">

--- a/db/migrate/20211214113405_add_allocation_starting_date_to_applicants.rb
+++ b/db/migrate/20211214113405_add_allocation_starting_date_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddAllocationStartingDateToApplicants < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applicants, :allocation_starting_date, :date
+  end
+end

--- a/db/migrate/20211214113405_add_allocation_starting_date_to_applicants.rb
+++ b/db/migrate/20211214113405_add_allocation_starting_date_to_applicants.rb
@@ -1,5 +1,0 @@
-class AddAllocationStartingDateToApplicants < ActiveRecord::Migration[6.1]
-  def change
-    add_column :applicants, :allocation_starting_date, :date
-  end
-end

--- a/db/migrate/20211214113405_add_rights_opening_date_to_applicants.rb
+++ b/db/migrate/20211214113405_add_rights_opening_date_to_applicants.rb
@@ -1,0 +1,5 @@
+class AddRightsOpeningDateToApplicants < ActiveRecord::Migration[6.1]
+  def change
+    add_column :applicants, :rights_opening_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_111858) do
+ActiveRecord::Schema.define(version: 2021_12_14_113405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_111858) do
     t.date "birth_date"
     t.date "invitation_accepted_at"
     t.integer "status", default: 0
+    t.date "allocation_starting_date"
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true
     t.index ["status"], name: "index_applicants_on_status"
     t.index ["uid"], name: "index_applicants_on_uid", unique: true
@@ -80,6 +81,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_111858) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "region"
+    t.string "pronoun"
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_113405) do
     t.date "birth_date"
     t.date "invitation_accepted_at"
     t.integer "status", default: 0
-    t.date "allocation_starting_date"
+    t.date "rights_opening_date"
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true
     t.index ["status"], name: "index_applicants_on_status"
     t.index ["uid"], name: "index_applicants_on_uid", unique: true
@@ -81,7 +81,6 @@ ActiveRecord::Schema.define(version: 2021_12_14_113405) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "region"
-    t.string "pronoun"
   end
 
   create_table "invitations", force: :cascade do |t|


### PR DESCRIPTION
Dans cette PR, j'ajoute l'attribut `allocation_starting_date` à la table `applicants`, qui correspond à la date d'ouverture des droits ou à la date d'entrée dans le flux des allocataires. Cette date est récupérée dans le fichier à l'upload, puis utilisée pour calculer le délai d'orientation. Elle a également été ajoutée aux pages show et edit.
Le nom affiché est "Date d'entré flux" (vu avec Claire).