### PR TITLE
feat(front): new footer + legal pages

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_agent!, only: [:welcome]
+  skip_before_action :authenticate_agent!, only: [:welcome, :legal_notice, :privacy_policy, :accessibility]
 
   def welcome
     redirect_to(organisations_path) if logged_in?
@@ -13,4 +13,10 @@ class StaticPagesController < ApplicationController
     @stats = Stat.new(applicants: @applicants, agents: @agents, invitations: @invitations,
                       rdvs: @rdvs, organisations: @organisations)
   end
+
+  def legal_notice; end
+
+  def privacy_policy; end
+
+  def accessibility; end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -22,11 +22,6 @@ html {
   min-height: 100%;
 }
 
-.container,
-.container-fluid {
-  margin-bottom: 85px;
-}
-
 a {
   text-decoration: none;
   color: black;
@@ -37,4 +32,11 @@ a {
 
 body {
   background-color: $light;
+  display:flex;
+  flex-direction:column;
+  min-height:100vh;
+}
+
+.wrapper {
+  flex:1
 }

--- a/app/javascript/stylesheets/components/_footer.scss
+++ b/app/javascript/stylesheets/components/_footer.scss
@@ -1,39 +1,85 @@
-.footer {
-  box-shadow: 0 1px 5px 0 rgba(0,0,0,0.07),0 1px 0 0 rgba(0,0,0,0.03);
-  background: white;
-  // transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  height: 85px;
-  padding: 0px 50px;
+footer {
+  background-color: white;
   width: 100%;
-  flex-shrink: 0;
-  position: absolute;
-  bottom: 0;
+  padding-top: 1.8rem;
+  border-top: 1px solid #d4d4d4;
 }
 
-.footer-links {
+footer * {
+  list-style-type: none;
+}
+
+.footer-top {
   display: flex;
+  justify-content: space-between;
   align-items: center;
+  list-style-type: none;
+  font-size: 0.9rem;
+  flex-wrap: wrap;
+}
 
-  a {
-    color: black;
-    text-decoration: none;
-    font-size: 20px;
-    padding: 0px 10px;
+.footer-top-list {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  li {
+    padding-top: 0.3rem;
+    &:first-child {
+      margin-top: 0.2rem;
+    }
   }
 }
 
-.nav-link {
-  color: black !important;
-  &:hover {
-    color: black !important;
+.footer-bottom {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  border-top: 1px solid #d4d4d4;
+  font-size: 0.8rem;
+}
+
+.footer-bottom * {
+  color: #818181;
+}
+
+.footer-bottom-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: .5rem 0 .7rem;
+  width: 100%;
+  margin: 0;
+}
+
+.footer-bottom-list-item {
+  display: flex;
+  position: relative;
+  margin: .5rem 0 0 1rem;
+  display: inline;
+  &:first-child {
+    margin: .5rem 0 .3rem 0;
+  }
+  &:not(:first-child)::before {
+    margin-right: .75rem;
+    margin-bottom: .25rem;
+    margin-top: .25rem;
+    background-color: #d4d4d4;
+    display: inline-block;
+    content: "";
+    vertical-align: middle;
+    position: relative;
+    width: 1px;
+    height: 1rem;
   }
 }
 
-@media (max-width: 700px) {
-  .optional-link {
-    display: none;
+@media (max-width: 770px) {
+  .footer-top {
+    justify-content: center;
+  }
+  .footer-top-links {
+    margin-top: 40px;
   }
 }

--- a/app/javascript/stylesheets/components/_image.scss
+++ b/app/javascript/stylesheets/components/_image.scss
@@ -10,6 +10,10 @@
   padding-left: 20px;
 }
 
+.footer-france-logo {
+  width: 160px;
+}
+
 @media (max-width: 400px) {
   .rdvi-logo{
     width: 150px;

--- a/app/javascript/stylesheets/components/_navbar.scss
+++ b/app/javascript/stylesheets/components/_navbar.scss
@@ -1,11 +1,14 @@
+header {
+  background-color: white;
+  box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.07),0 1px 0 0 rgba(0, 0, 0,0.03);
+}
+
 .navbar {
   transition: all 0.3s ease;
   height: 70px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.07),0 1px 0 0 rgba(0, 0, 0,0.03);
-  background-color: white;
 }
 
 .navbar-france-logo {
@@ -17,12 +20,11 @@
   display: flex;
   align-items: center;
   justify-content: left;
-  background-color: white;
   border-top: 1px solid $dark-grey;
-  box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.07),0 1px 0 0 rgba(0, 0, 0,0.03);
   position: relative;
   z-index: 2;
   p, a {
     font-size: 12px;
+    color: black;
   }
 }

--- a/app/javascript/stylesheets/components/_title.scss
+++ b/app/javascript/stylesheets/components/_title.scss
@@ -28,6 +28,13 @@
   }
 }
 
+.legal-notice {
+  h1, h2 {
+    font-weight: 600;
+    margin-top: 25px;
+  }
+}
+
 @media (max-width: 500px) {
   .welcome-title {
     h1 {

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container mt-5">
+<div class="container mt-5 mb-5">
   <div class="row mb-4 block-white justify-content-center">
     <div class="col-4 justify-content-center">
       <div class="mb-1">

--- a/app/views/common/_footer.html.erb
+++ b/app/views/common/_footer.html.erb
@@ -1,14 +1,58 @@
-<div class="footer navbar-static-bottom">
-  <div class="footer-links">
-    <%= link_to "https://beta.gouv.fr/", class: "mr-2", target: "_blank", rel: "noopener noreferrer" do %>
-      <%= image_pack_tag "logos/betagouv-disque.png", height: 50, alt: "Beta gouv" %>
-    <% end %>
+<footer class="marianne">
+  <div class="container">
+    <div class="footer-top row">
+      <div class="col-8 col-md-4">
+        <%= image_pack_tag "logos/republique-francaise-logo.svg", alt: "Logo République francaise", class: "footer-france-logo" %>
+      </div>
+      <div class="footer-top-links d-flex col-8 col-md-7 col-lg-5 col-xl-4 justify-content-between flex-wrap">
+        <div>
+          <h4>Ressources</h4>
+          <ul class="footer-top-list">
+            <li>
+              <%= link_to "Guide d'utilisation", "https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/", target: :blank %>
+            </li>
+            <li>
+              <%= link_to "Statistiques", stats_path %>
+            </li>
+            <li>
+              <%= link_to "Lecteur flux CNAF", "https://betagouv.github.io/analyse-flux-insertion/", target: :blank %>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h4>Nos partenaires</h4>
+          <ul class="footer-top-list">
+            <li>
+              <%= link_to "RDV-Solidarités", "https://www.rdv-solidarites.fr/", target: :blank %>
+            </li>
+            <li>
+              <%= link_to "CNAF", "https://www.caf.fr/", target: :blank %>
+            </li>
+            <li>
+              <%= link_to "Pôle emploi", "https://www.pole-emploi.fr/accueil/", target: :blank %>
+            </li>
+            <li>
+              <%= link_to "MSA", "https://www.msa.fr/lfp", target: :blank %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <ul class="footer-bottom-list">
+        <li class="footer-bottom-list-item">
+          <%= link_to 'Mentions légales', mentions_legales_path %>
+        </li>
+        <li class="footer-bottom-list-item">
+          <%= link_to 'Politique de confidentialité', politique_de_confidentialite_path %>
+        </li>
+        <li class="footer-bottom-list-item">
+          <%= link_to "Accessibilité: non conforme", accessibilite_path %>
+        </li>
+      </ul>
+      <div>
+        <p>Sauf mention contraire, tous les textes de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank">licence etalab-2.0</a></p>
+      </div>
+    </div>
   </div>
-  <div class="nav">
-    <%= link_to "Guide d'utilisation", "https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/", class: "nav-link optional-link", target: "_blank", rel: "noopener noreferrer" %>
-    <%= link_to "Statistiques", stats_path, class: "nav-link optional-link" %>
-    <%= link_to "RDV-Solidarités", "https://www.rdv-solidarites.fr/", class: "nav-link optional-link", target: "_blank", rel: "noopener noreferrer" %>
-    <%= link_to "Lecteur Flux CNAF", "https://betagouv.github.io/analyse-flux-insertion/", class: "nav-link optional-link", target: "_blank", rel: "noopener noreferrer" %>
-    <%= link_to "Contacter data.insertion", "mailto:data.insertion@beta.gouv.fr", class: "nav-link" %>
-  </div>
-</div>
+</footer>

--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav class="navbar px-3 navbar-expand-lg">
+  <nav class="container marianne navbar px-3 navbar-expand-lg">
     <div class="d-flex justify-content-start">
       <%= link_to root_path do %>
         <%= image_pack_tag "logos/republique-francaise-logo.svg", height: 50, alt: "République francaise", class: "d-none d-sm-inline navbar-france-logo" %>
@@ -33,13 +33,15 @@
   </nav>
   <% unless logged_in? || controller.controller_name.include?("sessions") %>
     <div class="sub-header d-none d-md-flex marianne">
-      <%= link_to "https://communaute.inclusion.beta.gouv.fr/", class: "nav-link optional-link ", target: :blank, rel: "noopener noreferrer" do %>
-        <p class="mb-0">Communauté de l'inclusion&nbsp;<i class="fas fa-external-link-alt"></i></p>
-      <% end %>
-      <%= link_to "https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/", target: :blank, class: "nav-link optional-link" do %>
-        <p class="mb-0">Guide d'utilisation&nbsp;<i class="fas fa-external-link-alt"></i></p>
-      <% end %>
-      <%= link_to "Contacter l'équipe", "mailto:data.insertion@beta.gouv.fr", class: "nav-link optional-link" %>
+      <div class="container d-none d-md-flex ">
+        <%= link_to "https://communaute.inclusion.beta.gouv.fr/", class: "nav-link optional-link ", target: :blank, rel: "noopener noreferrer" do %>
+          <p class="mb-0">Communauté de l'inclusion&nbsp;<i class="fas fa-external-link-alt"></i></p>
+        <% end %>
+        <%= link_to "https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/", target: :blank, class: "nav-link optional-link" do %>
+          <p class="mb-0">Guide d'utilisation&nbsp;<i class="fas fa-external-link-alt"></i></p>
+        <% end %>
+        <%= link_to "Contacter l'équipe", "mailto:data.insertion@beta.gouv.fr", class: "nav-link optional-link" %>
+      </div>
     </div>
   <% end %>
 </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,9 @@
   <body>
     <%= render 'common/header' %>
     <%= render 'common/flash' %>
-    <%= yield %>
+    <div class="wrapper">
+      <%= yield %>
+    </div>
     <%= render 'common/footer' %>
   </body>
 </html>

--- a/app/views/static_pages/accessibility.html.erb
+++ b/app/views/static_pages/accessibility.html.erb
@@ -1,0 +1,29 @@
+<div class="container legal-notice mb-4">
+  <div class="row d-flex justify-content-center mt-2">
+    <div class="col-10">
+      <h1>Accessibilité</h1>
+
+      <h2>Déclaration d'accessibilité</h2>
+      <p>La conformité aux normes d’accessibilité numérique est un objectif ultérieur mais nous tâchons de rendre ce site accessible à toutes et à tous. Pour en savoir plus sur la politique d’accessibilité numérique de l’État : <a href="http://references.modernisation.gouv.fr/accessibilite-numerique" target="_blank" class="text-decoration-underline">http://references.modernisation.gouv.fr/accessibilite-numerique</a></p>
+
+      <h2>État de conformité</h2>
+      <p>RDV-Insertion est non conforme avec le RGAA 4.1. Le site n’a pas encore été audité.</p>
+
+      <h2>Amélioration et contact</h2>
+      <p>Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter RDV-Insertion pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.</p>
+      <ul>
+        <li>E-mail : <a href="mailto:data.insertion@beta.gouv.fr" class="text-decoration-underline">data.insertion@beta.gouv.fr</a></li>
+        <li>Adresse : DINUM 20 avenue de Ségur 75007 Paris</li>
+      </ul>
+
+      <h2>Voie de recours</h2>
+      <p>Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.</p>
+      <p>Vous pouvez :</p>
+      <ul>
+        <li>Écrire un message au Défenseur des droits</li>
+        <li>Contacter le délégué du Défenseur des droits dans votre région</li>
+        <li>Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) : Défenseur des droits Libre réponse 71120 75342 Paris CEDEX 07</li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/legal_notice.html.erb
+++ b/app/views/static_pages/legal_notice.html.erb
@@ -1,0 +1,32 @@
+<div class="container legal-notice mb-4">
+  <div class="row d-flex justify-content-center mt-2">
+    <div class="col-10">
+      <h1>Mentions légales</h1>
+
+      <h2>Éditeur</h2>
+      <p>Ce site est édité par la direction interministérielle du numérique (DINUM), un service du Premier ministre.</p>
+      <p>DINUM<br/>
+      20 avenue de Ségur<br/>
+      75007 Paris<br/>
+      Tel. accueil : 01.71.21.01.70<br/>
+      SIRET : 12000101100010 (secrétariat général du gouvernement)<br/>
+      SIREN : 120 001 011</p>
+
+      <h2>Code source</h2>
+      <p>Le code source est disponible à cette adresse : <a href="https://github.com/betagouv/rdv-insertion" target="_blank" class="text-decoration-underline">https://github.com/betagouv/rdv-insertion</a>
+      </p>
+
+      <h2>Directeur de la publication</h2>
+      <p>Nadi Bou Hanna, Directeur interministériel du numérique.</p>
+
+      <h2>Hébergement</h2>
+      <p>Ce site est hébergé par :</p>
+      <p>Outscale SASU<br/>
+      1 rue Royale - 319 Bureaux de la Colline<br/>
+      92210 Saint-Cloud</p>
+
+      <h2>Sécurité</h2>
+      <p>Le site est protégé par un certificat électronique, matérialisé pour la grande majorité des navigateurs par un cadenas. Cette protection participe à la confidentialité des échanges. En aucun cas les services associés à la plateforme ne seront à l’origine d’envoi de courriels pour demander la saisie d’informations personnelles.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,121 @@
+<div class="container legal-notice mb-4">
+  <div class="row d-flex justify-content-center mt-2">
+    <div class="col-10">
+      <h1>Politique de confidentialité</h1>
+
+      <h2>Traitement des données à caractère personnel</h2>
+      <p>La plateforme dénommée « RDV-insertion » constitue un outil de prise de rendez-vous pour les usagers des services d’insertion des départements. C’est un outil à l’ambition simple – permettre à l’usager de prendre rendez-vous en ligne avec son département – mais à l’impact majeur. La plateforme vise à organiser et fluidifier le rendez-vous d’orientation pour les nouveaux bénéficiaires du RSA. Cela permettra d’accélérer l’entrée en parcours d’insertion des bénéficiaires.</p>
+      <p>RDV-insertion se situe au croisement des plateformes de data.insertion et RDV-solidarités, afin d’en faciliter l’usage. Elle est financée par le Service public de l’insertion et de l’emploi (SPIE) et dans la construction actuelle les acteurs principaux sont les départements, qui sont les responsables de traitement.</p>
+
+      <h2>Finalité</h2>
+      <p>De manière concrète, la plateforme a pour finalités&nbsp;:</p>
+      <ul>
+        <li>D’accélérer l’entrée dans le parcours d’insertion des bénéficiaires du RSA</li>
+        <li>De limiter l’absentéisme des bénéficiaires du RSA à leur rendez-vous d’orientation</li>
+        <li>Faciliter l’usage de rdv-solidarités par les acteurs utilisant data-insertion</li>
+      </ul>
+
+      <h2>Données à caractère personnel traitées</h2>
+      <p>Dans le cadre de l'utilisation de la plateforme RDV-insertion, les données suivantes sont traitées&nbsp;:</p>
+      <ul>
+        <li><strong>Données relatives au compte agent :</strong> e-mail</li>
+        <li><strong>Données relatives à la fiche "Nouvel entrant" :</strong> civilité, nom, prénom, de manière obligatoire, nom de naissance, date de naissance, adresse e-mail, numéro de téléphone, adresse, numéro d'allocataire, rôle, date d’ouverture des droits</li>
+        <li><strong>Données relatives aux rendez-vous :</strong> lieu, horaire, date, informations relatives à la présence ou absence de la personne concernée</li>
+        <li><strong>Données de localisation :</strong> adresse</li>
+        <li><strong>Données d'hébergeur :</strong> identifiant de connexion , nature des opérations</li>
+        <li><strong>Cookies</strong></li>
+      </ul>
+
+      <p>Les données traitées à l’occasion de ce traitement ont plusieurs fondements juridiques&nbsp;:</p>
+      <ul>
+        <li>l’obligation légale à laquelle est soumis le responsable de traitements au sens de l’article 6-c du RGPD</li>
+        <li>la mission d’intérêt public à laquelle le responsable du traitement est soumis au sens de l’article 6-e du RGPD</li>
+      </ul>
+
+      <p>Ces fondements sont précisés ci-dessous&nbsp;:</p>
+      <ol>
+        <li>Les données relatives au compte agent </li>
+        <p>Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.</p>
+        <li>Les données relatives à la fiche "Nouvel entrant"</li>
+        <p>Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.</p>
+        <li>Les données relatives aux rendez-vous</li>
+        <p>Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.</p>
+        <li>Les données de localisation</li>
+        <p>Ce traitement de données est nécessaire à l’exercice d’une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable de traitement au sens de l’article 6-e du règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l’égard du traitement des données à caractère personnel et à la libre circulation de ces données.</p>
+        <li>Les données d'hébergeur</li>
+        <p>Ce traitement de données est nécessaire au respect d'une obligation légale à laquelle le responsable de traitement est soumis au sens de l'article 6-c du Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel et à la libre circulation de ces données.</p>
+        <p>L'obligation légale est posée par la loi LCEN n° 2004-575 du 21 juin 2004 pour la confiance dans l'économie numérique et par les articles 1 et 3 du décret n°2021-1363 du 20 octobre 2021.</p>
+        <li>Cookies</li>
+        <p>En application de l’article 5(3) de la directive 2002/58/CE modifiée concernant le traitement des données à caractère personnel et la protection de la vie privée dans le secteur des communications électroniques, transposée à l’article 82 de la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les traceurs ou cookies suivent deux régimes distincts.</p>
+        <p>Les cookies strictement nécessaires au service ou ayant pour finalité exclusive de faciliter la communication par voie électronique sont dispensés de consentement préalable au titre de l’article 82 de la loi n°78-17 du 6 janvier 1978.</p>
+        <p>Les cookies n’étant pas strictement nécessaires au service ou n’ayant pas pour finalité exclusive de faciliter la communication par voie électronique doivent être consenti par l’utilisateur.</p>
+        <p>Ce consentement de la personne concernée pour une ou plusieurs finalités spécifiques constitue une base légale au sens du RGPD et doit être entendu au sens de l'article 6-a du Règlement (UE) 2016/679 du Parlement européen et du Conseil du 27 avril 2016 relatif à la protection des personnes physiques à l'égard du traitement des données à caractère personnel et à la libre circulation de ces données.</p>
+      </ol>
+
+      <h2>Durée de conservation</h2>
+      <p>Les données à caractère personnel sont conservées&nbsp;:</p>
+      <ul>
+        <li>Données relatives au compte agent, à la fiche "Nouvel entrant" et aux rendez-vous&nbsp;: Les données sont conservées jusqu'à la suppression du compte, ou 2 ans après l’inactivité du compte.</li>
+        <li>Données de localisation&nbsp;: Les données sont supprimées à compter de la prise de rendez-vous, elles permettent de proposer des lieux de rendez-vous proches de la personne.</li>
+        <li>Données de connexion conservées par l'hébergeur&nbsp;: Ces données sont conservées 12 mois, en application de la loi pour la confiance dans l’économie numérique n°2004-575 du 21 juin 2004 et de l’article 3 du décret n°2021-1363 du 20 octobre 2021.</li>
+        <li>Cookies&nbsp;: Ces données sont conservées 13 mois maximum.</li>
+      </ul>
+
+      <h2>Droit des personnes concernées</h2>
+      <p>Vous disposez des droits suivants concernant vos données à caractère personnel&nbsp;:</p>
+      <ul>
+        <li>Droit d’information</li>
+        <li>Droit d’accès aux données</li>
+        <li>Droit de rectiﬁcation</li>
+        <li>Droit de suppression des données</li>
+      </ul>
+      <p>Pour les exercer, faites-nous parvenir une demande en précisant la date et l’heure précise de la requête - ces éléments sont indispensables pour nous permettre de retrouver votre recherche - par voie électronique à l’adresse suivante&nbsp;: <a href="mailto:data.insertion@beta.gouv.fr" class="text-decoration-underline">data.insertion@beta.gouv.fr</a></p>
+      <p>En raison de l’obligation de sécurité et de conﬁdentialité dans le traitement des données à caractère personnel qui incombe au responsable de traitement, votre demande ne sera traitée que si vous apportez la preuve de votre identité. Pour vous aider dans votre démarche, <a href="https://www.cnil.fr/fr/modele/courrier/exercer-son-droit-dacces" target="_blank" class="text-decoration-underline">vous trouverez ici</a> un modèle de courrier élaboré par la Cnil.</p>
+      <p>Nous nous engageons à ne jamais céder ces informations à des tiers.</p>
+
+      <h2>Délais de réponse</h2>
+      <p>Le responsable de traitement et l’équipe responsable de RDV-Insertion s’engage à répondre dans un délai raisonnable qui ne saurait dépasser 1 mois à compter de la réception de votre demande.</p>
+
+      <h2>Destinataire des données</h2>
+      <p>Le responsable de traitement s'engage à ce que les données à caractères personnels soient traitées par les seules personnes autorisées.</p>
+
+      <h2>Sous-traitants</h2>
+      <p>Certaines données sont envoyées à des sous-traitants pour réaliser certaines missions. Le responsable de traitements s'est assuré de la mise en œuvre par ses sous-traitants de garanties adéquates et du respect de conditions strictes de conﬁdentialité, d’usage et de protection des données.</p>
+      <table class="table table-responsive">
+        <thead>
+          <th>Partenaire</th>
+          <th>Traitement</th>
+          <th>Pays destinataire</th>
+          <th>Garanties</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Outscale SASU</strong></td>
+            <td>Hébergement</td>
+            <td>France</td>
+            <td><a href="https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf" target="_blank" class="text-decoration-underline">https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf</a></td>
+          </tr>
+          <tr>
+            <td><strong>SendInBlue</strong></td>
+            <td>Envoi de mails</td>
+            <td>France</td>
+            <td><a href="https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf" target="_blank" class="text-decoration-underline">https://fr.outscale.com/wp-content/uploads/2020/10/Outscale-CGV-2020-09.pdf</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Utilisation de témoins de connexion (« cookies »)</h2>
+      <p>Les cookies utilisés sur RDV-Insertion ne sont que des cookies strictement nécessaires au bon fonctionnement du site, au sens des dernières recommandations de la CNIL à ce sujet. RDV-Insertion utilise également des cookies de statistiques anonymes qui ne nécessitent pas de bandeau cookies, toujours au sens des dernières recommandations de la CNIL à ce sujet. RDV-Insertion n'utilise aucun cookies dits "tiers".</p>
+      <p>Il convient d'indiquer que&nbsp;</p>
+      <ul>
+        <li>Les données collectées ne sont pas recoupées avec d’autres traitements.</li>
+        <li>Les cookies ne permettent pas de suivre la navigation de l’internaute sur d’autres sites.</li>
+      </ul>
+      <p>À tout moment, vous pouvez refuser l’utilisation des cookies et désactiver le dépôt sur votre ordinateur en utilisant la fonction dédiée de votre navigateur (fonction disponible notamment sur Microsoft Internet Explorer 11, Google Chrome, Mozilla Firefox, Apple Safari et Opera). Pour aller plus loin, vous pouvez consulter les ﬁches proposées par la Commission Nationale de l'Informatique et des Libertés (CNIL)&nbsp;:</p>
+      <ul>
+        <li><a href="https://www.cnil.fr/fr/cookies-et-traceurs-que-dit-la-loi" target="_blank" class="text-decoration-underline">Cookies et traceurs : que dit la loi ?</a></li>
+        <li><a href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser" target="_blank" class="text-decoration-underline">Cookies : les outils pour les maîtriser</a></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ end
 
 Rails.application.routes.draw do
   root "static_pages#welcome"
+  get "mentions-legales", to: "static_pages#legal_notice"
+  get "politique-de-confidentialite", to: "static_pages#privacy_policy"
+  get "accessibilite", to: "static_pages#accessibility"
   resources :organisations, only: [:index] do
     get :geolocated, on: :collection
     resources :applicants, only: [:index, :create, :show, :update, :edit, :new] do

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -21,4 +21,25 @@ describe StaticPagesController, type: :controller do
       end
     end
   end
+
+  describe "GET #accessiblity" do
+    it "returns a success response" do
+      get :accessibility
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #privacy_policy" do
+    it "returns a success response" do
+      get :privacy_policy
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #legal_notice" do
+    it "returns a success response" do
+      get :legal_notice
+      expect(response).to be_successful
+    end
+  end
 end


### PR DESCRIPTION
Dans cette PR, redesign du footer pour respecter le design system de l'état + ajout des pages Mentions légales, Politique de confidentialité et Accessibilité.
Légere modification du header (ajout d'un container) pour suivre la logique utilisée par pas mal de suite et se caler sur le footer, mais si ça ne te plait pas on peut enlever cette modif, je ne sais pas trop si c'est mieux ou pas.