### PR TITLE
fix(upload): format rights opening date

### DIFF
--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -95,16 +95,19 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                   row[parameterizedColumnNames.birth_date] &&
                   excelDateToString(row[parameterizedColumnNames.birth_date]),
                 city: parameterizedColumnNames.city && row[parameterizedColumnNames.city],
-                postalCode: parameterizedColumnNames.postal_code
-                  && row[parameterizedColumnNames.postal_code],
-                phoneNumber: parameterizedColumnNames.phone_number
-                  && row[parameterizedColumnNames.phone_number],
-                birthName: parameterizedColumnNames.birth_name
-                  && row[parameterizedColumnNames.birth_name],
-                customId: parameterizedColumnNames.custom_id
-                  && row[parameterizedColumnNames.custom_id],
-                rightsOpeningDate: parameterizedColumnNames.rights_opening_date
-                  && row[parameterizedColumnNames.rights_opening_date],
+                postalCode:
+                  parameterizedColumnNames.postal_code && row[parameterizedColumnNames.postal_code],
+                phoneNumber:
+                  parameterizedColumnNames.phone_number &&
+                  row[parameterizedColumnNames.phone_number],
+                birthName:
+                  parameterizedColumnNames.birth_name && row[parameterizedColumnNames.birth_name],
+                customId:
+                  parameterizedColumnNames.custom_id && row[parameterizedColumnNames.custom_id],
+                rightsOpeningDate:
+                  parameterizedColumnNames.rights_opening_date &&
+                  row[parameterizedColumnNames.rights_opening_date] &&
+                  excelDateToString(row[parameterizedColumnNames.rights_opening_date]),
               },
               department.number,
               organisation,
@@ -230,7 +233,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                     {parameterizedColumnNames.email && <th scope="col">Email</th>}
                     {parameterizedColumnNames.phone_number && <th scope="col">Téléphone</th>}
                     {parameterizedColumnNames.custom_id && <th scope="col">ID Editeur</th>}
-                    {parameterizedColumnNames.rights_opening_date && <th scope="col">Date d&apos;entrée flux</th>}
+                    {parameterizedColumnNames.rights_opening_date && (
+                      <th scope="col">Date d&apos;entrée flux</th>
+                    )}
                     <th scope="col" style={{ whiteSpace: "nowrap" }}>
                       Création compte
                     </th>


### PR DESCRIPTION
La date d'entrée du flux n'était pas formatée au moment de lire le fichier excel et n'était pas affichée ni prise en compte correctement. Ce fix fait appel à la fonction `excelDateToString` au moment de récupérer la date. 