### PR TITLE
feat(webhooks): sync organisations

### DIFF
--- a/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
+++ b/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
@@ -1,7 +1,7 @@
 module FilterRdvSolidaritesWebhooksConcern
   extend ActiveSupport::Concern
 
-  SUPPORTED_MODELS_TYPES = %w[Rdv User UserProfile].freeze
+  SUPPORTED_MODELS_TYPES = %w[Rdv User UserProfile Organisation].freeze
 
   included do
     before_action :check_webhook_auth!

--- a/app/controllers/rdv_solidarites_webhooks_controller.rb
+++ b/app/controllers/rdv_solidarites_webhooks_controller.rb
@@ -15,7 +15,8 @@ class RdvSolidaritesWebhooksController < ApplicationController
     {
       "User" => RdvSolidaritesWebhooks::ProcessUserJob,
       "Rdv" => RdvSolidaritesWebhooks::ProcessRdvJob,
-      "UserProfile" => RdvSolidaritesWebhooks::ProcessUserProfileJob
+      "UserProfile" => RdvSolidaritesWebhooks::ProcessUserProfileJob,
+      "Organisation" => RdvSolidaritesWebhooks::ProcessOrganisationJob
     }
   end
 

--- a/app/jobs/rdv_solidarites_webhooks/process_organisation_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_organisation_job.rb
@@ -1,0 +1,30 @@
+module RdvSolidaritesWebhooks
+  class ProcessOrganisationJob < ApplicationJob
+    def perform(data, meta)
+      @data = data.deep_symbolize_keys
+      @meta = meta.deep_symbolize_keys
+      return if organisation.blank?
+      return unless event == "updated"
+
+      update_organisation
+    end
+
+    private
+
+    def event
+      @meta[:event]
+    end
+
+    def rdv_solidarites_organisation_id
+      @data[:id]
+    end
+
+    def organisation
+      @organisation ||= Organisation.find_by(rdv_solidarites_organisation_id: rdv_solidarites_organisation_id)
+    end
+
+    def update_organisation
+      UpsertRecordJob.perform_async("Organisation", @data)
+    end
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,4 +1,5 @@
 class Organisation < ApplicationRecord
+  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:name, :phone_number, :email].freeze
   TIME_TO_ACCEPT_INVITATION = 3.days
 
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -6,7 +6,6 @@ class Rdv < ApplicationRecord
   PENDING_STATUSES = %w[unknown waiting].freeze
   CANCELLED_STATUSES = %w[excused revoked noshow].freeze
   CANCELLED_BY_USER_STATUSES = %w[excused noshow].freeze
-  RDV_SOLIDARITES_CLASS_NAME = "Rdv".freeze
 
   after_commit :refresh_applicant_statuses, on: [:create, :update]
 

--- a/app/services/upsert_record.rb
+++ b/app/services/upsert_record.rb
@@ -22,6 +22,10 @@ class UpsertRecord < BaseService
   end
 
   def rdv_solidarites_id_attribute_name
-    "rdv_solidarites_#{@klass::RDV_SOLIDARITES_CLASS_NAME.downcase}_id"
+    "rdv_solidarites_#{rdv_solidarites_class_name.downcase}_id"
+  end
+
+  def rdv_solidarites_class_name
+    defined?(@klass::RDV_SOLIDARITES_CLASS_NAME) ? @klass::RDV_SOLIDARITES_CLASS_NAME : @klass.name
   end
 end

--- a/spec/controllers/rdv_solidarites_webhooks_controller_spec.rb
+++ b/spec/controllers/rdv_solidarites_webhooks_controller_spec.rb
@@ -53,6 +53,20 @@ describe RdvSolidaritesWebhooksController, type: :controller do
     end
   end
 
+  context "for an organisation" do
+    let!(:meta) { { event: "updated", model: "Organisation" } }
+
+    it "enqueues the organisation job" do
+      request.headers["X-Lapin-Signature"] = OpenSSL::HMAC.hexdigest(
+        "SHA256", "i am secret", webhook_params.to_json
+      )
+      expect(RdvSolidaritesWebhooks::ProcessOrganisationJob).to receive(:perform_async)
+        .with(data, meta)
+      post :create, params: webhook_params, as: :json
+      expect(response).to be_successful
+    end
+  end
+
   context "when the webhook is not verified" do
     it "is a bad request" do
       request.headers["X-Lapin-Signature"] = "wrong signature"

--- a/spec/jobs/rdv_solidarites_webhooks/process_organisation_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_organisation_job_spec.rb
@@ -1,0 +1,60 @@
+describe RdvSolidaritesWebhooks::ProcessOrganisationJob, type: :job do
+  subject do
+    described_class.new.perform(data, meta)
+  end
+
+  let!(:data) do
+    {
+      "id" => rdv_solidarites_organisation_id,
+      "name" => "CD 28",
+      "email" => "contact@cd28.fr",
+      "phone_number" => "+33624242424"
+    }.deep_symbolize_keys
+  end
+
+  let!(:rdv_solidarites_organisation_id) { 22 }
+
+  let!(:meta) do
+    {
+      "model" => "Organisation",
+      "event" => "updated"
+    }.deep_symbolize_keys
+  end
+
+  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id) }
+
+  describe "#call" do
+    before do
+      allow(UpsertRecordJob).to receive(:perform_async)
+    end
+
+    it "enqueues upsert record job" do
+      expect(UpsertRecordJob).to receive(:perform_async)
+        .with("Organisation", data)
+      subject
+    end
+
+    context "when the organisation is not found" do
+      let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: "some-id") }
+
+      it "does not enqueue a job" do
+        expect(UpsertRecordJob).not_to receive(:perform_async)
+        subject
+      end
+    end
+
+    context "when it is not an update event" do
+      let!(:meta) do
+        {
+          "model" => "Organisation",
+          "event" => "destroyed"
+        }.deep_symbolize_keys
+      end
+
+      it "does not enqueue a job" do
+        expect(UpsertRecordJob).not_to receive(:perform_async)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette PR permet d'updater les infos d'une orga sur RDV-I lorsque ceux ci changent sur RDV-S en processant les webhooks correspondants (voir https://github.com/betagouv/rdv-solidarites.fr/pull/1963).