### PR TITLE
feat(webhooks): remove mattermost notif when no applicants

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
@@ -6,7 +6,7 @@ module RdvSolidaritesWebhooks
       @data = data.deep_symbolize_keys
       @meta = meta.deep_symbolize_keys
       check_organisation!
-      return send_no_applicants_to_mattermost if applicants.empty?
+      return if applicants.empty?
 
       check_applicants_organisation!
       upsert_or_delete_rdv
@@ -28,13 +28,6 @@ module RdvSolidaritesWebhooks
         WebhookProcessingJobError,
         "Applicants / Organisation mismatch: applicant_ids: #{applicant_ids} - organisation_id #{organisation.id} - " \
         "data: #{@data} - meta: #{@meta}"
-      )
-    end
-
-    def send_no_applicants_to_mattermost
-      MattermostClient.send_to_notif_channel(
-        "Webhook not linked to RDVI applicants.\n" \
-        "RDV Solidarites ids: #{rdv_solidarites_user_ids} - organisation id: #{organisation.id}\n"
       )
     end
 

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -80,11 +80,6 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
         end
         subject
       end
-
-      it "sends a message to mattermost" do
-        expect(MattermostClient).to receive(:send_to_notif_channel)
-        subject
-      end
     end
 
     context "when there is a mismatch between one applicant and the organisation" do


### PR DESCRIPTION
We are onboarding organisations that handle a lot of rdvs that are not linked to RDVI, then there is no point in notifying Mattermost in those cases it will just be noisy.