### PR TITLE
refactor(uids): Rework uid and department internal id logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,9 @@ Style/StringLiterals:
 Style/AsciiComments:
   Enabled: false
 
+Rails/SkipsModelValidations:
+  Enabled: false
+
 Lint/MissingSuper:
   Exclude:
     - "app/services/**/*" # Inheriting BaseService without calling super is OK.

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -1,7 +1,7 @@
 class ApplicantsController < ApplicationController
   PERMITTED_PARAMS = [
     :uid, :role, :first_name, :last_name, :birth_date, :email, :phone_number,
-    :birth_name, :address, :affiliation_number, :custom_id, :title, :status, :rights_opening_date
+    :birth_name, :address, :affiliation_number, :department_internal_id, :title, :status, :rights_opening_date
   ].freeze
   before_action :set_organisation, only: [:index, :create, :show, :update, :edit, :new]
   before_action :retrieve_applicants, only: [:search]
@@ -10,12 +10,16 @@ class ApplicantsController < ApplicationController
   include FilterableApplicantsConcern
 
   def new
-    @applicant = Applicant.new organisations: [@organisation]
+    @applicant = Applicant.new department: @organisation.department, organisations: [@organisation]
     authorize @applicant
   end
 
   def create
-    @applicant = Applicant.new(organisations: [@organisation], **applicant_params)
+    @applicant = Applicant.new(
+      department: @organisation.department,
+      organisations: [@organisation],
+      **applicant_params
+    )
     authorize @applicant
     respond_to do |format|
       format.html { upsert_applicant_and_redirect(:new) }

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -58,8 +58,12 @@ export default function Applicant({ applicant, dispatchApplicants }) {
       {applicant.shouldDisplay("birth_date") && <td>{applicant.birthDate ?? " - "}</td>}
       {applicant.shouldDisplay("email") && <td>{applicant.email ?? " - "}</td>}
       {applicant.shouldDisplay("phone_number") && <td>{applicant.phoneNumber ?? " - "}</td>}
-      {applicant.shouldDisplay("custom_id") && <td>{applicant.customId ?? " - "}</td>}
-      {applicant.shouldDisplay("rights_opening_date") && <td>{applicant.rightsOpeningDate ?? " - "}</td>}
+      {applicant.shouldDisplay("department_internal_id") && (
+        <td>{applicant.departmentInternalId ?? " - "}</td>
+      )}
+      {applicant.shouldDisplay("rights_opening_date") && (
+        <td>{applicant.rightsOpeningDate ?? " - "}</td>
+      )}
       <td>
         {applicant.createdAt ? (
           <i className="fas fa-check green-check" />

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -29,7 +29,7 @@ export default class Applicant {
     this.city = formattedAttributes.city;
     this.postalCode = formattedAttributes.postalCode;
     this.fullAddress = formattedAttributes.fullAddress || this.formatAddress();
-    this.customId = formattedAttributes.customId;
+    this.departmentInternalId = formattedAttributes.departmentInternalId;
     this.rightsOpeningDate = formattedAttributes.rightsOpeningDate;
     this.affiliationNumber = this.formatAffiliationNumber(formattedAttributes.affiliationNumber);
     this.phoneNumber = formatPhoneNumber(formattedAttributes.phoneNumber);
@@ -82,8 +82,8 @@ export default class Applicant {
   formatAffiliationNumber(affiliationNumber) {
     if (affiliationNumber && [13, 15].includes(affiliationNumber.length)) {
       // This means it is a NIR, we replace it by a custom ID if present
-      if (this.customId) {
-        return `CUS-${this.customId}`;
+      if (this.departmentInternalId) {
+        return `CUS-${this.departmentInternalId}`;
       }
       return null;
     }
@@ -168,7 +168,7 @@ export default class Applicant {
       ...(this.email && this.email.includes("@") && { email: this.email }),
       ...(this.birthDate && { birth_date: this.birthDate }),
       ...(this.birthName && { birth_name: this.birthName }),
-      ...(this.customId && { custom_id: this.customId }),
+      ...(this.departmentInternalId && { department_internal_id: this.departmentInternalId }),
       ...(this.rightsOpeningDate && { rights_opening_date: this.rightsOpeningDate }),
     };
   }

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -102,8 +102,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                   row[parameterizedColumnNames.phone_number],
                 birthName:
                   parameterizedColumnNames.birth_name && row[parameterizedColumnNames.birth_name],
-                customId:
-                  parameterizedColumnNames.custom_id && row[parameterizedColumnNames.custom_id],
+                departmentInternalId:
+                  parameterizedColumnNames.department_internal_id &&
+                  row[parameterizedColumnNames.department_internal_id],
                 rightsOpeningDate:
                   parameterizedColumnNames.rights_opening_date &&
                   row[parameterizedColumnNames.rights_opening_date] &&
@@ -232,7 +233,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                     {parameterizedColumnNames.birth_date && <th scope="col">Date de naissance</th>}
                     {parameterizedColumnNames.email && <th scope="col">Email</th>}
                     {parameterizedColumnNames.phone_number && <th scope="col">Téléphone</th>}
-                    {parameterizedColumnNames.custom_id && <th scope="col">ID Editeur</th>}
+                    {parameterizedColumnNames.departmentInternalId && (
+                      <th scope="col">ID Editeur</th>
+                    )}
                     {parameterizedColumnNames.rights_opening_date && (
                       <th scope="col">Date d&apos;entrée flux</th>
                     )}

--- a/app/jobs/soft_delete_applicant_job.rb
+++ b/app/jobs/soft_delete_applicant_job.rb
@@ -6,7 +6,7 @@ class SoftDeleteApplicantJob < ApplicationJob
     applicant.update!(
       status: "deleted",
       uid: nil,
-      custom_id: nil
+      department_internal_id: nil
     )
     MattermostClient.send_to_notif_channel(
       "RDV Solidarites user #{rdv_solidarites_user_id} deleted"

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -2,7 +2,7 @@ class Department < ApplicationRecord
   validates :name, :capital, :number, :pronoun, presence: true
 
   has_many :organisations, dependent: :nullify
-  has_many :applicants, through: :organisations
+  has_many :applicants, dependent: :nullify
   has_many :agents, through: :organisations
   has_many :invitations, through: :organisations
   has_many :rdvs, through: :organisations

--- a/db/migrate/20220111152434_add_department_to_applicants.rb
+++ b/db/migrate/20220111152434_add_department_to_applicants.rb
@@ -1,0 +1,14 @@
+class AddDepartmentToApplicants < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :applicants, :department, foreign_key: true
+
+    up_only do
+      Applicant.includes(organisations: [:department]).find_each do |applicant|
+        next if applicant.organisations.blank?
+
+        applicant.department_id = applicant.organisations.first.department.id
+        applicant.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20220111162622_rename_custom_id_to_department_internal_id.rb
+++ b/db/migrate/20220111162622_rename_custom_id_to_department_internal_id.rb
@@ -1,0 +1,25 @@
+class RenameCustomIdToDepartmentInternalId < ActiveRecord::Migration[6.1]
+  def up
+    rename_column :applicants, :custom_id, :department_internal_id
+    add_index "applicants", %w[department_internal_id department_id], unique: true
+
+    Configuration.find_each do |config|
+      next if config.column_names.dig('optional', 'custom_id').blank?
+
+      config.column_names['optional']['department_internal_id'] = config.column_names['optional'].delete('custom_id')
+      config.save!
+    end
+  end
+
+  def down
+    Configuration.find_each do |config|
+      next if config.column_names.dig('optional', 'department_internal_id').blank?
+
+      config.column_names['optional']['custom_id'] = config.column_names['optional'].delete('department_internal_id')
+      config.save!
+    end
+
+    remove_index "applicants", ["department_internal_id, department_id"]
+    rename_column :applicants, :department_internal_id, :custom_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_03_132647) do
+ActiveRecord::Schema.define(version: 2022_01_11_162622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2022_01_03_132647) do
     t.integer "role"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "custom_id"
+    t.string "department_internal_id"
     t.string "first_name"
     t.string "last_name"
     t.string "address"
@@ -47,6 +47,9 @@ ActiveRecord::Schema.define(version: 2022_01_03_132647) do
     t.integer "status", default: 0
     t.date "rights_opening_date"
     t.string "birth_name"
+    t.bigint "department_id"
+    t.index ["department_id"], name: "index_applicants_on_department_id"
+    t.index ["department_internal_id", "department_id"], name: "index_applicants_on_department_internal_id_and_department_id", unique: true
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true
     t.index ["status"], name: "index_applicants_on_status"
     t.index ["uid"], name: "index_applicants_on_uid", unique: true
@@ -143,6 +146,7 @@ ActiveRecord::Schema.define(version: 2022_01_03_132647) do
     t.index ["status"], name: "index_rdvs_on_status"
   end
 
+  add_foreign_key "applicants", "departments"
   add_foreign_key "configurations", "organisations"
   add_foreign_key "invitations", "applicants"
   add_foreign_key "invitations", "organisations"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,7 +38,7 @@ Configuration.create!(
       "title"=>"Civilité"
     },
     optional: {
-      "custom_id"=>"Code individu IODAS"
+      "department_internal_id"=>"Code individu IODAS"
     }
   }
 )

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -155,9 +155,10 @@ describe ApplicantsController, type: :controller do
 
   describe "#search" do
     let!(:search_params) { { applicants: { uids: ["23"] }, format: "json" } }
-    let!(:applicant) { create(:applicant, organisations: [organisation], uid: "23", email: "borisjohnson@gov.uk") }
+    let!(:applicant) { create(:applicant, organisations: [organisation],  email: "borisjohnson@gov.uk") }
 
     before do
+      applicant.update_columns(uid: "23") # used to skip callbacks and computation of uid
       sign_in(agent)
       setup_rdv_solidarites_session(rdv_solidarites_session)
     end
@@ -165,8 +166,10 @@ describe ApplicantsController, type: :controller do
     context "policy scope" do
       let!(:another_organisation) { create(:organisation) }
       let!(:agent) { create(:agent, organisations: [another_organisation]) }
-      let!(:another_applicant) { create(:applicant, uid: "0332", organisations: [another_organisation]) }
+      let!(:another_applicant) { create(:applicant, organisations: [another_organisation]) }
       let!(:search_params) { { applicants: { uids: %w[23 0332] }, format: "json" } }
+
+      before { another_applicant.update_columns(uid: "0332") }
 
       it "returns the policy scoped applicants" do
         post :search, params: search_params

--- a/spec/factories/applicant.rb
+++ b/spec/factories/applicant.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :applicant do
+    association :department
     sequence(:uid) { |n| "uid#{n}" }
     sequence(:rdv_solidarites_user_id)
     affiliation_number { "1234" }

--- a/spec/jobs/soft_delete_applicant_job_spec.rb
+++ b/spec/jobs/soft_delete_applicant_job_spec.rb
@@ -24,7 +24,7 @@ describe SoftDeleteApplicantJob, type: :job do
       subject
       expect(applicant.status).to eq("deleted")
       expect(applicant.uid).to eq(nil)
-      expect(applicant.custom_id).to eq(nil)
+      expect(applicant.department_internal_id).to eq(nil)
     end
   end
 end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -35,14 +35,44 @@ describe Applicant do
     end
 
     context "colliding uid" do
-      let!(:applicant_existing) { create(:applicant, uid: '123') }
-      let(:applicant) { build(:applicant, uid: '123') }
+      let!(:applicant_existing) { create(:applicant) }
+      let!(:applicant) { build(:applicant, uid: '123') }
+
+      before do
+        # we skip the callbacks not to recompute uid
+        applicant_existing.update_columns(uid: '123')
+      end
 
       it "adds errors" do
         expect(applicant).not_to be_valid
         expect(applicant.errors.details).to eq({ uid: [{ error: :taken, value: '123' }] })
         expect(applicant.errors.full_messages.to_sentence)
           .to include("Uid est déjà utilisé")
+      end
+    end
+  end
+
+  describe "department internal id uniqueness" do
+    context "no collision" do
+      let(:applicant) { build(:applicant, department_internal_id: '123') }
+
+      it { expect(applicant).to be_valid }
+    end
+
+    context "colliding department internal id" do
+      let!(:department) { create(:department) }
+      let!(:applicant_existing) do
+        create(:applicant, department: department, department_internal_id: "921")
+      end
+      let!(:applicant) do
+        build(:applicant, department: department, department_internal_id: "921")
+      end
+
+      it "adds errors" do
+        expect(applicant).not_to be_valid
+        expect(applicant.errors.details).to eq({ department_internal_id: [{ error: :taken, value: '921' }] })
+        expect(applicant.errors.full_messages.to_sentence)
+          .to include("Department internal est déjà utilisé")
       end
     end
   end


### PR DESCRIPTION
In this PR I made changes so that: 

* We now compute the `uid` every time there is a new save. This makes sense because we were not updating the uid when updating the affiliation number or the role.
* I renamed the column `custom_id` to `department_internal_id` to be more precise
* I added a uniqueness constraint on the `department_internal_id` in the scope of a department
* I also know link in DB an applicant and a department. This is in line with the work started by the RDVS team (see [this thread](https://mattermost.incubateur.net/betagouv/pl/ydweh657qf8z3mz5y189j6ktsa)) and is also coherent with our usecase
