### PR TITLE
add tests for departments routes

### DIFF
--- a/app/views/applicants/edit.html.erb
+++ b/app/views/applicants/edit.html.erb
@@ -1,4 +1,4 @@
 <%= simple_form_for(@applicant, redirect_path: compute_applicant_path(@applicant, @organisation, @department), url: compute_applicant_path(@applicant, @organisation, @department), html: { method: :patch }) do |f| %>
-  <%= render 'applicant_form', f: f, page_name: "edit", title: "Modifier allocataire", redirect_path: compute_applicant_path(@applicant, @organisation, @department) %>
+  <%= render 'applicant_form', f: f, title: "Modifier allocataire", redirect_path: compute_applicant_path(@applicant, @organisation, @department) %>
 <% end %>
 

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -1,4 +1,4 @@
 <%= simple_form_for(@applicant, url: organisation_applicants_path(@organisation, @applicant), html: { method: :post }) do |f| %>
-  <%= render 'applicant_form', f: f, page_name: "new", title: "Créer allocataire", redirect_path: compute_index_path(@organisation, @department) %>
+  <%= render 'applicant_form', f: f, title: "Créer allocataire", redirect_path: compute_index_path(@organisation, @department) %>
 <% end %>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2022_01_11_162622) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Dans cette PR, j'ajoute des tests pour les changements apportés par la PR #179.
Je supprime également le `page_name` passé au `applicant_form`, qui n'est plus nécessaire.