### PR TITLE
fix(upload): Avoid blank column names to block the process

### DIFF
--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -71,7 +71,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
         const header = [];
         const columnCount = XLSX.utils.decode_range(sheet["!ref"]).e.c + 1;
         for (let i = 0; i < columnCount; i += 1) {
-          header[i] = sheet[`${XLSX.utils.encode_col(i)}1`].v;
+          if (sheet[`${XLSX.utils.encode_col(i)}1`] !== undefined) {
+            header[i] = sheet[`${XLSX.utils.encode_col(i)}1`].v;
+          }
         }
         const missingColumnNames = checkColumnNames(parameterizeArray(header));
         let rows = XLSX.utils.sheet_to_row_object_array(sheet);


### PR DESCRIPTION
Lors de l'upload d'un fichier bénéficiaire, si une colonne était remplie mais son en-tête laissé vide, l'upload du fichier ne s'effectuait pas (cas découvert avec le fichier des Ardennes).
Cette PR corrige ce problème en ignorant ces colonnes là, car les colonnes qui nous sont nécessaires doivent être nommées conformément à ce qui a été convenu avec le département.