### PR TITLE
feat(db): Link multiple orgs to configuration

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -28,7 +28,7 @@ class ApplicantsController < ApplicationController
   end
 
   def index
-    @applicants = policy_scope(Applicant).includes(:invitations, :rdvs)
+    @applicants = policy_scope(Applicant).includes(:invitations, :rdvs).distinct
     @applicants = \
       if department_level?
         @applicants.where(organisations: policy_scope(Organisation).where(department: @department))

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,6 +1,5 @@
 class Configuration < ApplicationRecord
-  belongs_to :organisation
-  belongs_to :department, optional: true
+  has_many :organisations, dependent: :nullify
 
   enum invitation_format: { sms: 0, email: 1, sms_and_email: 2, link_only: 3, no_invitation: 4 }
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,5 +1,6 @@
 class Configuration < ApplicationRecord
   belongs_to :organisation
+  belongs_to :department, optional: true
 
   enum invitation_format: { sms: 0, email: 1, sms_and_email: 2, link_only: 3, no_invitation: 4 }
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -4,6 +4,7 @@ class Department < ApplicationRecord
   has_many :organisations, dependent: :nullify
   has_many :applicants, dependent: :nullify
   has_many :invitations, dependent: :nullify
+  has_one :configuration, dependent: :nullify
 
   has_many :agents, through: :organisations
   has_many :rdvs, through: :organisations

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -4,7 +4,6 @@ class Department < ApplicationRecord
   has_many :organisations, dependent: :nullify
   has_many :applicants, dependent: :nullify
   has_many :invitations, dependent: :nullify
-  has_one :configuration, dependent: :nullify
 
   has_many :agents, through: :organisations
   has_many :rdvs, through: :organisations

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,7 @@ class Organisation < ApplicationRecord
   has_and_belongs_to_many :agents, dependent: :nullify
   has_and_belongs_to_many :applicants, dependent: :nullify
   has_and_belongs_to_many :invitations, dependent: :nullify
-  has_one :configuration, dependent: :nullify
+  belongs_to :configuration
   has_many :rdvs, dependent: :nullify
 
   delegate :notify_applicant?, to: :configuration

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -37,12 +37,12 @@
 
         <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
           <li>
-          <%= link_to new_organisation_applicant_path(@organisation), class: "dropdown-item" do %>
+            <%= link_to new_organisation_applicant_path(@organisation), class: "dropdown-item" do %>
               Créer un allocataire
             <% end %>
           </li>
           <li>
-          <%= link_to new_organisation_upload_path(@organisation), class: "dropdown-item" do %>
+            <%= link_to new_organisation_upload_path(@organisation), class: "dropdown-item" do %>
               Charger fichier allocataires
             <% end %>
           </li>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -18,7 +18,7 @@
                 <ul class="list-inline">
                   <% if organisations.length > 1 %>
                     <%= link_to department_applicants_path(department) do %>
-                      <li class="my-3"><div class="col-5 pb-2 border-bottom">Toutes les organisations</div></li>
+                      <li class="my-4"><div class="col-5 pb-2 border-bottom"><h5>Toutes les organisations</h5></div></li>
                     <% end %>
                   <% end %>
                   <% organisations.each do |organisation| %>
@@ -30,7 +30,7 @@
               </div>
             </div>
             <div class="d-flex align-items-center">
-              <div>
+              <div class="px-3">
                 <% if image_compiled?("maps/#{department.name.parameterize}.svg") %>
                   <%= image_pack_tag("maps/#{department.name.parameterize}.svg", alt: department.name.parameterize) %>
                 <% end %>

--- a/db/migrate/20220120203747_change_configuration_organisation_association.rb
+++ b/db/migrate/20220120203747_change_configuration_organisation_association.rb
@@ -1,0 +1,30 @@
+class ChangeConfigurationOrganisationAssociation < ActiveRecord::Migration[6.1]
+  def up
+    add_reference :organisations, :configuration, foreign_key: true
+
+    Organisation.find_each do |organisation|
+      configuration = Configuration.find_by(organisation_id: organisation.id)
+      if configuration.blank?
+        configuration = Configuration.new(organisation_id: organisation.id, invitation_format: "sms_and_email")
+        configuration.save!
+      end
+
+      organisation.update!(configuration_id: configuration.id)
+    end
+
+    remove_reference :configurations, :organisation, foreign_key: true
+  end
+
+  def down
+    add_reference :configurations, :organisation, foreign_key: true
+
+    Configuration.find_each do |config|
+      organisation = Organisation.find_by(configuration_id: config.id)
+      next unless organisation
+
+      config.update!(organisation_id: organisation.id)
+    end
+
+    remove_reference :organisations, :configuration, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_20_130306) do
+ActiveRecord::Schema.define(version: 2022_01_20_203747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,10 +74,6 @@ ActiveRecord::Schema.define(version: 2022_01_20_130306) do
     t.datetime "updated_at", precision: 6, null: false
     t.json "column_names"
     t.boolean "notify_applicant", default: false
-    t.bigint "organisation_id"
-    t.bigint "department_id"
-    t.index ["department_id"], name: "index_configurations_on_department_id"
-    t.index ["organisation_id"], name: "index_configurations_on_organisation_id"
   end
 
   create_table "departments", force: :cascade do |t|
@@ -131,6 +127,8 @@ ActiveRecord::Schema.define(version: 2022_01_20_130306) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "department_id"
     t.string "rsa_agents_service_id"
+    t.bigint "configuration_id"
+    t.index ["configuration_id"], name: "index_organisations_on_configuration_id"
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
   end
@@ -157,11 +155,10 @@ ActiveRecord::Schema.define(version: 2022_01_20_130306) do
   end
 
   add_foreign_key "applicants", "departments"
-  add_foreign_key "configurations", "departments"
-  add_foreign_key "configurations", "organisations"
   add_foreign_key "invitations", "applicants"
   add_foreign_key "invitations", "departments"
   add_foreign_key "notifications", "applicants"
+  add_foreign_key "organisations", "configurations"
   add_foreign_key "organisations", "departments"
   add_foreign_key "rdvs", "organisations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_17_163650) do
+ActiveRecord::Schema.define(version: 2022_01_20_130306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,8 @@ ActiveRecord::Schema.define(version: 2022_01_17_163650) do
     t.json "column_names"
     t.boolean "notify_applicant", default: false
     t.bigint "organisation_id"
+    t.bigint "department_id"
+    t.index ["department_id"], name: "index_configurations_on_department_id"
     t.index ["organisation_id"], name: "index_configurations_on_organisation_id"
   end
 
@@ -155,6 +157,7 @@ ActiveRecord::Schema.define(version: 2022_01_17_163650) do
   end
 
   add_foreign_key "applicants", "departments"
+  add_foreign_key "configurations", "departments"
   add_foreign_key "configurations", "organisations"
   add_foreign_key "invitations", "applicants"
   add_foreign_key "invitations", "departments"

--- a/spec/factories/configuration.rb
+++ b/spec/factories/configuration.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :configuration do
     sheet_name { 'LISTE DEMANDEURS' }
     invitation_format { :sms }
-    association :organisation
   end
 end

--- a/spec/factories/organisation.rb
+++ b/spec/factories/organisation.rb
@@ -2,10 +2,7 @@ FactoryBot.define do
   factory :organisation do
     sequence(:name) { |n| "Departement n°#{n}" }
     sequence(:rdv_solidarites_organisation_id)
-
     department { create(:department) }
-    after(:create) do |organisation|
-      organisation.configuration ||= create(:configuration, organisation: organisation)
-    end
+    configuration { create(:configuration) }
   end
 end

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -35,8 +35,13 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
   let!(:applicant) { create(:applicant, organisations: [organisation], id: 3) }
   let!(:applicant2) { create(:applicant, organisations: [organisation], id: 4) }
 
-  let!(:configuration) { create(:configuration, organisation: organisation, notify_applicant: true) }
-  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id) }
+  let!(:configuration) { create(:configuration, notify_applicant: true) }
+  let!(:organisation) do
+    create(
+      :organisation,
+      rdv_solidarites_organisation_id: rdv_solidarites_organisation_id, configuration: configuration
+    )
+  end
 
   describe "#perform" do
     before do
@@ -110,7 +115,7 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
 
     context "when applicants should not be notified" do
       context "when the organisation does not notify applicants" do
-        let!(:configuration) { create(:configuration, organisation: organisation, notify_applicant: false) }
+        let!(:configuration) { create(:configuration, notify_applicant: false) }
 
         it "does not call the notify applicant job" do
           expect(NotifyApplicantJob).not_to receive(:perform_async)

--- a/spec/services/save_applicant_spec.rb
+++ b/spec/services/save_applicant_spec.rb
@@ -8,7 +8,12 @@ describe SaveApplicant, type: :service do
 
   let!(:rdv_solidarites_organisation_id) { 1010 }
   let!(:rdv_solidarites_user_id) { 2020 }
-  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id) }
+  let!(:organisation) do
+    create(
+      :organisation,
+      configuration: configuration, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id
+    )
+  end
   let!(:applicant_attributes) do
     {
       uid: "1234xyz", first_name: "john", last_name: "doe",
@@ -25,7 +30,7 @@ describe SaveApplicant, type: :service do
     }
   end
 
-  let!(:configuration) { create(:configuration, organisation: organisation, notify_applicant: false) }
+  let!(:configuration) { create(:configuration, notify_applicant: false) }
 
   let!(:applicant) do
     create(:applicant, applicant_attributes.merge(organisations: [organisation], rdv_solidarites_user_id: nil))
@@ -83,7 +88,7 @@ describe SaveApplicant, type: :service do
     end
 
     context "when organisation notifies customer from rdv insertion" do
-      let!(:configuration) { create(:configuration, organisation: organisation, notify_applicant: true) }
+      let!(:configuration) { create(:configuration, notify_applicant: true) }
 
       it "does not notify with rdv solidarites user" do
         expect(UpsertRdvSolidaritesUser).to receive(:call)


### PR DESCRIPTION
Je change la relation entre les orgas et les configuration pour pouvoir associer plusieurs orgas, ce qui permet de ne pas avoir à créer une config quand un département a plusieurs orgas comme le 64.

J'en profite pour régler qq trucs: 

* Faire en sorte de ne pas avoir de doublons sur la page index d'un territoire (en ajoutant `distinct` à la requête)
* Démarquer un peu plus le choix de "toutes les organisations" (l'UI est pas terrible c'est temporaire)

![image](https://user-images.githubusercontent.com/7602809/150423950-4fe2dca1-afd3-48fd-a756-4086d0038ff5.png)
