### PR TITLE
fix(invitations): prevent race conditions for invitations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,7 @@ RSpec/NamedSubject:
   Enabled: false
 
 RSpec/NestedGroups:
-  Max: 5
+  Max: 7
 
 RSpec/MessageChain:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem 'responders'
 gem 'kaminari'
 # PG search
 gem 'pg_search'
+# Adds advisory locking (mutexes)
+gem 'with_advisory_lock'
 
 # CSS styled emails with stylesheets
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_advisory_lock (4.6.0)
+      activerecord (>= 4.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -391,6 +393,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)
+  with_advisory_lock
 
 RUBY VERSION
    ruby 3.0.3p157

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -53,14 +53,10 @@ class BaseService
   private
 
   def call_service!(service, **kwargs)
-    service_call = service.call(**kwargs)
+    service_result = service.call(**kwargs)
+    return service_result if service_result.success?
 
-    if service_call.success?
-      instance_variable_set(:"@#{service.name.demodulize.underscore}_service", service_call)
-      return
-    end
-
-    result.errors += service_call.errors
+    result.errors += service_result.errors
     fail!
   end
 

--- a/app/services/invitations/save_and_send.rb
+++ b/app/services/invitations/save_and_send.rb
@@ -20,14 +20,11 @@ module Invitations
     end
 
     def send_invitation!
-      return if send_invitation.success?
+      send_to_applicant = @invitation.send_to_applicant
+      return if send_to_applicant.success?
 
-      result.errors += send_invitation.errors
+      result.errors += send_to_applicant.errors
       fail!
-    end
-
-    def send_invitation
-      @send_invitation ||= @invitation.send_to_applicant
     end
 
     def save_invitation_with_link!

--- a/app/services/notifications/notify_applicant.rb
+++ b/app/services/notifications/notify_applicant.rb
@@ -12,8 +12,8 @@ module Notifications
       return if @applicant.phone_number.blank?
 
       check_applicant_organisation!
-      notify_applicant!
-      update_notification_sent_at!
+      notify_applicant
+      update_notification_sent_at
     end
 
     protected
@@ -24,10 +24,10 @@ module Notifications
       fail!("l'allocataire ne peut être invité car il n'appartient pas à l'organisation.")
     end
 
-    def notify_applicant!
+    def notify_applicant
       Notification.transaction do
         save_record!(notification)
-        send_sms!
+        send_sms
       end
     end
 
@@ -35,7 +35,7 @@ module Notifications
       @applicant.phone_number_formatted
     end
 
-    def send_sms!
+    def send_sms
       return Rails.logger.info(content) if Rails.env.development?
 
       call_service!(
@@ -52,7 +52,7 @@ module Notifications
       )
     end
 
-    def update_notification_sent_at!
+    def update_notification_sent_at
       notification.sent_at = Time.zone.now
       save_record!(notification)
     end

--- a/app/services/rdv_solidarites_api/base.rb
+++ b/app/services/rdv_solidarites_api/base.rb
@@ -11,6 +11,7 @@ module RdvSolidaritesApi
     end
 
     def request!
+      result.status = rdv_solidarites_response.status
       return if rdv_solidarites_response.success?
 
       fail_with_errors

--- a/app/services/save_applicant.rb
+++ b/app/services/save_applicant.rb
@@ -8,15 +8,15 @@ class SaveApplicant < BaseService
   def call
     Applicant.transaction do
       save_record!(@applicant)
-      upsert_rdv_solidarites_user!
-      assign_rdv_solidarites_user_id! unless @applicant.rdv_solidarites_user_id?
+      upsert_rdv_solidarites_user
+      assign_rdv_solidarites_user_id unless @applicant.rdv_solidarites_user_id?
     end
   end
 
   private
 
-  def upsert_rdv_solidarites_user!
-    call_service!(
+  def upsert_rdv_solidarites_user
+    @upsert_rdv_solidarites_user ||= call_service!(
       UpsertRdvSolidaritesUser,
       rdv_solidarites_session: @rdv_solidarites_session,
       rdv_solidarites_organisation_id: @organisation.rdv_solidarites_organisation_id,
@@ -25,8 +25,8 @@ class SaveApplicant < BaseService
     )
   end
 
-  def assign_rdv_solidarites_user_id!
-    @applicant.rdv_solidarites_user_id = @upsert_rdv_solidarites_user_service.rdv_solidarites_user_id
+  def assign_rdv_solidarites_user_id
+    @applicant.rdv_solidarites_user_id = upsert_rdv_solidarites_user.rdv_solidarites_user_id
     save_record!(@applicant)
   end
 


### PR DESCRIPTION
J'ajoute la gem `with_advisory_lock` pour locker l'exécution de l'invitation (récupération token + link). Ainsi ce bloc ne pourra pas s'exécuter sur 2 threads différent en même temps pour un même allocataire.

J'en profite également pour: 

* ne plus utiliser les variables d'instances `@..._service` introduits la semaine dernière. Je change également certaines convention de nommage de méthode, je suffixe la méthode par `!` que lorsqu'elle appelle directement `fail!` (c'est discutable 🤷‍♂️ )
* ajouter une condition dans le service `UpsertRdvSolidaritesUser`: Si un applicant est rattaché au user RDV-Solidarités que l'on essaie de créer (peut arriver si le numéro d'allocataire ou le rôle change), ça fail parce que c'est normalement pas censé arriver.