### PR TITLE
feat(invitations): Add lieu id to invitations

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -27,7 +27,7 @@ class InvitationsController < ApplicationController
   private
 
   def invitation_params
-    params.require(:invitation).permit(:format, :context, :help_phone_number)
+    params.require(:invitation).permit(:format, :context, :help_phone_number, :rdv_solidarites_lieu_id)
   end
 
   def set_applicant

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -5,7 +5,8 @@ module Invitations
     end
 
     def call
-      retrieve_geolocalisation
+      # we don't need or want to geolocalise when we invite for a precise place
+      retrieve_geolocalisation unless @invitation.rdv_solidarites_lieu_id?
       result.invitation_link = redirect_link
     end
 
@@ -44,7 +45,7 @@ module Invitations
         organisation_ids: @invitation.organisations.map(&:rdv_solidarites_organisation_id),
         motif_search_terms: @invitation.context
       }
-        .merge(geo_attributes)
+        .merge(@invitation.rdv_solidarites_lieu_id? ? { lieu_id: @invitation.rdv_solidarites_lieu_id } : geo_attributes)
     end
 
     def address

--- a/db/migrate/20220125154225_add_rdv_solidarites_lieu_id_to_invitation.rb
+++ b/db/migrate/20220125154225_add_rdv_solidarites_lieu_id_to_invitation.rb
@@ -1,0 +1,13 @@
+class AddRdvSolidaritesLieuIdToInvitation < ActiveRecord::Migration[6.1]
+  def up
+    add_column :invitations, :rdv_solidarites_lieu_id, :bigint
+    change_column :organisations, :rdv_solidarites_organisation_id, :bigint
+    change_column :applicants, :rdv_solidarites_user_id, :bigint
+  end
+
+  def down
+    remove_column :invitations, :rdv_solidarites_lieu_id
+    change_column :organisations, :rdv_solidarites_organisation_id, :integer
+    change_column :organisations, :rdv_solidarites_organisation_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_20_203747) do
+ActiveRecord::Schema.define(version: 2022_01_25_154225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_203747) do
 
   create_table "applicants", force: :cascade do |t|
     t.string "uid"
-    t.integer "rdv_solidarites_user_id"
+    t.bigint "rdv_solidarites_user_id"
     t.string "affiliation_number"
     t.integer "role"
     t.datetime "created_at", precision: 6, null: false
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 2022_01_20_203747) do
     t.string "context"
     t.string "help_phone_number"
     t.bigint "department_id"
+    t.bigint "rdv_solidarites_lieu_id"
     t.index ["applicant_id"], name: "index_invitations_on_applicant_id"
     t.index ["department_id"], name: "index_invitations_on_department_id"
   end
@@ -122,11 +123,11 @@ ActiveRecord::Schema.define(version: 2022_01_20_203747) do
     t.string "name"
     t.string "phone_number"
     t.string "email"
-    t.integer "rdv_solidarites_organisation_id"
+    t.bigint "rdv_solidarites_organisation_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "department_id"
-    t.string "rsa_agents_service_id"
+    t.string "rsa_agents_service_id", default: "4"
     t.bigint "configuration_id"
     t.index ["configuration_id"], name: "index_organisations_on_configuration_id"
     t.index ["department_id"], name: "index_organisations_on_department_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,7 +127,7 @@ ActiveRecord::Schema.define(version: 2022_01_25_154225) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "department_id"
-    t.string "rsa_agents_service_id", default: "4"
+    t.string "rsa_agents_service_id"
     t.bigint "configuration_id"
     t.index ["configuration_id"], name: "index_organisations_on_configuration_id"
     t.index ["department_id"], name: "index_organisations_on_department_id"

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -97,5 +97,32 @@ describe Invitations::ComputeLink, type: :service do
         end
       end
     end
+
+    context "when a lieu id is passed" do
+      let!(:invitation) do
+        create(
+          :invitation,
+          department: department,
+          organisations: [organisation1, organisation2],
+          applicant: applicant,
+          context: "RSA accompagnement",
+          token: invitation_token,
+          rdv_solidarites_lieu_id: 5
+        )
+      end
+
+      it "does not retrieve the geolocalisation" do
+        expect(RetrieveGeolocalisation).not_to receive(:call)
+        subject
+      end
+
+      it "adds the lieu id instead of the geo attributes in the url" do
+        expect(subject.invitation_link).to eq(
+          "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
+          "departement=75&invitation_token=sometoken&lieu_id=5&motif_search_terms=RSA+accompagnement&" \
+          "organisation_ids%5B%5D=333&organisation_ids%5B%5D=444"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
I add the possibility to pass a `rdv_solidarites_lieu_id` in the invitation. We store it in the invitations table.
If we pass one, we obviously don't pass the geolocalisation attributes.
For now we never send one through the application.

I also took this opportunity to change the type of the columns `rdv_solidarites_organisation_id` and `rdv_solidarites_user_id` from `integer` to `bigint`.
