### PR TITLE
feat(front): add organisations name & birth_name to applicant show

### DIFF
--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -27,13 +27,8 @@
         <p><%= f.input :title, as: :select, collection: ["monsieur", "madame"] %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date d'entrée flux</h4>
-        <p><%= f.input :rights_opening_date,
-                        input_html: { class: "date-select" },
-                        as: :date, start_year: Date.today.year - 10,
-                        end_year: Date.today.year,
-                        include_blank: true,
-                        order: [:day, :month, :year] %></p>
+        <h4 class="attribute-title">Nom de naissance*</h4>
+        <p><%= f.input :birth_name %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
@@ -42,11 +37,15 @@
         <p><%= f.input :affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Email</h4>
-        <p><%= f.input :email %></p>
+        <h4 class="attribute-title">Rôle</h4>
+        <p><%= f.input :role, as: :select, collection: ["demandeur", "conjoint"], selected: @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Email</h4>
+        <p><%= f.input :email %></p>
+      </div>
       <div class="col-10 col-md-5">
         <h4 class="attribute-title">Date de naissance</h4>
         <p><%= f.input :birth_date,
@@ -55,10 +54,6 @@
                         end_year: Date.today.year,
                         include_blank: true,
                         order: [:day, :month, :year] %></p>
-      </div>
-      <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Rôle</h4>
-        <p><%= f.input :role, as: :select, collection: ["demandeur", "conjoint"], selected: @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
@@ -72,6 +67,18 @@
           <%= f.input :phone_number %>
         </p>
       </div>
+    </div>
+    <div class="row d-flex justify-content-around flex-wrap">
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Date d'entrée flux</h4>
+        <p><%= f.input :rights_opening_date,
+                        input_html: { class: "date-select" },
+                        as: :date, start_year: Date.today.year - 10,
+                        end_year: Date.today.year,
+                        include_blank: true,
+                        order: [:day, :month, :year] %></p>
+      </div>
+      <div class="col-10 col-md-5"></div>
     </div>
   </div>
 </div>

--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -27,8 +27,8 @@
         <p><%= f.input :title, as: :select, collection: ["monsieur", "madame"] %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Nom de naissance*</h4>
-        <p><%= f.input :birth_name %></p>
+        <h4 class="attribute-title">Rôle*</h4>
+        <p><%= f.input :role, as: :select, collection: ["demandeur", "conjoint"], selected: @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
@@ -37,8 +37,8 @@
         <p><%= f.input :affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Rôle</h4>
-        <p><%= f.input :role, as: :select, collection: ["demandeur", "conjoint"], selected: @applicant.role %></p>
+        <h4 class="attribute-title">ID logiciel gestion RSA</h4>
+        <p><%= f.input :department_internal_id %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">

--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -13,27 +13,27 @@
   <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:first_name) %></h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:first_name) %>*</h4>
         <p><%= f.input :first_name %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:last_name) %></h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:last_name) %>*</h4>
         <p><%= f.input :last_name %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:title) %></h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:title) %>*</h4>
         <p><%= f.input :title, as: :select, collection: ["monsieur", "madame"] %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:role) %></h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:role) %>*</h4>
         <p><%= f.input :role, as: :select, collection: ["demandeur", "conjoint"], selected: @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:affiliation_number) %></h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:affiliation_number) %>*</h4>
         <p><%= f.input :affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">

--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -13,41 +13,41 @@
   <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Prénom*</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:first_name) %></h4>
         <p><%= f.input :first_name %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Nom*</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:last_name) %></h4>
         <p><%= f.input :last_name %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Civilité*</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:title) %></h4>
         <p><%= f.input :title, as: :select, collection: ["monsieur", "madame"] %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Rôle*</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:role) %></h4>
         <p><%= f.input :role, as: :select, collection: ["demandeur", "conjoint"], selected: @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Numéro allocataire*</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:affiliation_number) %></h4>
         <p><%= f.input :affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">ID logiciel gestion RSA</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:department_internal_id) %></h4>
         <p><%= f.input :department_internal_id %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Email</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:email) %></h4>
         <p><%= f.input :email %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date de naissance</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:birth_date) %></h4>
         <p><%= f.input :birth_date,
                         input_html: { class: "date-select" },
                         as: :date, start_year: Date.today.year - 100,
@@ -58,11 +58,11 @@
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Adresse</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:address) %></h4>
         <p><%= f.input :address %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Téléphone</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:phone_number) %></h4>
         <p>
           <%= f.input :phone_number %>
         </p>
@@ -70,7 +70,7 @@
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date d'entrée flux</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:rights_opening_date) %></h4>
         <p><%= f.input :rights_opening_date,
                         input_html: { class: "date-select" },
                         as: :date, start_year: Date.today.year - 10,

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -37,8 +37,8 @@
         <p><%= display_attribute @applicant.title %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Nom de naissance</h4>
-        <p><%= display_attribute @applicant.birth_name %></p>
+        <h4 class="attribute-title">Rôle</h4>
+        <p><%= display_attribute @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
@@ -47,8 +47,8 @@
         <p><%= display_attribute @applicant.affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Rôle</h4>
-        <p><%= display_attribute @applicant.role %></p>
+        <h4 class="attribute-title">ID logiciel gestion RSA</h4>
+        <p><%= display_attribute @applicant.department_internal_id %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -22,63 +22,63 @@
   <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Prénom</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:first_name) %></h4>
         <p><%= display_attribute @applicant.first_name %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Nom</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:last_name) %></h4>
         <p><%= display_attribute @applicant.last_name %></p>
       </div>
     </div>
   <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Civilité</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:title) %></h4>
         <p><%= display_attribute @applicant.title %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Rôle</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:role) %></h4>
         <p><%= display_attribute @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Numéro allocataire</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:affiliation_number) %></h4>
         <p><%= display_attribute @applicant.affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">ID logiciel gestion RSA</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:department_internal_id) %></h4>
         <p><%= display_attribute @applicant.department_internal_id %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Email</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:email) %></h4>
         <p><%= display_attribute @applicant.email %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date de naissance</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:birth_date) %></h4>
         <p><%= display_attribute format_date(@applicant.birth_date) %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Adresse</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:address) %></h4>
         <p><%= display_attribute @applicant.address %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Téléphone</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:phone_number) %></h4>
         <p><%= display_attribute @applicant.phone_number %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date d'entrée flux</h4>
+        <h4 class="attribute-title"><%= Applicant.human_attribute_name(:rights_opening_date) %></h4>
         <p><%= display_attribute format_date(@applicant.rights_opening_date) %></p>
       </div>
       <div class="col-10 col-md-5">
         <% if department_level? %>
-          <h4 class="attribute-title">Organisation(s)</h4>
+          <h4 class="attribute-title"><%= Applicant.human_attribute_name(:organisations) %></h4>
           <p><%= @applicant.organisations.collect(&:name).join(", ") %></p>
         <% end %>
       </div>

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -22,22 +22,23 @@
   <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Nom</h4>
-        <p><%= display_attribute @applicant.last_name %></p>
-      </div>
-      <div class="col-10 col-md-5">
         <h4 class="attribute-title">Prénom</h4>
         <p><%= display_attribute @applicant.first_name %></p>
       </div>
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Nom</h4>
+        <p><%= display_attribute @applicant.last_name %></p>
+      </div>
     </div>
+  <div class="mb-4">
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
         <h4 class="attribute-title">Civilité</h4>
         <p><%= display_attribute @applicant.title %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date d'entrée flux</h4>
-        <p><%= display_attribute format_date(@applicant.rights_opening_date) %></p>
+        <h4 class="attribute-title">Nom de naissance</h4>
+        <p><%= display_attribute @applicant.birth_name %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
@@ -46,18 +47,18 @@
         <p><%= display_attribute @applicant.affiliation_number %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Email</h4>
-        <p><%= display_attribute @applicant.email %></p>
+        <h4 class="attribute-title">Rôle</h4>
+        <p><%= display_attribute @applicant.role %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Date de naissance</h4>
-        <p><%= display_attribute format_date(@applicant.birth_date) %></p>
+        <h4 class="attribute-title">Email</h4>
+        <p><%= display_attribute @applicant.email %></p>
       </div>
       <div class="col-10 col-md-5">
-        <h4 class="attribute-title">Rôle</h4>
-        <p><%= display_attribute @applicant.role %></p>
+        <h4 class="attribute-title">Date de naissance</h4>
+        <p><%= display_attribute format_date(@applicant.birth_date) %></p>
       </div>
     </div>
     <div class="row d-flex justify-content-around flex-wrap">
@@ -68,6 +69,18 @@
       <div class="col-10 col-md-5">
         <h4 class="attribute-title">Téléphone</h4>
         <p><%= display_attribute @applicant.phone_number %></p>
+      </div>
+    </div>
+    <div class="row d-flex justify-content-around flex-wrap">
+      <div class="col-10 col-md-5">
+        <h4 class="attribute-title">Date d'entrée flux</h4>
+        <p><%= display_attribute format_date(@applicant.rights_opening_date) %></p>
+      </div>
+      <div class="col-10 col-md-5">
+        <% if department_level? %>
+          <h4 class="attribute-title">Organisation(s)</h4>
+          <p><%= @applicant.organisations.collect(&:name).join(", ") %></p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/models/applicant.fr.yml
+++ b/config/locales/models/applicant.fr.yml
@@ -26,3 +26,6 @@ fr:
         address: Adresse
         email: Email
         title: Civilité
+        department_internal_id: ID interne au département
+        rights_opening_date: Date d'entrée flux
+        organisations: Organisation(s)

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -72,7 +72,7 @@ describe Applicant do
         expect(applicant).not_to be_valid
         expect(applicant.errors.details).to eq({ department_internal_id: [{ error: :taken, value: '921' }] })
         expect(applicant.errors.full_messages.to_sentence)
-          .to include("Department internal est déjà utilisé")
+          .to include("ID interne au département est déjà utilisé")
       end
     end
   end


### PR DESCRIPTION
Dans cette PR, j'ajoute l'affichage du nom de naissance et surtout, dans le cas où l'agent consulte un applicant au niveau du département, le nom des organisations auxquelles le bénéficiaire est attaché.
Je modifie également l'ordre de l'affichage des attributs, en partie pour être en accord avec `applicant_form` (inversion nom/prénom).