### PR TITLE
feat(front): add phone on index

### DIFF
--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -5,10 +5,10 @@
     <% else %>
       <table class="table table-hover table-responsive">
         <thead class="text-dark-blue">
-          <th scope="col" class="d-none d-lg-table-cell">Numéro d'allocataire</th>
-          <th scope="col">Prénom</th>
           <th scope="col">Nom</th>
+          <th scope="col">Prénom</th>
           <th scope="col" class="d-none d-lg-table-cell">Email</th>
+          <th scope="col" class="d-none d-lg-table-cell">Téléphone</th>
           <% if show_sms_invitation?(@configuration) %>
             <th scope="col">Dernière invitation SMS</th>
           <% end %>
@@ -24,10 +24,10 @@
         <tbody class="align-middle">
           <% @applicants.each do |applicant| %>
             <tr>
-              <td class="d-none d-lg-table-cell"><%= display_attribute applicant.affiliation_number %></td>
-              <td><%= display_attribute applicant.first_name %></td>
               <td><%= display_attribute applicant.last_name %></td>
+              <td><%= display_attribute applicant.first_name %></td>
               <td class="d-none d-lg-table-cell"><%= display_attribute applicant.email %></td>
+              <td class="d-none d-lg-table-cell"><%= display_attribute applicant.phone_number %></td>
               <% if show_sms_invitation?(@configuration) %>
                 <td><%= display_attribute format_date(applicant.last_sms_invitation_sent_at) %></td>
               <% end %>


### PR DESCRIPTION
Micro-changement d'affichage sur la page index, après retex du 64 : j'ajoute le numéro de téléphone à la place du numéro d'allocataire (sur cette page, le téléphone, avec le mail, permet de voir si un allocataire a un moyen d'être invité ou non ; le numéro d'allocataire ne sert pas trop).
Je passe le nom en premier élément de la colonne car c'est un élément plus différenciant que le prénom si on cherche rapidement des yeux quelqu'un dans la liste.