### PR TITLE
fix(invitations): reload applicant in save with link service

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -18,7 +18,7 @@ class ApplicantsController < ApplicationController
     @applicant = Applicant.new(
       department: @organisation.department,
       organisations: [@organisation],
-      **applicant_params
+      **applicant_params.compact_blank
     )
     authorize @applicant
     respond_to do |format|

--- a/app/services/invitations/save_with_link.rb
+++ b/app/services/invitations/save_with_link.rb
@@ -32,7 +32,9 @@ module Invitations
     end
 
     def applicant
-      @invitation.applicant
+      # we reload in case the applicant had a new invitation attached to it after
+      # the invitation has been instantiated
+      @invitation.applicant.reload
     end
 
     def retrieve_invitation_token


### PR DESCRIPTION
Essai de régler le problème de lien invalide en reloadant le record `applicant` lié à l'invitation dans le service `SaveWithLink`.
J'en profite pour nullifier les empty string à l'envoi du formulaire de création d'allocataire.