### PR TITLE
feat(configuration): change column type for invitation format in config

### DIFF
--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -4,11 +4,11 @@ module ApplicantsHelper
   end
 
   def show_sms_invitation?(configuration)
-    configuration.sms? || configuration.sms_and_email?
+    configuration.invitation_formats.include?("sms")
   end
 
   def show_email_invitation?(configuration)
-    configuration.email? || configuration.sms_and_email?
+    configuration.invitation_formats.include?("email")
   end
 
   def show_notification?(configuration)

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -163,17 +163,11 @@ export default class Applicant {
   }
 
   shouldBeInvitedBySms() {
-    return (
-      this.organisationConfiguration.invitation_format === "sms" ||
-      this.organisationConfiguration.invitation_format === "sms_and_email"
-    );
+    return this.organisationConfiguration.invitation_formats.includes("sms");
   }
 
   shouldBeInvitedByEmail() {
-    return (
-      this.organisationConfiguration.invitation_format === "email" ||
-      this.organisationConfiguration.invitation_format === "sms_and_email"
-    );
+    return this.organisationConfiguration.invitation_formats.includes("email");
   }
 
   belongsToCurrentOrg() {

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -340,14 +340,12 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                     <th scope="col" style={{ whiteSpace: "nowrap" }}>
                       Création compte
                     </th>
-                    {(configuration.invitation_format === "sms" ||
-                      configuration.invitation_format === "sms_and_email") && (
+                    {configuration.invitation_formats.includes("sms") && (
                       <>
                         <th scope="col-3">Invitation SMS</th>
                       </>
                     )}
-                    {(configuration.invitation_format === "email" ||
-                      configuration.invitation_format === "sms_and_email") && (
+                    {configuration.invitation_formats.includes("email") && (
                       <>
                         <th scope="col-3">Invitation mail</th>
                       </>

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,5 +1,3 @@
 class Configuration < ApplicationRecord
   has_many :organisations, dependent: :nullify
-
-  enum invitation_format: { sms: 0, email: 1, sms_and_email: 2, link_only: 3, no_invitation: 4 }
 end

--- a/db/migrate/20220204162710_change_invitation_format_in_config.rb
+++ b/db/migrate/20220204162710_change_invitation_format_in_config.rb
@@ -4,15 +4,15 @@ class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
 
     Configuration.find_each do |config|
       case config.invitation_format
-      when "sms"
+      when 0
         config.invitation_formats = %w[sms]
-      when "email"
+      when 1
         config.invitation_formats = %w[email]
-      when "sms_and_email"
+      when 2
         config.invitation_formats = %w[sms email]
-      when "link_only"
+      when 3
         config.invitation_formats = %w[postal]
-      when "no_invitation"
+      when 4
         config.invitation_formats = []
       end
 
@@ -23,21 +23,21 @@ class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
   end
 
   def down
-    add_column :configurations, :invitation_format
+    add_column :configurations, :invitation_format, :integer
 
     Configuration.find_each do |config|
       case config.invitation_formats
-      when ["sms"]
+      when 0
         config.invitation_format = "sms"
-      when ["email"]
+      when 1
         config.invitation_format = "email"
-      when %w[sms email]
+      when 2
         config.invitation_format = "sms_and_email"
-      when %w[sms email postal]
-        config.invitation_format = "all"
-      when %w[postal]
+      when 3
         config.invitation_format = "link_only"
-      when []
+      when 4
+        config.invitation_format = "all"
+      when 5
         config.invitation_format = "no_invitation"
       end
 

--- a/db/migrate/20220204162710_change_invitation_format_in_config.rb
+++ b/db/migrate/20220204162710_change_invitation_format_in_config.rb
@@ -31,14 +31,12 @@ class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
         config.invitation_format = 0
       when ["email"]
         config.invitation_format = 1
-      when %w[sms email]
+      when %w[sms email] || %w[sms email postal]
         config.invitation_format = 2
       when %w[postal]
         config.invitation_format = 3
       when []
         config.invitation_format = 4
-      when %w[sms email postal]
-        config.invitation_format = 5
       end
 
       config.save!

--- a/db/migrate/20220204162710_change_invitation_format_in_config.rb
+++ b/db/migrate/20220204162710_change_invitation_format_in_config.rb
@@ -1,5 +1,5 @@
 class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
-  def change
+  def up
     add_column :configurations, :invitation_formats, :string, array: true, null: false, default: %w[sms email postal]
 
     Configuration.find_each do |config|
@@ -20,5 +20,30 @@ class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
     end
 
     remove_column :configurations, :invitation_format
+  end
+
+  def down
+    add_column :configurations, :invitation_format
+
+    Configuration.find_each do |config|
+      case config.invitation_formats
+      when ["sms"]
+        config.invitation_format = "sms"
+      when ["email"]
+        config.invitation_format = "email"
+      when %w[sms email]
+        config.invitation_format = "sms_and_email"
+      when %w[sms email postal]
+        config.invitation_format = "all"
+      when %w[postal]
+        config.invitation_format = "link_only"
+      when []
+        config.invitation_format = "no_invitation"
+      end
+
+      config.save!
+    end
+
+    remove_column :configurations, :invitation_formats, :string, array: true, null: false, default: %w[sms email postal]
   end
 end

--- a/db/migrate/20220204162710_change_invitation_format_in_config.rb
+++ b/db/migrate/20220204162710_change_invitation_format_in_config.rb
@@ -1,0 +1,24 @@
+class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
+  def change
+    add_column :configurations, :invitation_formats, :string, array: true, null: false, default: %w[sms email postal]
+
+    Configuration.find_each do |config|
+      case config.invitation_format
+      when "sms"
+        config.invitation_formats = %w[sms]
+      when "email"
+        config.invitation_formats = %w[email]
+      when "sms_and_email"
+        config.invitation_formats = %w[sms email]
+      when "link_only"
+        config.invitation_formats = %w[postal]
+      when "no_invitation"
+        config.invitation_formats = []
+      end
+
+      config.save!
+    end
+
+    remove_column :configurations, :invitation_format
+  end
+end

--- a/db/migrate/20220204162710_change_invitation_format_in_config.rb
+++ b/db/migrate/20220204162710_change_invitation_format_in_config.rb
@@ -27,18 +27,18 @@ class ChangeInvitationFormatInConfig < ActiveRecord::Migration[6.1]
 
     Configuration.find_each do |config|
       case config.invitation_formats
-      when 0
-        config.invitation_format = "sms"
-      when 1
-        config.invitation_format = "email"
-      when 2
-        config.invitation_format = "sms_and_email"
-      when 3
-        config.invitation_format = "link_only"
-      when 4
-        config.invitation_format = "all"
-      when 5
-        config.invitation_format = "no_invitation"
+      when ["sms"]
+        config.invitation_format = 0
+      when ["email"]
+        config.invitation_format = 1
+      when %w[sms email]
+        config.invitation_format = 2
+      when %w[postal]
+        config.invitation_format = 3
+      when []
+        config.invitation_format = 4
+      when %w[sms email postal]
+        config.invitation_format = 5
       end
 
       config.save!

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_170508) do
+ActiveRecord::Schema.define(version: 2022_02_04_162710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,11 +69,11 @@ ActiveRecord::Schema.define(version: 2022_01_26_170508) do
 
   create_table "configurations", force: :cascade do |t|
     t.string "sheet_name"
-    t.integer "invitation_format"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.json "column_names"
     t.boolean "notify_applicant", default: false
+    t.string "invitation_formats", default: ["sms", "email", "postal"], null: false, array: true
   end
 
   create_table "departments", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ agent.save!
 puts "Creating configurations..."
 Configuration.create!(
   sheet_name: "ENTRETIENS PHYSIQUES",
-  invitation_format: "sms",
+  invitation_formats: %w[sms email],
   organisation_id: Organisation.last.id,
   column_names: {
     required: {

--- a/spec/factories/configuration.rb
+++ b/spec/factories/configuration.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :configuration do
     sheet_name { 'LISTE DEMANDEURS' }
-    invitation_format { :sms }
+    invitation_formats { %w[sms] }
   end
 end


### PR DESCRIPTION
Dans cette PR, je change le type de la colonne `invitation_format` dans la table `configurations` en mettant un array/string à la place d'un enum/integer afin de gérer plus facilement les conditions d'affichages (comme suggéré en commentaire de l'issue #198). Je change également le nom de la colonne en `invitation_formats` car il s'agit désormais d'une array (+ `invitation_format` est parfois utilisé pour le `format` de l'invitation, par exemple dans `invitations_controller`, donc cela permet de mieux différencier).
Cette PR devra être mergée avant la PR concernant la "landing page" des invitations courrier et celle concernant l'ajout de la possibilité d'inviter par courrier sur la page upload.