### PR TITLE
fix(app): compact update applicant params

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -55,7 +55,7 @@ class ApplicantsController < ApplicationController
   def update
     @applicant.assign_attributes(
       organisations: (@applicant.organisations.to_a + [@organisation]).uniq,
-      **applicant_params
+      **applicant_params.compact_blank
     )
     authorize @applicant
     respond_to do |format|


### PR DESCRIPTION
Permet de ne pas prendre en compte les paramètres non rempli sur le formulaire (qui sont des strings vide `""`), et ainsi éviter une erreur d'unicité sur ces strings vides.