### PR TITLE
fix(app): update applicants params

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -55,7 +55,7 @@ class ApplicantsController < ApplicationController
   def update
     @applicant.assign_attributes(
       organisations: (@applicant.organisations.to_a + [@organisation]).uniq,
-      **applicant_params.compact_blank
+      **applicant_params
     )
     authorize @applicant
     respond_to do |format|

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -55,7 +55,7 @@ class ApplicantsController < ApplicationController
   def update
     @applicant.assign_attributes(
       organisations: (@applicant.organisations.to_a + [@organisation]).uniq,
-      **applicant_params
+      **formatted_params
     )
     authorize @applicant
     respond_to do |format|
@@ -67,7 +67,14 @@ class ApplicantsController < ApplicationController
   private
 
   def applicant_params
-    params.require(:applicant).permit(*PERMITTED_PARAMS)
+    params.require(:applicant).permit(*PERMITTED_PARAMS).to_h.deep_symbolize_keys
+  end
+
+  def formatted_params
+    # we nullify some blank params for unicity exceptions (ActiveRecord::RecordNotUnique) not to raise
+    applicant_params.to_h do |k, v|
+      [k, k.in?([:affiliation_number, :department_internal_id]) ? v.presence : v]
+    end
   end
 
   def save_applicant_and_redirect(page)

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -25,7 +25,7 @@ class Applicant < ApplicationRecord
 
   validates :uid, uniqueness: true, allow_nil: true
   validates :rdv_solidarites_user_id, uniqueness: true, allow_nil: true
-  validates :department_internal_id, uniqueness: { scope: :department_id }, allow_blank: true
+  validates :department_internal_id, uniqueness: { scope: :department_id }, allow_nil: true
   validates :last_name, :first_name, :title, presence: true
   validates :affiliation_number, presence: true, allow_nil: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -25,7 +25,7 @@ class Applicant < ApplicationRecord
 
   validates :uid, uniqueness: true, allow_nil: true
   validates :rdv_solidarites_user_id, uniqueness: true, allow_nil: true
-  validates :department_internal_id, uniqueness: { scope: :department_id }, allow_nil: true
+  validates :department_internal_id, uniqueness: { scope: :department_id }, allow_blank: true
   validates :last_name, :first_name, :title, presence: true
   validates :affiliation_number, presence: true, allow_nil: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }


### PR DESCRIPTION
Le fix appliqué dans #217 n'est pas bon car il empêche de nullifier un attribut d'un allocataire quand on le modifie.

Du coup je nullify directement les paramètres qu'on est obligé de nullifier (malheureusement on ne peut pas tous les nullifier, car nullifier les dates telle qu'on les passe - avec 3 valeurs - fait raiser la méthode `assign_attributes` d'ActiveRecord).