### PR TITLE
feat(invitations): forbid sms invitations for landlines numbers

### DIFF
--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -9,6 +9,10 @@ module HasPhoneNumberConcern
     Phonelib.parse(phone_number).e164
   end
 
+  def mobile_phone_number?
+    phone_number && Phonelib.parse(phone_number).types.include?(:mobile)
+  end
+
   private
 
   def validate_phone_number

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -19,7 +19,8 @@ module Invitations
     end
 
     def check_phone_number!
-      fail!("le téléphone doit être renseigné") if applicant.phone_number.blank?
+      fail!("Le téléphone doit être renseigné") if applicant.phone_number.blank?
+      fail!("Le numéro de téléphone doit être un mobile") unless applicant.mobile_phone_number?
     end
 
     def send_sms

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -62,7 +62,17 @@ describe Invitations::SendSms, type: :service do
       it("is a failure") { is_a_failure }
 
       it "returns the error" do
-        expect(subject.errors).to eq(["le téléphone doit être renseigné"])
+        expect(subject.errors).to eq(["Le téléphone doit être renseigné"])
+      end
+    end
+
+    context "when the phone number is not a mobile" do
+      let!(:phone_number) { '0123456789' }
+
+      it("is a failure") { is_a_failure }
+
+      it "returns the error" do
+        expect(subject.errors).to eq(["Le numéro de téléphone doit être un mobile"])
       end
     end
 


### PR DESCRIPTION
Dans cette PR, j'empêche l'envoi des invitations SMS si le numéro de téléphone est un téléphone fixe.