### PR TITLE
feat(front): add homepage link for invitations

### DIFF
--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -9,7 +9,7 @@ $orange-light: #ffb88e;
 $dark-blue: #083b66;
 $dark-blue-dim: #083c66ab;
 $light: #f9fbff;
-$green: #5EDA92 ;
+$green: #57EE93 ;
 
 $primary:$dark-blue;
 $danger: $orange;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "./components/title";
 @import "./components/color";
 @import "./components/stat";
+@import "./components/banner";
 @import "./fontawesome_imports";
 @import "tippy.js/dist/tippy.css";
 

--- a/app/javascript/stylesheets/components/_banner.scss
+++ b/app/javascript/stylesheets/components/_banner.scss
@@ -1,0 +1,13 @@
+.invitation-banner {
+  background-color: #5EDA92;
+  color: $dark-blue;
+  padding: 13px 0;
+  font-size: 1.1rem;
+  p {
+    margin: 0;
+  }
+  i {
+    display: inline;
+    color: white;
+  }
+}

--- a/app/javascript/stylesheets/components/_banner.scss
+++ b/app/javascript/stylesheets/components/_banner.scss
@@ -1,5 +1,5 @@
 .invitation-banner {
-  background-color: #5EDA92;
+  background-color: $green;
   color: $dark-blue;
   padding: 13px 0;
   font-size: 1.1rem;

--- a/app/javascript/stylesheets/components/_image.scss
+++ b/app/javascript/stylesheets/components/_image.scss
@@ -25,3 +25,10 @@
   }
 }
 
+@media (max-width: 325px) {
+  .rdvi-logo{
+    width: 140px;
+    padding-left: 0px;
+  }
+}
+

--- a/app/views/static_pages/welcome.html.erb
+++ b/app/views/static_pages/welcome.html.erb
@@ -1,3 +1,12 @@
+<%= link_to invitation_landing_path do %>
+  <div class="marianne invitation-banner">
+    <p class="invitation-banner text-center">
+      <i class="fas fa-solid fa-envelope"></i>
+        &nbsp;&nbsp;J'ai reçu par courrier une invitation à prendre rendez-vous&nbsp;&nbsp;
+      <i class="fas fa-solid fa-envelope"></i>
+    </p>
+  </div>
+<% end %>
 <div class="container-fluid mt-5 marianne">
   <div class="row justify-content-center mb-5">
     <div class="col-11 col-lg-5 welcome-title">


### PR DESCRIPTION
Dans cette PR, j'ajoute un lien très visible (sous forme de bannière) sur la page d'accueil pour les bénéficiaires qui auraient reçu l'invitation par courrier mais n'auraient pas tapé l'url exacte.

![image](https://user-images.githubusercontent.com/46218316/155702162-e36a1fd1-d946-40d2-8552-74169a04c64c.png)
