### PR TITLE
fix(new applicant): avoid raise when uid already exists

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -16,7 +16,7 @@ class Applicant < ApplicationRecord
   include HasPhoneNumberConcern
   include InvitableConcern
 
-  before_save :generate_uid
+  before_validation :generate_uid
 
   has_and_belongs_to_many :organisations
   has_many :invitations, dependent: :destroy

--- a/config/locales/models/applicant.fr.yml
+++ b/config/locales/models/applicant.fr.yml
@@ -29,3 +29,4 @@ fr:
         department_internal_id: ID interne au département
         rights_opening_date: Date d'entrée flux
         organisations: Organisation(s)
+        uid: Le couple numéro d'allocataire + rôle

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -47,7 +47,7 @@ describe Applicant do
         expect(applicant).not_to be_valid
         expect(applicant.errors.details).to eq({ uid: [{ error: :taken, value: '123' }] })
         expect(applicant.errors.full_messages.to_sentence)
-          .to include("Uid est déjà utilisé")
+          .to include("Le couple numéro d'allocataire + rôle est déjà utilisé")
       end
     end
   end
@@ -62,10 +62,10 @@ describe Applicant do
     context "colliding department internal id" do
       let!(:department) { create(:department) }
       let!(:applicant_existing) do
-        create(:applicant, department: department, department_internal_id: "921")
+        create(:applicant, department: department, department_internal_id: "921", role: "demandeur")
       end
       let!(:applicant) do
-        build(:applicant, department: department, department_internal_id: "921")
+        build(:applicant, department: department, department_internal_id: "921", role: "conjoint")
       end
 
       it "adds errors" do


### PR DESCRIPTION
Dans cette PR, je change le callback de `generate_uid` d'un `before_save` en un `before_validation` pour éviter un raise d'ActiveRecord en cas de doublon d'uid.
J'en profite également pour expliciter dans le yml, à destination des agents, ce à quoi correspond l'uid.