### PR TITLE
fix(monitoring): reduce sentry sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,9 +5,5 @@ Sentry.init do |config|
   # Set tracesSampleRate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production
-  # config.traces_sample_rate = 0.5
-  # or
-  config.traces_sampler = lambda do |_context|
-    true
-  end
+  config.traces_sample_rate = 0.05
 end


### PR DESCRIPTION
Je fixe l'envoi de transactions à Sentry utilisé pour le monitoring des performances à 5% pour réduire la consommation du quota de transactions (https://mattermost.incubateur.net/betagouv/pl/qgeyjnhu6383ub3unoc3ain5hw).