### PR TITLE
fix(pdf): change images path for pdf in production

### DIFF
--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -15,7 +15,7 @@ module PdfHelper
     if Rails.env.development?
       image_pack_tag(source)
     else
-      image_tag wicked_pdf_asset_pack_path(source)
+      image_tag wicked_pdf_asset_pack_path("media/images/#{source}")
     end
   end
 end


### PR DESCRIPTION
Dans cette PR, je modifie le path donné à wicked_pdf pour réparer un bug au moment de la génération du courrier d'invitation en production.