### PR TITLE
fix(webhooks): Nullify blank values in upsert record

### DIFF
--- a/app/services/upsert_record.rb
+++ b/app/services/upsert_record.rb
@@ -10,6 +10,7 @@ class UpsertRecord < BaseService
       @rdv_solidarites_attributes
         .slice(*@klass::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
         .compact
+        .transform_values(&:presence)
         .merge(@additional_attributes)
     )
     record.save! if record.changed?


### PR DESCRIPTION
I nullify blank values from webhooks to prevent these kind of errors: https://sentry.io/organizations/betagouv-f7/issues/2843211881/?project=5958991&query=is%3Aunresolved