### PR TITLE
fix(mailer): try to send email outside of promotions

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'RDV-Insertion <contact@rdv-insertion.fr>',
-          reply_to: 'data.insertion@beta.gouv.fr'
+  default from: 'RDV-Insertion <contact@rdv-insertion.fr>'
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -28,7 +28,7 @@
               <table width="100%">
                 <tr>
                   <td align="center" class="content-block">
-                    <%= link_to "https://doc.rdv-solidarites.fr/informations-generales/informations-generales-et-legales-1" do %>
+                    <%= link_to mentions_legales_url do %>
                       <span>Informations légales</span>
                     <% end %>
                   </td>


### PR DESCRIPTION
Lié à #96 .

J'enlève le `reply-to` et je mets les liens des mentions légales vers RDV-I plutôt que RDV-S dans les mails envoyés.
L'adresse de `reply-to` sera donc `contact@rdv-insertion.fr` qui redirige vers mon adresse (c'est d'ailleurs mieux que les mails de réponse des bRSA ne soient pas partagés entre tous les destinataires de `data.insertion@beta.gouv.fr`).

Si ça ne marche toujours pas la dernière qu'on pourrait tenter serait d'enlever ou de réduire les images présentes dans le mail.