### PR TITLE
feat(applicant): Validate uid or department internal id presence

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -30,6 +30,7 @@ class Applicant < ApplicationRecord
   validates :affiliation_number, presence: true, allow_nil: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
   validate :birth_date_validity
+  validate :uid_or_department_internal_id_presence
 
   enum role: { demandeur: 0, conjoint: 1 }
   enum title: { monsieur: 0, madame: 1 }
@@ -58,6 +59,12 @@ class Applicant < ApplicationRecord
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
     errors.add(:birth_date, "n'est pas valide")
+  end
+
+  def uid_or_department_internal_id_presence
+    return if department_internal_id.present? || (affiliation_number.present? && role.present?)
+
+    errors.add(:base, "le couple role/numéro allocataire ou l'ID interne au département doivent être présents.")
   end
 
   def action_required?

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -64,7 +64,7 @@ class Applicant < ApplicationRecord
   def uid_or_department_internal_id_presence
     return if department_internal_id.present? || (affiliation_number.present? && role.present?)
 
-    errors.add(:base, "le couple role/numéro allocataire ou l'ID interne au département doivent être présents.")
+    errors.add(:base, "le couple numéro d'allocataire + rôle ou l'ID interne au département doivent être présents.")
   end
 
   def action_required?

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -325,4 +325,24 @@ describe Applicant do
       end
     end
   end
+
+  describe "uid or department_internal_id presence" do
+    context "when an affiliation_number and a role is present" do
+      let(:applicant) { build(:applicant, role: "demandeur", affiliation_number: "KOKO", department_internal_id: nil) }
+
+      it { expect(applicant).to be_valid }
+    end
+
+    context "when a department_internal_id is present" do
+      let(:applicant) { build(:applicant, role: nil, affiliation_number: nil, department_internal_id: "32424") }
+
+      it { expect(applicant).to be_valid }
+    end
+
+    context "when no affiliation_number and no department_internal_id is present" do
+      let(:applicant) { build(:applicant, role: nil, affiliation_number: nil, department_internal_id: nil) }
+
+      it { expect(applicant).not_to be_valid }
+    end
+  end
 end


### PR DESCRIPTION
Je fais en sorte qu'il ne soit pas possible de créer un BRSA si l'`uid` ou le `department_interrnal_id` ne sont pas présents pour identifier le bRSA.