### PR TITLE
fix(invitation): Small adds on postal invitations

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -39,7 +39,7 @@ class InvitationsController < ApplicationController
   end
 
   def pdf_filename
-    "#{@applicant.last_name}_#{@applicant.first_name}_invitation_#{Time.now.to_i}.pdf"
+    "Invitation_#{Time.now.to_i}_#{@applicant.last_name}_#{@applicant.first_name}.pdf"
   end
 
   def save_and_send_invitation

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -12,7 +12,7 @@ class InvitationsController < ApplicationController
     )
     authorize @invitation
     if save_and_send_invitation.success?
-      return send_data pdf, filename: pdf_filename if @invitation.format == "postal"
+      return send_data pdf, filename: pdf_filename if @invitation.format_postal?
 
       render json: { success: true, invitation: @invitation }
     else
@@ -39,7 +39,7 @@ class InvitationsController < ApplicationController
   end
 
   def pdf_filename
-    "Invitation_#{Time.now.to_i}_#{@applicant.last_name}_#{@applicant.first_name}.pdf"
+    "#{@applicant.last_name}_#{@applicant.first_name}_invitation_#{Time.now.to_i}.pdf"
   end
 
   def save_and_send_invitation

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -98,7 +98,7 @@ class Applicant < ApplicationRecord
 
   def street_address
     split_address = address&.match(/^(.+) (\d{5}.*)$/)
-    split_address.present? ? split_address[1].strip.gsub(/-$/, '') : nil
+    split_address.present? ? split_address[1].strip.gsub(/-$/, '').gsub(/,$/, '').gsub(/.$/, '') : nil
   end
 
   def zipcode_and_city

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -154,7 +154,7 @@ describe InvitationsController, type: :controller do
           expect(response.headers["Content-Disposition"]).to start_with("attachment; filename=")
           first_name = applicant.first_name
           last_name = applicant.last_name
-          expect(response.headers["Content-Disposition"]).to end_with("_#{last_name}_#{first_name}.pdf")
+          expect(response.headers["Content-Disposition"]).to include("#{last_name}_#{first_name}_invitation")
         end
       end
     end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -154,7 +154,7 @@ describe InvitationsController, type: :controller do
           expect(response.headers["Content-Disposition"]).to start_with("attachment; filename=")
           first_name = applicant.first_name
           last_name = applicant.last_name
-          expect(response.headers["Content-Disposition"]).to include("#{last_name}_#{first_name}_invitation")
+          expect(response.headers["Content-Disposition"]).to end_with("_#{last_name}_#{first_name}.pdf")
         end
       end
     end


### PR DESCRIPTION
Je fais 2 mini changements sur les invitations: 

* Je mets le nom en premier dans le fichier, car + facile à rechercher dans les téléchargements
* J'enlève les `,` et les `.` en fin d'adresse en plus du `-`