### PR TITLE
refactor(mailer): Remove images from invitation email

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -4,38 +4,30 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <%= stylesheet_pack_tag 'mail' %>
   </head>
-
   <body>
     <table class="body-wrap">
-      <tr align="center" class="d-block">
-        <td class="logo d-block">
-          <%= image_pack_tag "logos/rdv-insertion.png", alt: "Logo rdv insertion" %>
-        </td>
+      <tr align="center" class="d-block py-2">
         <td class="container">
-          <div class="content">
-            <table class="main" width="100%">
-              <tr>
-                <td class="content-wrap">
-                  <table width="100%">
-                    <tbody>
-                      <%= yield %>
-                    </tbody>
-                  </table>
-                </td>
-              </tr>
-            </table>
-            <div class="footer">
-              <table width="100%">
-                <tr>
-                  <td align="center" class="content-block">
-                    <%= link_to mentions_legales_url do %>
-                      <span>Informations légales</span>
-                    <% end %>
-                  </td>
-                </tr>
-              </table>
-            </div>
-          </div>
+          <table class="main content" width="100%">
+            <tr>
+              <td class="content-wrap">
+                <table width="100%">
+                  <tbody>
+                    <%= yield %>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+          </table>
+          <table width="100%" class="footer">
+            <tr>
+              <td align="center" class="content-block">
+                <%= link_to mentions_legales_url do %>
+                  <span>Informations légales</span>
+                <% end %>
+              </td>
+            </tr>
+          </table>
         </td>
       </tr>
     </table>

--- a/app/views/mailers/invitation_mailer/first_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/first_invitation.html.erb
@@ -9,8 +9,3 @@
 <p>En cas de problème technique, contactez le <%= @invitation.help_phone_number_formatted %></p>
 <p>À bientôt,</p>
 <p>Le département <%= I18n.t("with_prefix.#{@invitation.department.pronoun}", name: @invitation.department.name) %>.</p>
-<% if File.exist?("app/javascript/images/logos/#{@invitation.department.name.parameterize}.svg") %>
-  <%= image_pack_tag "logos/#{@invitation.department.name.parameterize}.svg", alt: "Logo du département", class: "department-logo" %>
-<% elsif File.exist?("app/javascript/images/logos/#{@invitation.department.name.parameterize}.png") %>
-  <%= image_pack_tag "logos/#{@invitation.department.name.parameterize}.png", alt: "Logo du département", class: "department-logo" %>
-<% end %>


### PR DESCRIPTION
Dans cette PR j'enlève les images du logo de RDV-I et du département comme dernière tentative de déplacer les mails de l'onglet "promotions" de gmail (#96)

## Preview

<img width="1609" alt="image" src="https://user-images.githubusercontent.com/7602809/156584699-80393506-d88f-4ad3-b376-1cae131d42b7.png">
