### PR TITLE
feat(app): add teleprocedure information page

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,6 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_agent!, only: [:welcome, :legal_notice, :privacy_policy, :accessibility]
+  skip_before_action :authenticate_agent!, only: [:welcome, :legal_notice, :privacy_policy,
+                                                  :accessibility, :teleprocedure]
 
   def welcome
     redirect_to(organisations_path) if logged_in?
@@ -19,4 +20,8 @@ class StaticPagesController < ApplicationController
   def privacy_policy; end
 
   def accessibility; end
+
+  def teleprocedure
+    @department = Department.find_by(number: params[:department_number])
+  end
 end

--- a/app/javascript/stylesheets/components/_image.scss
+++ b/app/javascript/stylesheets/components/_image.scss
@@ -18,10 +18,18 @@
   width: 100%;
 }
 
+.teleprocedure-department-logo {
+  width: 500px;
+}
+
 @media (max-width: 400px) {
   .rdvi-logo{
     width: 150px;
     padding-left: 0px;
+  }
+
+  .teleprocedure-department-logo {
+    width: 80%;
   }
 }
 

--- a/app/views/common/_header.html.erb
+++ b/app/views/common/_header.html.erb
@@ -18,7 +18,7 @@
         </div>
       <% end %>
       <div class="ml-5 d-flex align-items-center">
-        <% unless logged_in? || controller_name.include?("sessions") %>
+        <% unless logged_in? || controller_name.include?("sessions") || controller.action_name.include?("teleprocedure") %>
           <div class="text-center mx-3 col">
             <%= link_to sign_in_path do %>
               <button class="btn btn-default btn-blue w-100">
@@ -31,7 +31,7 @@
       </div>
     </div>
   </nav>
-  <% unless logged_in? || controller.controller_name.include?("sessions") %>
+  <% unless logged_in? || controller.controller_name.include?("sessions") || controller.action_name.include?("teleprocedure") %>
     <div class="sub-header d-none d-md-flex marianne">
       <div class="container d-none d-md-flex ">
         <%= link_to "https://communaute.inclusion.beta.gouv.fr/", class: "nav-link optional-link ", target: :blank, rel: "noopener noreferrer" do %>

--- a/app/views/static_pages/teleprocedure.html.erb
+++ b/app/views/static_pages/teleprocedure.html.erb
@@ -1,0 +1,9 @@
+<div class="container marianne text-dark-blue mb-5">
+  <div class="welcome-title justify-content-around mt-5 flex-wrap text-center">
+    <h1 class="pb-3">INFORMATION - RSA</h1>
+    <%= image_pack_tag "logos/#{@department.name.parameterize}.svg", alt: "Logo Département", class: "teleprocedure-department-logo" %>
+  </div>
+  <div class="text-center pb-3">
+    <%= render partial: "static_pages/teleprocedure_message/#{@department.number}" %>
+  </div>
+</div>

--- a/app/views/static_pages/teleprocedure_message/_13.html.erb
+++ b/app/views/static_pages/teleprocedure_message/_13.html.erb
@@ -1,0 +1,6 @@
+<h3 class="pt-3 pb-5">Si vous résidez dans l’une des 29 communes listées ci-dessous, vous êtes concerné par une expérimentation du Conseil départemental des Bouches-du-Rhône visant à faciliter votre prise de rendez-vous RSA.</h3>
+<h5>À la suite de votre demande de RSA, un email et/ou un SMS va vous être transmis par le Conseil départemental pour fixer un premier rendez-vous d’orientation. Veuillez cliquer sur le lien contenu dans ce mail/SMS pour choisir un créneau à votre convenance.</h5>
+<br/>
+<p><u>Communes concernées&nbsp;:</u><mark> Arles, Aureille, Barbentane, Baux-de-Provence, Boulbon, Cabannes, Chateaurenard, Eygalières, Eyragues, Fontvieille, Graveson, Maillane, Mas-Blanc-des-Alpilles, Maussane-les-Alpilles, Saint-Pierre-de-Mézoargues, Molleges, Mouries, Noves, Orgon, Paradou, Plan-d'Orgon, Rognonas, Saint-Andiol, Saint-Etienne-du-Gres, Saintes-Maries-de-la-Mer, Saint-Martin-de-Crau, Saint-Rémy-de-Provence, Tarascon, Verquieres.</mark></p>
+<br/>
+<p>Si vous ne résidez pas dans l’une des 29 communes listées ci-dessus, vous n’êtes pas concerné par ces modalités de prise de rendez-vous et serez convié à votre rendez-vous d’orientation par courrier postal avec accusé de réception.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,11 @@ Rails.application.routes.draw do
   get "mentions-legales", to: "static_pages#legal_notice"
   get "politique-de-confidentialite", to: "static_pages#privacy_policy"
   get "accessibilite", to: "static_pages#accessibility"
+  resources :teleprocedure, param: "department_number",
+                            path: '/parcours-insertion',
+                            to: "static_pages#teleprocedure",
+                            as: :teleprocedure, only: [:show]
+
   resources :organisations, only: [:index] do
     get :geolocated, on: :collection
     resources :applicants, only: [:index, :create, :show, :update, :edit, :new] do
@@ -43,11 +48,6 @@ Rails.application.routes.draw do
       resources :invitations, only: [:create]
     end
   end
-
-  resources :parcours_insertion, param: "department_number",
-                                 path: '/parcours-insertion',
-                                 to: "static_pages#teleprocedure",
-                                 as: :teleprocedure
 
   namespace :api do
     namespace :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,11 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :parcours_insertion, param: "department_number",
+                                 path: '/parcours-insertion',
+                                 to: "static_pages#teleprocedure",
+                                 as: :teleprocedure
+
   namespace :api do
     namespace :v1 do
       resources :organisations, param: "rdv_solidarites_organisation_id", only: [] do

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,6 +1,7 @@
 describe StaticPagesController, type: :controller do
   render_views
 
+  let!(:department) { create(:department, number: "13", name: "Bouches-du-Rhône") }
   let!(:organisation) { create(:organisation) }
   let!(:agent) { create(:agent, organisations: [organisation]) }
 
@@ -39,6 +40,13 @@ describe StaticPagesController, type: :controller do
   describe "GET #legal_notice" do
     it "returns a success response" do
       get :legal_notice
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #teleprocedure" do
+    it "returns a success response" do
+      get :teleprocedure, params: { to: "static_pages#teleprocedure", department_number: "13" }
       expect(response).to be_successful
     end
   end


### PR DESCRIPTION
Dans cette PR, j'ajoute les pages d'information à destination des bRSA en fin de téléprocédure (pour l'instant uniquement pour les Bouches-du-Rhône). Le message affiché risquant d'être très custom à chaque fois (par exemple, ici, une liste de villes), je passe par une partial pour la partie principale partie du contenu.

![image](https://user-images.githubusercontent.com/46218316/156810454-aca1953f-7cc6-4120-9150-a76258e39757.png)
![image](https://user-images.githubusercontent.com/46218316/156810523-5f6517c3-dbe5-43a4-8c0d-c7bacaa5e703.png)
