### PR TITLE
fix(applicant): Consider department in find or initialize service

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -85,7 +85,8 @@ class ApplicantsController < ApplicationController
     @find_or_initialize_applicant ||= FindOrInitializeApplicant.call(
       department_internal_id: applicant_params[:department_internal_id],
       role: applicant_params[:role],
-      affiliation_number: applicant_params[:affiliation_number]
+      affiliation_number: applicant_params[:affiliation_number],
+      department_id: @department.id
     )
   end
 

--- a/app/services/find_or_initialize_applicant.rb
+++ b/app/services/find_or_initialize_applicant.rb
@@ -1,8 +1,9 @@
 class FindOrInitializeApplicant < BaseService
-  def initialize(department_internal_id:, role:, affiliation_number:)
+  def initialize(department_internal_id:, role:, affiliation_number:, department_id:)
     @department_internal_id = department_internal_id
     @role = role
     @affiliation_number = affiliation_number
+    @department_id = department_id
   end
 
   def call
@@ -20,7 +21,7 @@ class FindOrInitializeApplicant < BaseService
   def find_applicant_by_department_internal_id
     return if @department_internal_id.blank?
 
-    Applicant.find_by(department_internal_id: @department_internal_id)
+    Applicant.find_by(department_internal_id: @department_internal_id, department_id: @department_id)
   end
 
   def find_applicant_by_role_and_affiliation_number
@@ -28,7 +29,8 @@ class FindOrInitializeApplicant < BaseService
 
     Applicant.find_by(
       affiliation_number: @affiliation_number,
-      role: @role
+      role: @role,
+      department_id: @department_id
     )
   end
 end

--- a/spec/services/find_or_initialize_applicant_spec.rb
+++ b/spec/services/find_or_initialize_applicant_spec.rb
@@ -1,81 +1,54 @@
 describe FindOrInitializeApplicant, type: :service do
   subject do
     described_class.call(
-      department_internal_id: applicant_params[:department_internal_id],
-      role: applicant_params[:role],
-      affiliation_number: applicant_params[:affiliation_number]
+      department_internal_id: department_internal_id,
+      role: role,
+      affiliation_number: affiliation_number,
+      department_id: department_id
     )
   end
 
-  let(:applicant_params) do
-    {
-      first_name: "john", last_name: "doe", email: "johndoe@example.com",
-      affiliation_number: "1234", role: "conjoint", department_internal_id: "6789"
-    }
-  end
+  let!(:department_internal_id) { "6789" }
+  let!(:role) { "demandeur" }
+  let!(:affiliation_number) { "1234" }
   let!(:organisation) { create(:organisation) }
-  let!(:another_organisation) { create(:organisation) }
-  let(:applicant) { create(:applicant, organisations: [another_organisation]) }
+  let!(:department) { create(:department, id: department_id) }
+  let!(:department_id) { 22 }
+  let!(:another_department) { create(:department) }
 
   describe "#call" do
-    before do
-      allow(Applicant).to receive(:find_by)
-        .and_return(applicant)
-    end
-
     it("is a success") { is_a_success }
 
-    it "returns an applicant" do
-      expect(subject.applicant).to eq(applicant)
-    end
+    context "when an applicant with the same department internal id exists" do
+      let!(:applicant) { create(:applicant, department: department, department_internal_id: department_internal_id) }
 
-    context "when department internal id is present" do
-      it "search for an applicant with department internal id" do
-        expect(Applicant).to receive(:find_by)
-          .with(department_internal_id: "6789")
-        subject
+      it "returns the found applicant" do
+        expect(subject.applicant).to eq(applicant)
       end
 
-      context "when an applicant is found" do
-        it "does not search for an applicant with role and affiliation number" do
-          expect(Applicant).not_to receive(:find_by)
-            .with(role: "conjoint", affiliation_number: "1234")
-          subject
-        end
-      end
+      context "for another department" do
+        let!(:applicant) { create(:applicant, department: another_department, department_internal_id: department_internal_id) }
 
-      context "when no applicant is found" do
-        context "when role and affiliation number are present" do
-          let(:applicant_params) do
-            {
-              first_name: "john", last_name: "doe", email: "johndoe@example.com",
-              affiliation_number: "1234", role: "conjoint"
-            }
-          end
-
-          it "searches for an applicant with role and affiliation number" do
-            expect(Applicant).to receive(:find_by)
-              .with(role: "conjoint", affiliation_number: "1234")
-            subject
-          end
-        end
-
-        context "when role and affiliation number are not present" do
-          it "does not search for an applicant with role and affiliation number" do
-            expect(Applicant).not_to receive(:find_by)
-              .with(role: "conjoint", affiliation_number: "1234")
-            subject
-          end
+        it "does not return the existing applicant" do
+          expect(subject).not_to eq(applicant)
         end
       end
     end
 
-    context "when no applicant is found" do
-      before do
-        allow(Applicant).to receive(:find_by)
-          .and_return(nil)
-        allow(Applicant).to receive(:new)
+    context "when an applicant with the same affiliation_number and role exists" do
+      let!(:applicant) do
+        create(:applicant, department: department, role: role, affiliation_number: affiliation_number)
       end
+
+      it "returns the found applicant" do
+        expect(subject.applicant).to eq(applicant)
+      end
+    end
+
+    context "when no applicant with these attributes exist" do
+      let!(:applicant) { build(:applicant) }
+
+      before { allow(Applicant).to receive(:new).and_return(applicant) }
 
       it "initializes an applicant" do
         expect(Applicant).to receive(:new)

--- a/spec/services/find_or_initialize_applicant_spec.rb
+++ b/spec/services/find_or_initialize_applicant_spec.rb
@@ -27,7 +27,9 @@ describe FindOrInitializeApplicant, type: :service do
       end
 
       context "for another department" do
-        let!(:applicant) { create(:applicant, department: another_department, department_internal_id: department_internal_id) }
+        let!(:applicant) do
+          create(:applicant, department: another_department, department_internal_id: department_internal_id)
+        end
 
         it "does not return the existing applicant" do
           expect(subject).not_to eq(applicant)


### PR DESCRIPTION
2 personnes différentes peuvent potentiellement avoir le même ID interne ou le même numéro CAF si elles sont dans 2 départements différents.
Je prends donc en compte l'ID du département dans le `FindOrInitializeApplicant` service.