### PR TITLE
fix(app): do not require uids on search

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -150,7 +150,7 @@ class ApplicantsController < ApplicationController
     @applicants = policy_scope(Applicant).includes(:organisations, :invitations, :rdvs).distinct
     @applicants = @applicants
                   .where(department_internal_id: params.require(:applicants)[:department_internal_ids])
-                  .or(@applicants.where(uid: params[:applicants].require(:uids)))
+                  .or(@applicants.where(uid: params.require(:applicants)[:uids]))
                   .to_a
   end
 end


### PR DESCRIPTION
Certains départements comme la Manche ont l'ID interne au département dans leur fichier mais pas le couple numéro allocataire / rôle. 
Dans ces cas-là il faut pas qu'on ait une erreur.