### PR TITLE
refactor(jsapp): Remove warning when no role or affiliation number

### DIFF
--- a/app/javascript/react/lib/handleApplicantCreation.js
+++ b/app/javascript/react/lib/handleApplicantCreation.js
@@ -1,37 +1,7 @@
 import Swal from "sweetalert2";
-import confirmationModal from "../../lib/confirmationModal";
 import createApplicant from "../actions/createApplicant";
 
-const displayDuplicationWarning = async (applicant, organisationId) => {
-  let warningMessage = "";
-
-  if (!applicant.affiliationNumber) {
-    warningMessage =
-      "Le numéro d'allocataire n'est pas spécifié (si c'est un NIR il a été filtré).";
-  } else if (!applicant.role) {
-    warningMessage = "Le rôle de l'allocataire n'est pas spécifié.";
-  }
-
-  const searchApplicantLink = new URL(
-    `${window.location.origin}/organisations/${organisationId}/applicants`
-  );
-  searchApplicantLink.searchParams.set("search_query", applicant.lastName);
-
-  return confirmationModal(
-    `${warningMessage}\nVérifiez <a class="light-blue" href="${searchApplicantLink.href}" target="_blank">ici</a>` +
-      " que l'allocataire n'a pas déjà été créé avant de continuer.",
-    {
-      confirmButtonText: "Créer",
-      cancelButtonText: "Annuler",
-    }
-  );
-};
-
 const handleApplicantCreation = async (applicant, organisationId) => {
-  if (!applicant.affiliationNumber || !applicant.role) {
-    const confirmation = await displayDuplicationWarning(applicant, organisationId);
-    if (!confirmation.isConfirmed) return;
-  }
   const result = await createApplicant(applicant, organisationId);
   if (result.success) {
     applicant.updateWith(result.applicant);


### PR DESCRIPTION
J'enlève le warning à la création lorsqu'on on a pas de numéro d'allocataire ou de rôle, puisque de toutes façons on est obligés maintenant d'avoir soit le couple numéro allocataire/rôle soit l'ID interne au département, et dans le cas de la manche on utilise que l'ID interne.
