### PR TITLE
fix(app): format phone numbers correctly for outre mer

### DIFF
--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -1,3 +1,5 @@
+# Concern to include in application models
+# Models need to have a :phone_number and a :phone_number_formatted attributes
 module HasPhoneNumberConcern
   extend ActiveSupport::Concern
 
@@ -5,37 +7,47 @@ module HasPhoneNumberConcern
     validate :validate_phone_number
   end
 
+  # See issue #1471 in RDV-Solidarités. This setup allows:
+  # * international (e164) phone numbers
+  # * “french format” (ten digits with a leading 0)
+  # However, we need to special-case some ten-digit numbers,
+  # because the ARCEP assigns some blocks of "O6 XX XX XX XX" numbers to DROM operators.
+  # Guadeloupe | GP | +590 | 0690XXXXXX, 0691XXXXXX
+  # Guyane     | GF | +594 | 0694XXXXXX
+  # Martinique | MQ | +596 | 0696XXXXXX, 0697XXXXXX
+  # Réunion    | RE | +262 | 0692XXXXXX, 0693XXXXXX
+  # Mayotte    | YT | +262 | 0692XXXXXX, 0693XXXXXX
+  # Cf: Plan national de numérotation téléphonique,
+  # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
+  COUNTRY_CODES = [:FR, :GP, :GF, :MQ, :RE, :YT].freeze
+
   def phone_number_formatted
-    Phonelib.parse(phone_number).e164
+    parsed_number(phone_number)&.e164
   end
-
-  def mobile_phone_number?
-    phone_number && Phonelib.parse(phone_number).types.include?(:mobile)
-  end
-
-  private
 
   def validate_phone_number
-    errors.add(:phone_number, :invalid) if phone_number.present? && !phone_number_is_valid?
+    return if phone_number.blank?
+
+    errors.add(:phone_number, :invalid) unless phone_number_is_valid?
   end
 
   def phone_number_is_valid?
-    return false if phone_number.blank?
+    parsed_number(phone_number).present?
+  end
 
-    parsed_number = Phonelib.parse(phone_number)
-    country_codes = [:FR, :GP, :GF, :MQ, :RE, :YT]
-    # See issue #1471 in RDV-Solidarités. This setup allows:
-    # * international (e164) phone numbers
-    # * “french format” (ten digits with a leading 0)
-    # However, we need to special-case some ten-digit numbers,
-    # because the ARCEP assigns some blocks of "O6 XX XX XX XX" numbers to DROM operators.
-    # Guadeloupe | GP | +590 | 0690XXXXXX, 0691XXXXXX
-    # Guyane     | GF | +594 | 0694XXXXXX
-    # Martinique | MQ | +596 | 0696XXXXXX, 0697XXXXXX
-    # Réunion    | RE | +262 | 0692XXXXXX, 0693XXXXXX
-    # Mayotte    | YT | +262 | 0692XXXXXX, 0693XXXXXX
-    # Cf: Plan national de numérotation téléphonique,
-    # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
-    parsed_number.valid? || country_codes.any?{ parsed_number.valid_for_country? _1 }
+  def phone_number_is_mobile?
+    types = parsed_number(phone_number)&.types
+    types&.include?(:mobile)
+  end
+
+  def parsed_number(phone_number)
+    return if phone_number.blank?
+
+    COUNTRY_CODES.each do |country_code|
+      parsed_attempt = Phonelib.parse(phone_number, country_code)
+      return parsed_attempt if parsed_attempt.valid?
+    end
+
+    nil
   end
 end

--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -7,6 +7,7 @@ module HasPhoneNumberConcern
     validate :validate_phone_number
   end
 
+  COUNTRY_CODES = [:FR, :GP, :GF, :MQ, :RE, :YT].freeze
   # See issue #1471 in RDV-Solidarités. This setup allows:
   # * international (e164) phone numbers
   # * “french format” (ten digits with a leading 0)
@@ -19,11 +20,17 @@ module HasPhoneNumberConcern
   # Mayotte    | YT | +262 | 0692XXXXXX, 0693XXXXXX
   # Cf: Plan national de numérotation téléphonique,
   # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
-  COUNTRY_CODES = [:FR, :GP, :GF, :MQ, :RE, :YT].freeze
 
   def phone_number_formatted
     parsed_number(phone_number)&.e164
   end
+
+  def phone_number_is_mobile?
+    types = parsed_number(phone_number)&.types
+    types&.include?(:mobile)
+  end
+
+  private
 
   def validate_phone_number
     return if phone_number.blank?
@@ -33,11 +40,6 @@ module HasPhoneNumberConcern
 
   def phone_number_is_valid?
     parsed_number(phone_number).present?
-  end
-
-  def phone_number_is_mobile?
-    types = parsed_number(phone_number)&.types
-    types&.include?(:mobile)
   end
 
   def parsed_number(phone_number)

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -20,7 +20,7 @@ module Invitations
 
     def check_phone_number!
       fail!("Le téléphone doit être renseigné") if applicant.phone_number.blank?
-      fail!("Le numéro de téléphone doit être un mobile") unless applicant.mobile_phone_number?
+      fail!("Le numéro de téléphone doit être un mobile") unless applicant.phone_number_is_mobile?
     end
 
     def send_sms

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -76,6 +76,12 @@ describe Invitations::SendSms, type: :service do
       end
     end
 
+    context "when the phone number is not a metropolitan mobile" do
+      let!(:phone_number) { '0692926878' }
+
+      it("is a success") { is_a_success }
+    end
+
     context "when the invitation format is not sms" do
       let!(:invitation) do
         create(:invitation, applicant: applicant, format: "email")


### PR DESCRIPTION
Dans cette PR, je modifie le `HasPhoneNumberConcern` afin que les sms soient bien envoyés aux utilisateurs ayant un numéro de portable en outre mer.