### PR TITLE
fix(routes): teleprocedure path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get "accessibilite", to: "static_pages#accessibility"
 
   resources :teleprocedure_landings, param: "department_number",
-                                     path: '/parcours-insertion',
+                                     path: '/parcours_insertion',
                                      only: [:show]
 
   resources :organisations, only: [:index] do


### PR DESCRIPTION
Dans cette PR, je corrige l'url de la page de fin de téléprocédure afin de coller à ce qui a été déployée par la CNAF.