### PR TITLE
feat(invitation letter): add letter configuration table and default signature

### DIFF
--- a/app/models/letter_configuration.rb
+++ b/app/models/letter_configuration.rb
@@ -1,0 +1,4 @@
+class LetterConfiguration < ApplicationRecord
+  has_many :organisations, dependent: :nullify
+  validates :direction_names, :motif, presence: true
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -11,6 +11,7 @@ class Organisation < ApplicationRecord
   has_and_belongs_to_many :invitations, dependent: :nullify
   belongs_to :configuration
   belongs_to :responsible, optional: true
+  belongs_to :letter_configuration, optional: true
   has_many :rdvs, dependent: :nullify
 
   delegate :notify_applicant?, to: :configuration

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -7,6 +7,7 @@ module Invitations
     def call
       check_invitation_format!
       check_address!
+      check_letter_configuration!
       generate_letter
     end
 
@@ -20,7 +21,8 @@ module Invitations
           invitation: @invitation,
           department: @invitation.department,
           applicant: applicant,
-          organisation: @invitation.organisations.last
+          organisation: @invitation.organisations.last,
+          letter_configuration: letter_configuration
         }
       )
     end
@@ -34,6 +36,10 @@ module Invitations
       fail!("Le format de l'adresse est invalide") if street_address.blank? || zipcode_and_city.blank?
     end
 
+    def check_letter_configuration!
+      fail!("La configuration des courriers pour votre organisation est incomplète") if letter_configuration.blank?
+    end
+
     def address
       applicant.address
     end
@@ -44,6 +50,10 @@ module Invitations
 
     def zipcode_and_city
       applicant.zipcode_and_city
+    end
+
+    def letter_configuration
+      @invitation.organisations.last&.letter_configuration
     end
 
     def applicant

--- a/app/views/invitations/invitation_letter.html.erb
+++ b/app/views/invitations/invitation_letter.html.erb
@@ -3,12 +3,12 @@
     <div class="logo">
       <%= pdf_image_tag("logos/#{department.name.parameterize}.svg") %>
     </div>
-    <% department.direction_names&.each do |sender_name| %>
-      <p><%= sender_name.upcase %></p>
+    <% department.direction_names&.each do |direction_name| %>
+      <p><%= direction_name.upcase %></p>
     <% end %>
   </div>
   <div class="right-col">
-    <%# Remplacer par une varialbe organisation.city ? %>
+    <%# Remplacer par une variable organisation.city ? %>
     <p><%= department.capital %>, le <%= Date.today.strftime('%d/%m/%Y') %></p>
     <br/>
     <p>À l'attention de</p>

--- a/app/views/invitations/invitation_letter.html.erb
+++ b/app/views/invitations/invitation_letter.html.erb
@@ -3,14 +3,12 @@
     <div class="logo">
       <%= pdf_image_tag("logos/#{department.name.parameterize}.svg") %>
     </div>
-    <%# Remplacer par une variable department.direction_name ? %>
-    <p>DIRECTION GÉNÉRALE DES SERVICES DÉPARTEMENTAUX</p>
-    <p>DIRECTION DE L’INSERTION ET DU RETOUR À L’EMPLOI</p>
-    <%# Remplacer par une variable department.service_name ? %>
-    <p>SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI</p>
+    <% department.direction_names&.each do |sender_name| %>
+      <p><%= sender_name.upcase %></p>
+    <% end %>
   </div>
   <div class="right-col">
-    <%# Remplacer par une variable department.city ou @organisation.city ? %>
+    <%# Remplacer par une varialbe organisation.city ? %>
     <p><%= department.capital %>, le <%= Date.today.strftime('%d/%m/%Y') %></p>
     <br/>
     <p>À l'attention de</p>

--- a/app/views/invitations/invitation_letter.html.erb
+++ b/app/views/invitations/invitation_letter.html.erb
@@ -3,7 +3,7 @@
     <div class="logo">
       <%= pdf_image_tag("logos/#{department.name.parameterize}.svg") %>
     </div>
-    <% letter_configuration.direction_names&.each do |direction_name| %>
+    <% letter_configuration.direction_names.each do |direction_name| %>
       <p><%= direction_name.upcase %></p>
     <% end %>
   </div>

--- a/app/views/invitations/invitation_letter.html.erb
+++ b/app/views/invitations/invitation_letter.html.erb
@@ -3,13 +3,12 @@
     <div class="logo">
       <%= pdf_image_tag("logos/#{department.name.parameterize}.svg") %>
     </div>
-    <% department.direction_names&.each do |direction_name| %>
+    <% letter_configuration.direction_names&.each do |direction_name| %>
       <p><%= direction_name.upcase %></p>
     <% end %>
   </div>
   <div class="right-col">
-    <%# Remplacer par une variable organisation.city ? %>
-    <p><%= department.capital %>, le <%= Date.today.strftime('%d/%m/%Y') %></p>
+    <p><%= letter_configuration.sender_city || department.capital %>, le <%= Date.today.strftime('%d/%m/%Y') %></p>
     <br/>
     <p>À l'attention de</p>
     <br/><br/>
@@ -20,7 +19,7 @@
 </div>
 <div class="mail-object">
     <%# Remplacer par une variable @motif ? %>
-  <p class="bold-blue"><span class="bold-blue">Objet : Rendez-vous d’orientation dans le cadre de votre RSA</span></p>
+  <p class="bold-blue"><span class="bold-blue">Objet : <%= letter_configuration.motif %></span></p>
   <% if applicant.affiliation_number %>
     <p>N° allocataire : <%= applicant.affiliation_number %></p>
   <% end %>
@@ -35,14 +34,15 @@
   <p>Dans le cadre du versement de votre allocation RSA, vous devez obligatoirement prendre ce rendez-vous dans un délai de 15 jours à réception de ce courrier.</p>
   <p>Si vous rencontrez une difficulté pour accéder à internet, veuillez téléphoner dès réception de ce courrier au <%= invitation.help_phone_number_formatted %>.</p>
   <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
-  <% if organisation.responsible.present? %>
-    <div class="letter-signature">
+  <div class="letter-signature">
+    <% if organisation.responsible.present? %>
       <p>Pour le Président du Conseil départemental et par délégation,<br/>
       <%= organisation.responsible.full_name %>, <%= organisation.responsible.role %></p>
-    </div>
-  <% else %>
-    <br/><br/>
-  <% end %>
+    <% else %>
+      <p>Le département <%= I18n.t("with_prefix.#{department.pronoun}", name: @invitation.department.name) %></p>
+      <br/>
+    <% end %>
+  </div>
 </div>
 <div>
   <div class="left-col logo">

--- a/db/migrate/20220328173945_add_direction_names_to_department.rb
+++ b/db/migrate/20220328173945_add_direction_names_to_department.rb
@@ -1,9 +1,0 @@
-class AddDirectionNamesToDepartment < ActiveRecord::Migration[6.1]
-  def up
-    add_column :departments, :direction_names, :string, array: true
-  end
-
-  def down
-    remove_column :departments, :direction_names, :string, array: true
-  end
-end

--- a/db/migrate/20220328173945_add_direction_names_to_department.rb
+++ b/db/migrate/20220328173945_add_direction_names_to_department.rb
@@ -1,0 +1,9 @@
+class AddDirectionNamesToDepartment < ActiveRecord::Migration[6.1]
+  def up
+    add_column :departments, :direction_names, :string, array: true
+  end
+
+  def down
+    remove_column :departments, :direction_names, :string, array: true
+  end
+end

--- a/db/migrate/20220328173945_create_letter_configurations.rb
+++ b/db/migrate/20220328173945_create_letter_configurations.rb
@@ -1,0 +1,31 @@
+class CreateLetterConfigurations < ActiveRecord::Migration[6.1]
+  def up
+    create_table :letter_configurations do |t|
+      t.string :direction_names, array: true
+      t.string :sender_city
+      t.string :motif, default: "Rendez-vous d’orientation dans le cadre de votre RSA"
+
+      t.timestamps
+    end
+
+    add_reference :organisations, :letter_configuration, foreign_key: true
+
+    # assign a default letter_configuration for organisations who already have postal invitations
+    postal_configurations = Configuration.where("invitation_formats && ?", "{postal}")
+    postal_organisations = Organisation.where(configuration_id: postal_configurations.pluck(:id))
+    lc = LetterConfiguration.create!(direction_names: [
+                                       "DIRECTION GÉNÉRALE DES SERVICES DÉPARTEMENTAUX",
+                                       "DIRECTION DE L’INSERTION ET DU RETOUR À L’EMPLOI",
+                                       "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"
+                                     ])
+    postal_organisations.each do |o|
+      o.letter_configuration = lc
+      o.save!
+    end
+  end
+
+  def down
+    remove_reference :organisations, :letter_configuration
+    drop_table :letter_configurations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,7 +86,6 @@ ActiveRecord::Schema.define(version: 2022_03_28_173945) do
     t.string "pronoun"
     t.string "email"
     t.string "phone_number"
-    t.string "direction_names", array: true
   end
 
   create_table "invitations", force: :cascade do |t|
@@ -112,6 +111,14 @@ ActiveRecord::Schema.define(version: 2022_03_28_173945) do
     t.index ["organisation_id", "invitation_id"], name: "index_invitations_orgas_on_orga_id_and_invitation_id", unique: true
   end
 
+  create_table "letter_configurations", force: :cascade do |t|
+    t.string "direction_names", array: true
+    t.string "sender_city"
+    t.string "motif", default: "Rendez-vous d’orientation dans le cadre de votre RSA"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "notifications", force: :cascade do |t|
     t.bigint "applicant_id", null: false
     t.integer "event"
@@ -132,8 +139,10 @@ ActiveRecord::Schema.define(version: 2022_03_28_173945) do
     t.bigint "department_id"
     t.bigint "configuration_id"
     t.bigint "responsible_id"
+    t.bigint "letter_configuration_id"
     t.index ["configuration_id"], name: "index_organisations_on_configuration_id"
     t.index ["department_id"], name: "index_organisations_on_department_id"
+    t.index ["letter_configuration_id"], name: "index_organisations_on_letter_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
     t.index ["responsible_id"], name: "index_organisations_on_responsible_id"
   end
@@ -173,6 +182,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_173945) do
   add_foreign_key "notifications", "applicants"
   add_foreign_key "organisations", "configurations"
   add_foreign_key "organisations", "departments"
+  add_foreign_key "organisations", "letter_configurations"
   add_foreign_key "organisations", "responsibles"
   add_foreign_key "rdvs", "organisations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_21_113650) do
+ActiveRecord::Schema.define(version: 2022_03_28_173945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2022_03_21_113650) do
     t.date "rights_opening_date"
     t.string "birth_name"
     t.bigint "department_id"
+    t.string "archiving_reason"
     t.index ["department_id"], name: "index_applicants_on_department_id"
     t.index ["department_internal_id", "department_id"], name: "index_applicants_on_department_internal_id_and_department_id", unique: true
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true
@@ -86,6 +87,7 @@ ActiveRecord::Schema.define(version: 2022_03_21_113650) do
     t.string "pronoun"
     t.string "email"
     t.string "phone_number"
+    t.string "direction_names", array: true
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,7 +48,6 @@ ActiveRecord::Schema.define(version: 2022_03_28_173945) do
     t.date "rights_opening_date"
     t.string "birth_name"
     t.bigint "department_id"
-    t.string "archiving_reason"
     t.index ["department_id"], name: "index_applicants_on_department_id"
     t.index ["department_internal_id", "department_id"], name: "index_applicants_on_department_internal_id_and_department_id", unique: true
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true

--- a/spec/factories/letter_configuration.rb
+++ b/spec/factories/letter_configuration.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :letter_configuration do
+    direction_names do
+      ["DIRECTION GÉNÉRALE DES SERVICES DÉPARTEMENTAUX",
+       "DIRECTION DE L’INSERTION ET DU RETOUR À L’EMPLOI",
+       "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"]
+    end
+  end
+end

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -13,8 +13,11 @@ describe Invitations::GenerateLetter, type: :service do
                    department: department, format: "postal"
     )
   end
-  let!(:organisation) { create(:organisation, responsible: responsible, department: department) }
+  let!(:letter_configuration) { create(:letter_configuration) }
   let!(:responsible) { create(:responsible, first_name: "Gael", last_name: "Monfils") }
+  let!(:organisation) do
+    create(:organisation, responsible: responsible, letter_configuration: letter_configuration, department: department)
+  end
 
   describe "#call" do
     it("is a success") { is_a_success }


### PR DESCRIPTION
Dans cette PR, je permets la configuration de l'en-tête de courrier en fonction de la dénomination des services dans les départements.
J'ai opté pour un array car le "nombre" de noms de services/de lignes est variable en fonction des départements (3 dans les Ardennes, 2 dans la Drôme, par exemple).