### PR TITLE
feat(app): Add rack cors to allow all requests from rdv-insertion domains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ gem 'addressable'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 
+# CORS support
+gem 'rack-cors'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,8 @@ GEM
       activesupport (>= 3.0.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.7.2)
       rack
     rack-test (1.1.0)
@@ -375,6 +377,7 @@ DEPENDENCIES
   premailer-rails
   puma (~> 4.3)
   pundit
+  rack-cors
   rails (>= 6.0.4.1)
   react-rails
   responders

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = ENV['HOST']
+  config.action_controller.asset_host = ENV['HOST']
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins(/^(.*\.|)rdv-insertion\.fr$/)
+    resource '*', headers: :any, methods: [:get, :post, :patch, :put]
+  end
+end


### PR DESCRIPTION
J'ajoute ça pour éviter les problèmes de CORS lorsque les assets sont délivrés sur les subdomains de `rdv-insertion.fr`.