### PR TITLE
fix(invitation letter): fix signature bug and avoid page break

### DIFF
--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -15,7 +15,6 @@ u {
 .left-col {
   display: inline-block;
   width: 40%;
-  margin-top: 10px;
   margin-right: 140px;
 }
 
@@ -32,7 +31,7 @@ u {
 }
 
 .mail-object {
-  margin: 40px 0 40px;
+  margin: 40px 0 20px;
 }
 
 .main-content {

--- a/app/views/invitations/invitation_letter.html.erb
+++ b/app/views/invitations/invitation_letter.html.erb
@@ -40,7 +40,6 @@
       <%= organisation.responsible.full_name %>, <%= organisation.responsible.role %></p>
     <% else %>
       <p>Le département <%= I18n.t("with_prefix.#{department.pronoun}", name: invitation.department.name) %><br/></p>
-
     <% end %>
   </div>
 </div>

--- a/app/views/invitations/invitation_letter.html.erb
+++ b/app/views/invitations/invitation_letter.html.erb
@@ -39,8 +39,8 @@
       <p>Pour le Président du Conseil départemental et par délégation,<br/>
       <%= organisation.responsible.full_name %>, <%= organisation.responsible.role %></p>
     <% else %>
-      <p>Le département <%= I18n.t("with_prefix.#{department.pronoun}", name: @invitation.department.name) %></p>
-      <br/>
+      <p>Le département <%= I18n.t("with_prefix.#{department.pronoun}", name: invitation.department.name) %><br/></p>
+
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Dans cette PR, je résous le bug lié à l'absence de `responsible` lors de la génération d'un courrier, et je réduis certaines marges pour éviter que le courrier parte sur 2 pages dans certains cas.