### PR TITLE
fix(worker): Use update_columns when soft deleting

### DIFF
--- a/app/jobs/soft_delete_applicant_job.rb
+++ b/app/jobs/soft_delete_applicant_job.rb
@@ -3,7 +3,7 @@ class SoftDeleteApplicantJob < ApplicationJob
     applicant = Applicant.find_by(rdv_solidarites_user_id: rdv_solidarites_user_id)
     return if applicant.blank?
 
-    applicant.update!(
+    applicant.update_columns(
       status: "deleted",
       uid: nil,
       department_internal_id: nil


### PR DESCRIPTION
J'utilise `update_columns` au lieu d'un update lors de la soft deletion pour ne pas lancer les callbacks et éviter ce genre d'erreurs. 