### PR TITLE
fix(upload): add safety check on contacts file upload

### DIFF
--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useReducer } from "react";
+import Swal from "sweetalert2";
 
 import * as XLSX from "xlsx";
 import FileHandler from "../components/FileHandler";
@@ -140,6 +141,14 @@ export default function ApplicantsUpload({ organisation, configuration, departme
   };
 
   const handleContactsFile = async (file) => {
+    if (!(file.name.endsWith(".csv") || file.name.endsWith(".txt"))) {
+      Swal.fire({
+        title: "Le fichier doit être au format .txt ou .csv",
+        icon: "error",
+      });
+      return;
+    }
+
     setContactsUpdated(false);
     setFileSize(file.size);
     const contactsData = await retrieveContactsData(file);


### PR DESCRIPTION
Sur la page d'upload, pour la feature d'enrichissement avec données de contacts, le format demandé était csv/txt, mais il était toujours possible de charger un fichier d'un autre format, ce qui ne fonctionnait pas mais ne renvoyait aucune erreur. Cette PR vise à corriger ce problème pour éviter des incompréhensions côté utilisateur (cas de la Manche).