### PR TITLE
feat(webhook): Consider motif category when processing webhook

### DIFF
--- a/app/models/rdv_solidarites/rdv.rb
+++ b/app/models/rdv_solidarites/rdv.rb
@@ -6,7 +6,7 @@ module RdvSolidarites
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 
-    delegate :presential?, to: :motif
+    delegate :presential?, :category, to: :motif
 
     def initialize(attributes = {})
       super(attributes)
@@ -39,10 +39,6 @@ module RdvSolidarites
         rdv_solidarites_motif_id: motif_id,
         rdv_solidarites_lieu_id: lieu_id
       )
-    end
-
-    def context
-      motif.category
     end
 
     def agents


### PR DESCRIPTION
Cette PR devra être mergée après cette PR sur RDV-S: https://github.com/betagouv/rdv-solidarites.fr/pull/2328

Dans cette PR je prends en compte la catégories du motif liée au RDV pour pouvoir ajouter le RDV sur le bon contexte.
Il faudra évidemment configurer tous les motifs d'intérêts des départements qui travaillent avec nous pour leur assigner une catégorie.