### PR TITLE
feat(app): add applicants export button

### DIFF
--- a/app/controllers/concerns/filterable_applicants_concern.rb
+++ b/app/controllers/concerns/filterable_applicants_concern.rb
@@ -26,6 +26,8 @@ module FilterableApplicantsConcern
   end
 
   def filter_applicants_by_page
+    return if request.format == "csv"
+
     @applicants = @applicants.page(page)
   end
 end

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -83,6 +83,14 @@ module ApplicantsHelper
     "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/#{organisation_id}/users/#{applicant.rdv_solidarites_user_id}"
   end
 
+  def applicants_export_url
+    if request.url.include?("?")
+      "#{request.url}&format=csv"
+    else
+      "#{request.url}?format=csv"
+    end
+  end
+
   def department_level?
     params[:department_id].present?
   end

--- a/app/javascript/components/tooltip.js
+++ b/app/javascript/components/tooltip.js
@@ -11,6 +11,12 @@ const initToolTip = () => {
     allowHTML: true,
   });
 
+  tippy("#js-csv-export-tooltip", {
+    content:
+      "Les bénéficiaires seront exportés en fonction du contexte et des éventuels filtres sélectionnés",
+    placement: "bottom",
+  });
+
   tippy("#js-rdv-cancelled-by-user-tooltip", {
     content: "Nombre de rendez-vous manqués ou annulés par l'allocataire",
   });

--- a/app/mailers/csv_export_mailer.rb
+++ b/app/mailers/csv_export_mailer.rb
@@ -1,11 +1,6 @@
 class CsvExportMailer < ApplicationMailer
-  def applicants_csv_export(csv, email, structure)
-    csv_name = if structure.nil?
-                 "applicants_extraction.csv"
-               else
-                 "#{structure.class.name}_#{structure.name.parameterize(separator: '_')}_applicants_extraction.csv"
-               end
-    attachments[csv_name] = { mime_type: 'text/csv', content: csv }
+  def applicants_csv_export(email, csv, filename)
+    attachments[filename] = { mime_type: 'text/csv', content: csv }
     mail(
       to: email,
       subject: "Export csv d'allocataires",

--- a/app/services/create_applicants_csv_export.rb
+++ b/app/services/create_applicants_csv_export.rb
@@ -1,0 +1,100 @@
+require "csv"
+
+class CreateApplicantsCsvExport < BaseService
+  def initialize(applicants:, structure:, context:)
+    @applicants = applicants
+    @structure = structure
+    @context = context
+  end
+
+  def call
+    result.filename = filename
+    result.csv = generate_csv
+  end
+
+  private
+
+  def generate_csv
+    CSV.generate(write_headers: true, col_sep: ";", headers: headers, encoding: 'utf-8') do |row|
+      @applicants.each do |applicant|
+        row << applicant_csv(applicant)
+      end
+    end
+  end
+
+  def headers
+    [Applicant.human_attribute_name(:title),
+     Applicant.human_attribute_name(:last_name),
+     Applicant.human_attribute_name(:first_name),
+     Applicant.human_attribute_name(:affiliation_number),
+     Applicant.human_attribute_name(:department_internal_id),
+     Applicant.human_attribute_name(:email),
+     Applicant.human_attribute_name(:address),
+     Applicant.human_attribute_name(:phone_number),
+     Applicant.human_attribute_name(:birth_date),
+     Applicant.human_attribute_name(:rights_opening_date),
+     Applicant.human_attribute_name(:role),
+     "Invitation acceptée le",
+     Applicant.human_attribute_name(:status),
+     "Archivé ?",
+     Applicant.human_attribute_name(:archiving_reason),
+     "Numéro du département",
+     "Nom du département",
+     "Nombre d'organisations",
+     "Nom des organisations",
+     "Dernière invitation envoyée le",
+     "Orienté ?",
+     "Date d'orientation",
+     "Date du rendez-vous le plus récent"]
+  end
+
+  def applicant_csv(applicant) # rubocop:disable Metrics/AbcSize
+    [applicant.title,
+     applicant.last_name,
+     applicant.first_name,
+     applicant.affiliation_number,
+     applicant.department_internal_id,
+     applicant.email,
+     applicant.address,
+     applicant.phone_number,
+     format_date(applicant.birth_date),
+     format_date(applicant.rights_opening_date),
+     applicant.role,
+     format_date(applicant.invitation_accepted_at),
+     rdv_context_status(applicant),
+     I18n.t("boolean.#{applicant.is_archived?}"),
+     applicant.archiving_reason,
+     applicant.department.number,
+     applicant.department.name,
+     applicant.organisations.count,
+     applicant.organisations.collect(&:name).join(", "),
+     format_date(applicant.last_invitation_sent_at),
+     I18n.t("boolean.#{applicant.oriented?}"),
+     format_date(applicant.orientation_date),
+     rdv_context_date(applicant)]
+  end
+
+  def filename
+    if @structure.nil?
+      "applicants_extraction.csv"
+    else
+      "#{@structure.class.name}_#{@structure.name.parameterize(separator: '_')}_applicants_extraction.csv"
+    end
+  end
+
+  def rdv_context_status(applicant)
+    rdv_context(applicant)&.status || "Non invité"
+  end
+
+  def rdv_context_date(applicant)
+    rdv_context(applicant) ? format_date(rdv_context(applicant).rdvs.last&.starts_at) : ""
+  end
+
+  def rdv_context(applicant)
+    applicant.rdv_contexts.find_by(context: @context)
+  end
+
+  def format_date(date)
+    date&.strftime("%d/%m/%Y")
+  end
+end

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -51,6 +51,11 @@
           </li>
         </ul>
       <% end %>
+      <% if department_level? %>
+        <%= link_to "Export csv bénéficiaires", applicants_export_url, class: "btn btn-blue-out mt-2", id: "js-csv-export-tooltip", target: "_blank" %>
+      <% else %>
+        <%= link_to "Export csv bénéficiaires", applicants_export_url, class: "btn btn-blue-out mt-2", id: "js-csv-export-tooltip", target: "_blank" %>
+      <% end %>
       <%= link_to "https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/", target: :blank do %>
         <button class="btn btn-blue-out mt-2">Guide d'utilisation<i class="fas fa-external-link-alt icon-sm"></i></button>
       <% end %>

--- a/scripts/extract_applicants_to_csv.rb
+++ b/scripts/extract_applicants_to_csv.rb
@@ -8,7 +8,7 @@ require 'csv'
 EMAIL = ARGV[0] == "nil" ? nil : ARGV[0]
 ORGANISATION_ID = ARGV[1] == "nil" ? nil : ARGV[1]
 DEPARTMENT_ID = ARGV[2] == "nil" ? nil : ARGV[2]
-CONTEXT = ARGV[3] == "nil" ? "rsa_orientation" : ARGV[3]
+CONTEXT = ARGV[3] == "nil" ? nil : ARGV[3]
 
 structure = if DEPARTMENT_ID.present?
               Department.find(DEPARTMENT_ID)
@@ -17,9 +17,13 @@ structure = if DEPARTMENT_ID.present?
             end
 
 applicants = structure&.applicants || Applicant.order(:department_id)
-context_applicants = applicants.where(context: context)
+context_applicants = if CONTEXT.present?
+                       applicants.joins(:rdv_contexts).where(rdv_contexts: { context: CONTEXT })
+                     else
+                       applicants.where.missing(:rdv_contexts)
+                     end
 
-result = CreateApplicantsCsvExport.call(applicants: context_applicants, structure: structure, context: context)
+result = CreateApplicantsCsvExport.call(applicants: context_applicants, structure: structure, context: CONTEXT)
 
 if EMAIL.present?
   CsvExportMailer.applicants_csv_export(EMAIL, result.csv, result.filename).deliver_now

--- a/scripts/extract_applicants_to_csv.rb
+++ b/scripts/extract_applicants_to_csv.rb
@@ -8,6 +8,7 @@ require 'csv'
 EMAIL = ARGV[0] == "nil" ? nil : ARGV[0]
 ORGANISATION_ID = ARGV[1] == "nil" ? nil : ARGV[1]
 DEPARTMENT_ID = ARGV[2] == "nil" ? nil : ARGV[2]
+CONTEXT = ARGV[3] == "nil" ? "rsa_orientation" : ARGV[3]
 
 structure = if DEPARTMENT_ID.present?
               Department.find(DEPARTMENT_ID)
@@ -16,61 +17,12 @@ structure = if DEPARTMENT_ID.present?
             end
 
 applicants = structure&.applicants || Applicant.order(:department_id)
+context_applicants = applicants.where(context: context)
 
-headers = [Applicant.human_attribute_name(:title),
-           Applicant.human_attribute_name(:last_name),
-           Applicant.human_attribute_name(:first_name),
-           Applicant.human_attribute_name(:affiliation_number),
-           Applicant.human_attribute_name(:department_internal_id),
-           Applicant.human_attribute_name(:email),
-           Applicant.human_attribute_name(:address),
-           Applicant.human_attribute_name(:phone_number),
-           Applicant.human_attribute_name(:birth_date),
-           Applicant.human_attribute_name(:rights_opening_date),
-           Applicant.human_attribute_name(:role),
-           "Invitation acceptée le",
-           Applicant.human_attribute_name(:status),
-           "Archivé ?",
-           Applicant.human_attribute_name(:archiving_reason),
-           "Numéro du département",
-           "Nom du département",
-           "Nombre d'organisations",
-           "Nom des organisations",
-           "Dernière invitation envoyée le",
-           "Orienté ?",
-           "Date d'orientation",
-           "Date du rendez-vous le plus récent"]
-
-csv = CSV.generate(write_headers: true, col_sep: ";", headers: headers, encoding: 'iso8859-1') do |row|
-  applicants.each do |applicant|
-    row << [applicant.title,
-            applicant.last_name,
-            applicant.first_name,
-            applicant.affiliation_number,
-            applicant.department_internal_id,
-            applicant.email,
-            applicant.address,
-            applicant.phone_number,
-            applicant.birth_date&.strftime("%d/%m/%Y"),
-            applicant.rights_opening_date&.strftime("%d/%m/%Y"),
-            applicant.role,
-            applicant.invitation_accepted_at&.strftime("%d/%m/%Y"),
-            applicant.status,
-            I18n.t("boolean.#{applicant.is_archived?}"),
-            applicant.archiving_reason,
-            applicant.department.number,
-            applicant.department.name,
-            applicant.organisations.count,
-            applicant.organisations.collect(&:name).join(", "),
-            applicant.last_invitation_sent_at&.strftime("%d/%m/%Y"),
-            I18n.t("boolean.#{applicant.oriented?}"),
-            applicant.orientation_date&.strftime("%d/%m/%Y"),
-            applicant.rdvs.last&.starts_at&.strftime("%d/%m/%Y")]
-  end
-end
+result = CreateApplicantsCsvExport.call(applicants: context_applicants, structure: structure, context: context)
 
 if EMAIL.present?
-  CsvExportMailer.applicants_csv_export(csv, EMAIL, structure).deliver_now
+  CsvExportMailer.applicants_csv_export(EMAIL, result.csv, result.filename).deliver_now
 else
-  puts csv
+  puts result.csv
 end

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -443,6 +443,46 @@ describe ApplicantsController, type: :controller do
         expect(response.body).not_to match(/Baer/)
       end
     end
+
+    context "when csv request" do
+      before do
+        allow(CreateApplicantsCsvExport).to receive(:call)
+          .and_return(OpenStruct.new)
+      end
+
+      it "calls the service" do
+        expect(CreateApplicantsCsvExport).to receive(:call)
+        get :index, params: index_params.merge(format: :csv)
+      end
+
+      context "when not authorized" do
+        let!(:another_organisation) { create(:organisation) }
+        let!(:another_agent) { create(:agent, organisations: [another_organisation]) }
+
+        before do
+          sign_in(another_agent)
+          setup_rdv_solidarites_session(rdv_solidarites_session)
+        end
+
+        it "does not call the service" do
+          expect do
+            get :index, params: index_params.merge(format: :csv)
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "when the csv creation succeeds" do
+        before do
+          allow(CreateApplicantsCsvExport).to receive(:call)
+            .and_return(OpenStruct.new(success?: true))
+        end
+
+        it "is a success" do
+          get :index, params: index_params.merge(format: :csv)
+          expect(response).to be_successful
+        end
+      end
+    end
   end
 
   describe "#edit" do

--- a/spec/services/create_applicants_csv_export_spec.rb
+++ b/spec/services/create_applicants_csv_export_spec.rb
@@ -1,0 +1,52 @@
+describe CreateApplicantsCsvExport, type: :service do
+  subject { described_class.call(applicants: applicants, structure: structure, context: context) }
+
+  let!(:context) { "rsa_orientation" }
+  let!(:organisation) { create(:organisation) }
+  let!(:structure) { :organisation }
+  let(:applicant1) { create(:applicant, last_name: "Dhobb", organisations: [organisation]) }
+  let(:applicant2) { create(:applicant, last_name: "Casubolo", organisations: [organisation]) }
+  let(:applicant3) { create(:applicant, last_name: "Blanc", organisations: [organisation]) }
+  let(:applicant4) { create(:applicant, last_name: "Prébot", organisations: [organisation]) }
+  let!(:applicants) { [applicant1, applicant2, applicant3] }
+
+  describe "#call" do
+    context "it exports applicants to csv" do
+      it "is a success" do
+        expect(subject.success?).to eq(true)
+      end
+
+      context "it generates a filename" do
+        context "structure is present" do
+          it "generates a filename with structure" do
+            expect(subject.filename).to eq("#{structure.class.name}_#{structure.name \
+              .parameterize(separator: '_')}_applicants_extraction.csv")
+          end
+        end
+
+        context "structure is nil" do
+          let!(:structure) { nil }
+
+          it "generates a generic filename" do
+            expect(subject.filename).to eq("applicants_extraction.csv")
+          end
+        end
+      end
+
+      it "generates headers" do
+        expect(subject.csv).to start_with("Civilité;Nom;Prénom;Numéro d'allocataire;ID interne au département;Email;")
+      end
+
+      it "generates one line for each applicant required" do
+        expect(subject.csv.scan(/(?=\n)/).count).to eq(applicants.count + 1)
+      end
+
+      it "includes the required applicants" do
+        expect(subject.csv).to include("Dhobb")
+        expect(subject.csv).to include("Casubolo")
+        expect(subject.csv).to include("Blanc")
+        expect(subject.csv).not_to include("Prébot")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dans cette PR, j'ajoute le service `CreateApplicantsCsvExport`, qui permet de générer un csv à partir d'une liste de bRSA.
Ce service est appelé par l'action `#index` du `ApplicantsController`, lorsque le format demandé est du `csv`. Il est aussi appelé par le script `extract_applicants_to_csv`.
Depuis la page index, les bénéficiaires sont exportés en fonction du contexte et des éventuels filtres sélectionnés.