### PR TITLE
feat(invitations): Pass motif category parameter

### DIFF
--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -43,7 +43,7 @@ module Invitations
         address: address,
         invitation_token: @invitation.token,
         organisation_ids: @invitation.organisations.map(&:rdv_solidarites_organisation_id),
-        motif_search_terms: @invitation.context_name
+        motif_category: @invitation.context
       }
         .merge(@invitation.rdv_solidarites_lieu_id? ? { lieu_id: @invitation.rdv_solidarites_lieu_id } : geo_attributes)
     end

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -61,7 +61,7 @@ describe Invitations::ComputeLink, type: :service do
       expect(subject.invitation_link).to eq(
         "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
         "city_code=75107&departement=75&invitation_token=sometoken&latitude=48.850699&longitude=2.308628&" \
-        "motif_search_terms=RSA+accompagnement&organisation_ids%5B%5D=333&"\
+        "motif_category=rsa_accompagnement&organisation_ids%5B%5D=333&"\
         "organisation_ids%5B%5D=444&street_ban_id=75107_8909"
       )
     end
@@ -91,7 +91,7 @@ describe Invitations::ComputeLink, type: :service do
         it "does not add the attributes to the link" do
           expect(subject.invitation_link).to eq(
             "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
-            "departement=75&invitation_token=sometoken&motif_search_terms=RSA+accompagnement&" \
+            "departement=75&invitation_token=sometoken&motif_category=rsa_accompagnement&" \
             "organisation_ids%5B%5D=333&organisation_ids%5B%5D=444"
           )
         end
@@ -119,7 +119,7 @@ describe Invitations::ComputeLink, type: :service do
       it "adds the lieu id instead of the geo attributes in the url" do
         expect(subject.invitation_link).to eq(
           "https://www.rdv-solidarites.fr/prendre_rdv?address=20+avenue+de+s%C3%A9gur+75007+Paris&" \
-          "departement=75&invitation_token=sometoken&lieu_id=5&motif_search_terms=RSA+accompagnement&" \
+          "departement=75&invitation_token=sometoken&lieu_id=5&motif_category=rsa_accompagnement&" \
           "organisation_ids%5B%5D=333&organisation_ids%5B%5D=444"
         )
       end


### PR DESCRIPTION
Cette PR est liée et doit être mergée après [cette PR](https://github.com/betagouv/rdv-solidarites.fr/pull/2354) sur RDV-Solidarités.
On envoie maintenant la catégorie du motif dans le lien d'invitation plutôt que des termes à rechercher dans le nom du motif.