### PR TITLE
feat(invitations): Set number of days to accept invitations as parameter

### DIFF
--- a/app/controllers/concerns/filterable_applicants_concern.rb
+++ b/app/controllers/concerns/filterable_applicants_concern.rb
@@ -15,7 +15,9 @@ module FilterableApplicantsConcern
   def filter_applicants_by_action_required
     return unless params[:action_required] == "true"
 
-    @applicants = @applicants.joins(:rdv_contexts).where(rdv_contexts: @rdv_contexts.action_required)
+    @applicants = @applicants.joins(:rdv_contexts).where(
+      rdv_contexts: @rdv_contexts.action_required(@current_configuration.number_of_days_to_accept_invitation)
+    )
   end
 
   def filter_applicants_by_search_query

--- a/app/controllers/concerns/filterable_applicants_concern.rb
+++ b/app/controllers/concerns/filterable_applicants_concern.rb
@@ -16,7 +16,7 @@ module FilterableApplicantsConcern
     return unless params[:action_required] == "true"
 
     @applicants = @applicants.joins(:rdv_contexts).where(
-      rdv_contexts: @rdv_contexts.action_required(@current_configuration.number_of_days_to_accept_invitation)
+      rdv_contexts: @rdv_contexts.action_required(@current_configuration.number_of_days_before_action_required)
     )
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -36,7 +36,9 @@ class InvitationsController < ApplicationController
   private
 
   def invitation_params
-    params.require(:invitation).permit(:format, :help_phone_number, :rdv_solidarites_lieu_id)
+    params.require(:invitation).permit(
+      :format, :help_phone_number, :rdv_solidarites_lieu_id, :number_of_days_to_accept_invitation
+    )
   end
 
   def pdf

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -37,10 +37,10 @@ module ApplicantsHelper
     end
   end
 
-  def background_class_for_context_status(context)
+  def background_class_for_context_status(context, number_of_days_to_accept_invitation)
     return "" if context.nil?
 
-    if context.action_required?
+    if context.action_required?(number_of_days_to_accept_invitation)
       context.attention_needed? ? "bg-warning border-warning" : "bg-danger border-danger"
     elsif context.rdv_seen?
       "bg-success border-success"
@@ -61,19 +61,19 @@ module ApplicantsHelper
     end
   end
 
-  def display_context_status(context, with_notice: true)
+  def display_context_status(context, number_of_days_to_accept_invitation)
     return "Non invité" if context.nil?
 
-    I18n.t("activerecord.attributes.rdv_context.statuses.#{context.status}") + \
-      (with_notice ? display_context_status_notice(context) : "")
+    I18n.t("activerecord.attributes.rdv_context.statuses.#{context.status}") +
+     display_context_status_notice(context, number_of_days_to_accept_invitation)
   end
 
   def display_rdv_status(rdv)
     rdv.pending? ? "À venir" : I18n.t("activerecord.attributes.rdv.statuses.#{rdv.status}")
   end
 
-  def display_context_status_notice(context)
-    if context.invited_before_time_window? && context.invitation_pending?
+  def display_context_status_notice(context, number_of_days_to_accept_invitation)
+    if context.invited_before_time_window?(number_of_days_to_accept_invitation) && context.invitation_pending?
       " (Délai dépassé)"
     else
       ""

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -37,10 +37,10 @@ module ApplicantsHelper
     end
   end
 
-  def background_class_for_context_status(context, number_of_days_to_accept_invitation)
+  def background_class_for_context_status(context, number_of_days_before_action_required)
     return "" if context.nil?
 
-    if context.action_required?(number_of_days_to_accept_invitation)
+    if context.action_required?(number_of_days_before_action_required)
       context.attention_needed? ? "bg-warning border-warning" : "bg-danger border-danger"
     elsif context.rdv_seen?
       "bg-success border-success"
@@ -61,19 +61,19 @@ module ApplicantsHelper
     end
   end
 
-  def display_context_status(context, number_of_days_to_accept_invitation)
+  def display_context_status(context, number_of_days_before_action_required)
     return "Non invité" if context.nil?
 
     I18n.t("activerecord.attributes.rdv_context.statuses.#{context.status}") +
-      display_context_status_notice(context, number_of_days_to_accept_invitation)
+      display_context_status_notice(context, number_of_days_before_action_required)
   end
 
   def display_rdv_status(rdv)
     rdv.pending? ? "À venir" : I18n.t("activerecord.attributes.rdv.statuses.#{rdv.status}")
   end
 
-  def display_context_status_notice(context, number_of_days_to_accept_invitation)
-    if context.invited_before_time_window?(number_of_days_to_accept_invitation) && context.invitation_pending?
+  def display_context_status_notice(context, number_of_days_before_action_required)
+    if context.invited_before_time_window?(number_of_days_before_action_required) && context.invitation_pending?
       " (Délai dépassé)"
     else
       ""

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -65,7 +65,7 @@ module ApplicantsHelper
     return "Non invité" if context.nil?
 
     I18n.t("activerecord.attributes.rdv_context.statuses.#{context.status}") +
-     display_context_status_notice(context, number_of_days_to_accept_invitation)
+      display_context_status_notice(context, number_of_days_to_accept_invitation)
   end
 
   def display_rdv_status(rdv)

--- a/app/javascript/react/actions/inviteApplicant.js
+++ b/app/javascript/react/actions/inviteApplicant.js
@@ -8,6 +8,7 @@ const inviteApplicant = async (
   invitationFormat,
   helpPhoneNumber,
   context,
+  numberOfDaysToAcceptInvitation,
   types = "application/json"
 ) => {
   let url;
@@ -22,6 +23,7 @@ const inviteApplicant = async (
     {
       format: invitationFormat,
       help_phone_number: helpPhoneNumber,
+      number_of_days_to_accept_invitation: numberOfDaysToAcceptInvitation,
       rdv_context: {
         context,
       },

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -32,6 +32,7 @@ export default function Applicant({
       applicant.currentOrganisation,
       isDepartmentLevel,
       applicant.currentConfiguration.context,
+      applicant.currentConfiguration.number_of_days_to_accept_invitation,
     ];
     if (action === "accountCreation") {
       if (!applicant.currentOrganisation) {

--- a/app/javascript/react/components/InvitationBlock.jsx
+++ b/app/javascript/react/components/InvitationBlock.jsx
@@ -13,6 +13,7 @@ export default function InvitationBlock({
   context,
   isDepartmentLevel,
   invitationFormats,
+  numberOfDaysToAcceptInvitation,
   status,
 }) {
   const [isLoading, setIsLoading] = useState({
@@ -42,7 +43,14 @@ export default function InvitationBlock({
 
   const handleClick = async (action) => {
     setIsLoading({ ...isLoading, [action]: true });
-    const applicantParams = [applicant, department.id, organisation, isDepartmentLevel, context];
+    const applicantParams = [
+      applicant,
+      department.id,
+      organisation,
+      isDepartmentLevel,
+      context,
+      numberOfDaysToAcceptInvitation,
+    ];
     if (action === "smsInvitation") {
       const invitation = await handleApplicantInvitation(...applicantParams, "sms");
       setLastSmsInvitationSentAt(invitation?.sent_at);

--- a/app/javascript/react/lib/handleApplicantInvitation.js
+++ b/app/javascript/react/lib/handleApplicantInvitation.js
@@ -7,6 +7,7 @@ const handleApplicantInvitation = async (
   organisation,
   isDepartmentLevel,
   context,
+  numberOfDaysToAcceptInvitation,
   invitationFormat
 ) => {
   const result = await inviteApplicant(
@@ -16,7 +17,8 @@ const handleApplicantInvitation = async (
     isDepartmentLevel,
     invitationFormat,
     organisation.phone_number,
-    context
+    context,
+    numberOfDaysToAcceptInvitation
   );
   if (result.success) {
     const { invitation } = result;

--- a/app/models/concerns/invitable_concern.rb
+++ b/app/models/concerns/invitable_concern.rb
@@ -33,7 +33,7 @@ module InvitableConcern
     last_postal_invitation&.sent_at
   end
 
-  def invited_before_time_window?
-    last_invitation_sent_at && last_invitation_sent_at < Organisation::TIME_TO_ACCEPT_INVITATION.ago
+  def invited_before_time_window?(number_of_days_to_accept_invitation)
+    last_invitation_sent_at && last_invitation_sent_at < number_of_days_to_accept_invitation.days.ago
   end
 end

--- a/app/models/concerns/invitable_concern.rb
+++ b/app/models/concerns/invitable_concern.rb
@@ -33,7 +33,7 @@ module InvitableConcern
     last_postal_invitation&.sent_at
   end
 
-  def invited_before_time_window?(number_of_days_to_accept_invitation)
-    last_invitation_sent_at && last_invitation_sent_at < number_of_days_to_accept_invitation.days.ago
+  def invited_before_time_window?(number_of_days_before_action_required)
+    last_invitation_sent_at && last_invitation_sent_at < number_of_days_before_action_required.days.ago
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,7 +6,8 @@ class Invitation < ApplicationRecord
 
   attr_accessor :content
 
-  validates :help_phone_number, :context, :token, :organisations, :link, presence: true
+  validates :help_phone_number, :context, :token, :organisations, :link, :number_of_days_to_accept_invitation,
+            presence: true
   validate :organisations_cannot_be_from_different_departments
 
   delegate :context, :context_name, to: :rdv_context
@@ -14,7 +15,9 @@ class Invitation < ApplicationRecord
   enum format: { sms: 0, email: 1, postal: 2 }, _prefix: :format
   after_commit :set_applicant_status, :set_rdv_context_status
 
-  scope :sent_in_time_window, -> { where("sent_at > ?", Organisation::TIME_TO_ACCEPT_INVITATION.ago) }
+  scope :sent_in_time_window, lambda { |number_of_days_to_accept_invitation|
+    where("sent_at > ?", number_of_days_to_accept_invitation.days.ago)
+  }
 
   def send_to_applicant
     case self.format

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -15,8 +15,8 @@ class Invitation < ApplicationRecord
   enum format: { sms: 0, email: 1, postal: 2 }, _prefix: :format
   after_commit :set_applicant_status, :set_rdv_context_status
 
-  scope :sent_in_time_window, lambda { |number_of_days_to_accept_invitation|
-    where("sent_at > ?", number_of_days_to_accept_invitation.days.ago)
+  scope :sent_in_time_window, lambda { |number_of_days_before_action_required|
+    where("sent_at > ?", number_of_days_before_action_required.days.ago)
   }
 
   def send_to_applicant

--- a/app/models/letter_configuration.rb
+++ b/app/models/letter_configuration.rb
@@ -1,4 +1,4 @@
 class LetterConfiguration < ApplicationRecord
   has_many :organisations, dependent: :nullify
-  validates :direction_names, :motif, presence: true
+  validates :direction_names, presence: true
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,6 +1,5 @@
 class Organisation < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:name, :phone_number, :email].freeze
-  TIME_TO_ACCEPT_INVITATION = 3.days
 
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, presence: true

--- a/app/models/rdv_context.rb
+++ b/app/models/rdv_context.rb
@@ -15,18 +15,18 @@ class RdvContext < ApplicationRecord
   STATUSES_WITH_ATTENTION_NEEDED = %w[invitation_pending].freeze
 
   scope :status, ->(status) { where(status: status) }
-  scope :action_required, lambda { |number_of_days_to_accept_invitation|
+  scope :action_required, lambda { |number_of_days_before_action_required|
     status(STATUSES_WITH_ACTION_REQUIRED)
-      .or(attention_needed.invited_before_time_window(number_of_days_to_accept_invitation))
+      .or(attention_needed.invited_before_time_window(number_of_days_before_action_required))
   }
   scope :attention_needed, -> { status(STATUSES_WITH_ATTENTION_NEEDED) }
-  scope :invited_before_time_window, lambda { |number_of_days_to_accept_invitation|
-    where.not(id: Invitation.sent_in_time_window(number_of_days_to_accept_invitation).pluck(:rdv_context_id).uniq)
+  scope :invited_before_time_window, lambda { |number_of_days_before_action_required|
+    where.not(id: Invitation.sent_in_time_window(number_of_days_before_action_required).pluck(:rdv_context_id).uniq)
   }
 
-  def action_required?(number_of_days_to_accept_invitation)
+  def action_required?(number_of_days_before_action_required)
     status.in?(STATUSES_WITH_ACTION_REQUIRED) ||
-      (attention_needed? && invited_before_time_window?(number_of_days_to_accept_invitation))
+      (attention_needed? && invited_before_time_window?(number_of_days_before_action_required))
   end
 
   def attention_needed?

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -37,7 +37,7 @@ module Invitations
     def content_for_rsa_orientation
       "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous " \
         "d'orientation. Pour choisir la date et l'horaire de votre premier RDV, " \
-        "cliquez sur le lien suivant dans les 3 jours: " \
+        "cliquez sur le lien suivant dans les #{number_of_days_to_accept_invitation} jours: " \
         "#{redirect_invitations_url(params: { token: @invitation.token }, host: ENV['HOST'])}\n" \
         "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
         "#{@invitation.help_phone_number}."
@@ -46,7 +46,7 @@ module Invitations
     def content_for_rsa_accompagnement
       "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous " \
         "d'accompagnement. Pour choisir la date et l'horaire de votre premier RDV, " \
-        "cliquez sur le lien suivant dans les 3 jours: " \
+        "cliquez sur le lien suivant dans les #{number_of_days_to_accept_invitation} jours: " \
         "#{redirect_invitations_url(params: { token: @invitation.token }, host: ENV['HOST'])}\n" \
         "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
         "#{@invitation.help_phone_number}."
@@ -55,12 +55,16 @@ module Invitations
     def content_for_rsa_orientation_on_phone_platform
       "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez contacter la plateforme départementale " \
         "afin de démarrer votre parcours d’accompagnement. Pour cela, merci d’appeler le " \
-        "#{@invitation.help_phone_number} dans un délai de 3 jours. "\
+        "#{@invitation.help_phone_number} dans un délai de #{number_of_days_to_accept_invitation} jours. "\
         "Cet appel est nécessaire pour le traitement de votre dossier."
     end
 
     def phone_number_formatted
       applicant.phone_number_formatted
+    end
+
+    def number_of_days_to_accept_invitation
+      @invitation.number_of_days_to_accept_invitation
     end
 
     def applicant

--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -60,8 +60,8 @@
                 <% if applicant.is_archived? %>
                   <td>Dossier archivé</td>
                 <% else %>
-                  <td class="<%= background_class_for_context_status(rdv_context, @current_configuration.number_of_days_to_accept_invitation) %>">
-                    <%= display_context_status(rdv_context, @current_configuration.number_of_days_to_accept_invitation) %>
+                  <td class="<%= background_class_for_context_status(rdv_context, @current_configuration.number_of_days_before_action_required) %>">
+                    <%= display_context_status(rdv_context, @current_configuration.number_of_days_before_action_required) %>
                   </td>
                 <% end %>
               <% end %>

--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -60,8 +60,8 @@
                 <% if applicant.is_archived? %>
                   <td>Dossier archivé</td>
                 <% else %>
-                  <td class="<%= background_class_for_context_status(rdv_context) %>">
-                    <%= display_context_status(rdv_context) %>
+                  <td class="<%= background_class_for_context_status(rdv_context, @current_configuration.number_of_days_to_accept_invitation) %>">
+                    <%= display_context_status(rdv_context, @current_configuration.number_of_days_to_accept_invitation) %>
                   </td>
                 <% end %>
               <% end %>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -54,7 +54,7 @@
       </thead>
       <tbody>
         <tr>
-          <td class="p-4 <%= background_class_for_context_status(rdv_context, configuration.number_of_days_to_accept_invitation) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context, configuration.number_of_days_to_accept_invitation) %></td>
+          <td class="p-4 <%= background_class_for_context_status(rdv_context, configuration.number_of_days_before_action_required) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context, configuration.number_of_days_before_action_required) %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -10,7 +10,8 @@
         isDepartmentLevel: department_level?,
         invitationFormats: configuration.invitation_formats,
         context: configuration.context,
-        status: rdv_context&.status
+        numberOfDaysToAcceptInvitation: configuration.number_of_days_to_accept_invitation,
+        status: rdv_context&.status,
       }
     ) %>
   <% end %>
@@ -53,7 +54,7 @@
       </thead>
       <tbody>
         <tr>
-          <td class="p-4 <%= background_class_for_context_status(rdv_context) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context) %></td>
+          <td class="p-4 <%= background_class_for_context_status(rdv_context, configuration.number_of_days_to_accept_invitation) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context, configuration.number_of_days_to_accept_invitation) %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/letters/invitation_for_rsa_accompagnement.html.erb
+++ b/app/views/letters/invitation_for_rsa_accompagnement.html.erb
@@ -12,7 +12,7 @@
   <p>Pour faciliter votre prise de rendez-vous, le Conseil départemental a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.token %></div>
-  <p>Dans le cadre du versement de votre allocation RSA, vous devez obligatoirement prendre ce rendez-vous dans un délai de 15 jours à réception de ce courrier.</p>
+  <p>Dans le cadre du versement de votre allocation RSA, vous devez obligatoirement prendre ce rendez-vous dans un délai de <%= invitation.number_of_days_to_accept_invitation %> jours à réception de ce courrier.</p>
   <p>Si vous rencontrez une difficulté pour accéder à internet, veuillez téléphoner dès réception de ce courrier au <%= invitation.help_phone_number_formatted %>.</p>
   <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
   <div class="letter-signature">

--- a/app/views/letters/invitation_for_rsa_orientation.html.erb
+++ b/app/views/letters/invitation_for_rsa_orientation.html.erb
@@ -13,7 +13,7 @@
   <p>Pour faciliter votre prise de rendez-vous, le Conseil départemental a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.token %></div>
-  <p>Dans le cadre du versement de votre allocation RSA, vous devez obligatoirement prendre ce rendez-vous dans un délai de 15 jours à réception de ce courrier.</p>
+  <p>Dans le cadre du versement de votre allocation RSA, vous devez obligatoirement prendre ce rendez-vous dans un délai de <%= invitation.number_of_days_to_accept_invitation %> jours à réception de ce courrier.</p>
   <p>Si vous rencontrez une difficulté pour accéder à internet, veuillez téléphoner dès réception de ce courrier au <%= invitation.help_phone_number_formatted %>.</p>
   <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
   <div class="letter-signature">

--- a/app/views/letters/invitation_for_rsa_orientation_on_phone_platform.html.erb
+++ b/app/views/letters/invitation_for_rsa_orientation_on_phone_platform.html.erb
@@ -10,7 +10,7 @@
   <p><%= applicant.title.capitalize %>,</p>
   <p>Vous êtes allocataire du Revenu de Solidarité Active (RSA) et devez bénéficier d’un accompagnement obligatoire dans le cadre de vos démarches d’insertion.</p>
   <p>La première étape est <span class="bold-blue">un appel téléphonique avec un professionnel de l’insertion</span> afin de définir, selon votre situation et vos besoins, quelle sera la structure la mieux adaptée pour vous accompagner.</p>
-  <p>Pour cela, <span class="bold-blue">merci d’appeler le <%= invitation.help_phone_number %> dans un délai de 3 jours à réception de ce courrier.</span></p>
+  <p>Pour cela, <span class="bold-blue">merci d’appeler le <%= invitation.help_phone_number %> dans un délai de <%= invitation.number_of_days_to_accept_invitation %> jours à réception de ce courrier.</span></p>
   <p>Cet appel est obligatoire dans le cadre du versement de votre allocation RSA.</p>
   <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
   <div class="letter-signature">

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_accompagnement.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_accompagnement.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'accompagnement.</p>
-<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les 3 jours</span>. Ce rendez-vous est obligatoire.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>. Ce rendez-vous est obligatoire.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { token: @invitation.token, format: "email" }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Je prends RDV

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'orientation.</p>
-<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les 3 jours</span>. Ce rendez-vous est obligatoire.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>. Ce rendez-vous est obligatoire.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { token: @invitation.token, format: "email" }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Je prends RDV

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation_on_phone_platform.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation_on_phone_platform.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>En tant que bénéficiaire du RSA vous devez contacter la plateforme départementale afin de démarrer votre parcours d’accompagnement.</p>
-<p><span class="font-weight-bold">Pour cela, merci d’appeler le <%= @invitation.help_phone_number_formatted %> dans un délai de 3 jours.</span> Cet appel est nécessaire pour le traitement de votre dossier.</p>
+<p><span class="font-weight-bold">Pour cela, merci d’appeler le <%= @invitation.help_phone_number_formatted %> dans un délai de <%= @invitation.number_of_days_to_accept_invitation %> jours.</span> Cet appel est nécessaire pour le traitement de votre dossier.</p>
 
 <p>À bientôt,</p>
 <p>Le département <%= I18n.t("with_prefix.#{@invitation.department.pronoun}", name: @invitation.department.name) %>.</p>

--- a/config/locales/models/invitation.fr.yml
+++ b/config/locales/models/invitation.fr.yml
@@ -7,4 +7,4 @@ fr:
         help_phone_number: Téléphone de contact
         link: Lien
         token: Token
-        context: Contexte
+        number_of_days_to_accept_invitation: Nombre de jours pour accepter l'invitation

--- a/db/migrate/20220412150442_add_days_to_accept_invitations_to_configuations_and_invitations.rb
+++ b/db/migrate/20220412150442_add_days_to_accept_invitations_to_configuations_and_invitations.rb
@@ -1,0 +1,12 @@
+class AddDaysToAcceptInvitationsToConfiguationsAndInvitations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :configurations, :number_of_days_to_accept_invitation, :integer, default: 3
+    add_column :invitations, :number_of_days_to_accept_invitation, :integer
+
+    up_only do
+      Invitation.find_each do |invitation|
+        invitation.update!(number_of_days_to_accept_invitation: 3)
+      end
+    end
+  end
+end

--- a/db/migrate/20220412150442_add_days_to_accept_invitations_to_configuations_and_invitations.rb
+++ b/db/migrate/20220412150442_add_days_to_accept_invitations_to_configuations_and_invitations.rb
@@ -1,6 +1,7 @@
 class AddDaysToAcceptInvitationsToConfiguationsAndInvitations < ActiveRecord::Migration[6.1]
   def change
     add_column :configurations, :number_of_days_to_accept_invitation, :integer, default: 3
+    add_column :configurations, :number_of_days_before_action_required, :integer, default: 3
     add_column :invitations, :number_of_days_to_accept_invitation, :integer
 
     up_only do

--- a/db/migrate/20220412151557_remove_motif_from_letter_configurations.rb
+++ b/db/migrate/20220412151557_remove_motif_from_letter_configurations.rb
@@ -1,0 +1,5 @@
+class RemoveMotifFromLetterConfigurations < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :letter_configurations, :motif, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_31_104257) do
+ActiveRecord::Schema.define(version: 2022_04_12_151557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2022_03_31_104257) do
     t.string "invitation_formats", default: ["sms", "email", "postal"], null: false, array: true
     t.boolean "notify_applicant", default: false
     t.integer "context", default: 0
+    t.integer "number_of_days_to_accept_invitation", default: 3
   end
 
   create_table "configurations_organisations", id: false, force: :cascade do |t|
@@ -110,6 +111,7 @@ ActiveRecord::Schema.define(version: 2022_03_31_104257) do
     t.bigint "department_id"
     t.bigint "rdv_solidarites_lieu_id"
     t.bigint "rdv_context_id"
+    t.integer "number_of_days_to_accept_invitation"
     t.index ["applicant_id"], name: "index_invitations_on_applicant_id"
     t.index ["department_id"], name: "index_invitations_on_department_id"
     t.index ["rdv_context_id"], name: "index_invitations_on_rdv_context_id"
@@ -124,7 +126,6 @@ ActiveRecord::Schema.define(version: 2022_03_31_104257) do
   create_table "letter_configurations", force: :cascade do |t|
     t.string "direction_names", array: true
     t.string "sender_city"
-    t.string "motif", default: "Rendez-vous d’orientation dans le cadre de votre RSA"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_04_12_151557) do
     t.boolean "notify_applicant", default: false
     t.integer "context", default: 0
     t.integer "number_of_days_to_accept_invitation", default: 3
+    t.integer "number_of_days_before_action_required", default: 3
   end
 
   create_table "configurations_organisations", id: false, force: :cascade do |t|

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -4,10 +4,10 @@ describe ApplicantsController, type: :controller do
     create(
       :configuration,
       context: "rsa_orientation",
-      number_of_days_to_accept_invitation: number_of_days_to_accept_invitation
+      number_of_days_before_action_required: number_of_days_before_action_required
     )
   end
-  let!(:number_of_days_to_accept_invitation) { 3 }
+  let!(:number_of_days_before_action_required) { 3 }
   let!(:organisation) do
     create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
                           department_id: department.id, configurations: [configuration])
@@ -407,7 +407,7 @@ describe ApplicantsController, type: :controller do
 
     context "when action_required is passed" do
       let!(:index_params) { { organisation_id: organisation.id, action_required: "true" } }
-      let!(:number_of_days_to_accept_invitation) { 4 }
+      let!(:number_of_days_before_action_required) { 4 }
 
       context "when the invitation has been sent before the number of days defined in the configuration ago" do
         let!(:invitation) { create(:invitation, applicant: applicant2, rdv_context: rdv_context2, sent_at: 5.days.ago) }

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -1,6 +1,13 @@
 describe ApplicantsController, type: :controller do
   let!(:department) { create(:department) }
-  let!(:configuration) { create(:configuration, context: "rsa_orientation") }
+  let!(:configuration) do
+    create(
+      :configuration,
+      context: "rsa_orientation",
+      number_of_days_to_accept_invitation: number_of_days_to_accept_invitation
+    )
+  end
+  let!(:number_of_days_to_accept_invitation) { 3 }
   let!(:organisation) do
     create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
                           department_id: department.id, configurations: [configuration])
@@ -400,8 +407,9 @@ describe ApplicantsController, type: :controller do
 
     context "when action_required is passed" do
       let!(:index_params) { { organisation_id: organisation.id, action_required: "true" } }
+      let!(:number_of_days_to_accept_invitation) { 4 }
 
-      context "when the invitation has been sent more than 3 days ago" do
+      context "when the invitation has been sent before the number of days defined in the configuration ago" do
         let!(:invitation) { create(:invitation, applicant: applicant2, rdv_context: rdv_context2, sent_at: 5.days.ago) }
 
         it "filters by action required" do
@@ -411,8 +419,8 @@ describe ApplicantsController, type: :controller do
         end
       end
 
-      context "when the invitation has not been sent more than 3 days ago" do
-        let!(:invitation) { create(:invitation, applicant: applicant2, rdv_context: rdv_context2, sent_at: 1.day.ago) }
+      context "when the invitation has been sent after the number of days defined in the configuration 3 days ago" do
+        let!(:invitation) { create(:invitation, applicant: applicant2, rdv_context: rdv_context2, sent_at: 3.days.ago) }
 
         it "filters by action required" do
           get :index, params: index_params

--- a/spec/factories/invitation.rb
+++ b/spec/factories/invitation.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     token { "some_token" }
     link { "https://www.rdv_solidarites.com/some_params" }
     format { :sms }
+    number_of_days_to_accept_invitation { 3 }
     department { create(:department) }
     association :applicant
     help_phone_number { "0139393939" }

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe InvitationMailer, type: :mailer do
   let!(:invitation) do
     create(
       :invitation,
-      applicant: applicant, token: token, department: department, format: "email", help_phone_number: help_phone_number
+      applicant: applicant, token: token, department: department, format: "email", help_phone_number: help_phone_number,
+      number_of_days_to_accept_invitation: 5
     )
   end
   let!(:token) { "some_token" }
@@ -35,6 +36,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       )
       expect(subject.body.encoded).to match("/invitations/redirect")
       expect(subject.body.encoded).to match("token=some_token")
+      expect(subject.body.encoded).to match("dans les 5 jours")
     end
   end
 
@@ -60,6 +62,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       )
       expect(subject.body.encoded).to match("/invitations/redirect")
       expect(subject.body.encoded).to match("token=some_token")
+      expect(subject.body.encoded).to match("dans les 5 jours")
     end
   end
 
@@ -85,6 +88,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         " afin de démarrer votre parcours d’accompagnement"
       )
       expect(subject.body.encoded).not_to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("dans un délai de 5 jours")
     end
   end
 end

--- a/spec/models/rdv_context_spec.rb
+++ b/spec/models/rdv_context_spec.rb
@@ -1,6 +1,8 @@
 describe RdvContext do
   describe "#action_required" do
-    subject { described_class.action_required }
+    subject { described_class.action_required(number_of_days_to_accept_invitation) }
+
+    let!(:number_of_days_to_accept_invitation) { 3 }
 
     context "when status requires action" do
       let!(:rdv_context) { create(:rdv_context, status: "rdv_noshow") }

--- a/spec/models/rdv_context_spec.rb
+++ b/spec/models/rdv_context_spec.rb
@@ -1,8 +1,8 @@
 describe RdvContext do
   describe "#action_required" do
-    subject { described_class.action_required(number_of_days_to_accept_invitation) }
+    subject { described_class.action_required(number_of_days_before_action_required) }
 
-    let!(:number_of_days_to_accept_invitation) { 3 }
+    let!(:number_of_days_before_action_required) { 3 }
 
     context "when status requires action" do
       let!(:rdv_context) { create(:rdv_context, status: "rdv_noshow") }

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -28,6 +28,7 @@ describe Invitations::SendSms, type: :service do
     create(
       :invitation,
       applicant: applicant, department: department, token: "123", help_phone_number: help_phone_number,
+      number_of_days_to_accept_invitation: 9,
       link: "https://www.rdv-solidarites.fr/lieux?invitation_token=123", format: "sms", rdv_context: rdv_context
     )
   end
@@ -38,7 +39,7 @@ describe Invitations::SendSms, type: :service do
     let!(:content) do
       "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
         "d'orientation. Pour choisir la date et l'horaire de votre premier RDV, cliquez sur le lien suivant "\
-        "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?token=123\n"\
+        "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?token=123\n"\
         "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le 0147200001."
     end
 
@@ -101,7 +102,7 @@ describe Invitations::SendSms, type: :service do
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
           "d'accompagnement. Pour choisir la date et l'horaire de votre premier RDV, cliquez sur le lien suivant "\
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?token=123\n"\
+          "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?token=123\n"\
           "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le 0147200001."
       end
 
@@ -121,7 +122,7 @@ describe Invitations::SendSms, type: :service do
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez contacter la plateforme départementale " \
           "afin de démarrer votre parcours d’accompagnement. Pour cela, merci d’appeler le " \
-          "0147200001 dans un délai de 3 jours. "\
+          "0147200001 dans un délai de 9 jours. "\
           "Cet appel est nécessaire pour le traitement de votre dossier."
       end
 


### PR DESCRIPTION
Cette PR est liée à #275 .

Dans cette PR j'ajoute une colonne `number_of_days_to_accept_invitation` à la table `invitations` ainsi qu'à la table `configurations`:

* Dans le 1er cas ça sert à afficher ce délai dynamiquement dans les SMS, mails et courriers
* Dans le 2eme cas ça sert à avoir un délai d'intervention nécessaire qui dépend du contexte dans lequel on est sur les vues des allocataires (index et show) 

J'en profite également pour supprimer la colonne `motif` de la table `letter_configurations` qui n'est plus utilisée.