### PR TITLE
fix(front): more coherent show page

### DIFF
--- a/app/javascript/react/components/InvitationBlock.jsx
+++ b/app/javascript/react/components/InvitationBlock.jsx
@@ -61,7 +61,7 @@ export default function InvitationBlock({
 
   return (
     <div className="d-flex justify-content-center">
-      <table className="tracking-block block-white text-center align-middle mb-4 mx-4">
+      <table className="block-white text-center align-middle mb-4 mx-4">
         <caption className="text-center">Dernières Invitations</caption>
         <thead>
           <tr>

--- a/app/javascript/stylesheets/pages/_applicants.scss
+++ b/app/javascript/stylesheets/pages/_applicants.scss
@@ -1,5 +1,13 @@
+.context-block {
+  th, td {
+    min-width: 140px;
+    max-width: 140px;
+  }
+}
+
 .block-white {
   background-color: white;
+  caption-side: top;
   border: 0.5px solid $light-grey;
   border-radius: 5px;
   padding: 20px;
@@ -30,16 +38,11 @@
   vertical-align: middle;
 }
 
-.tracking-block {
-  width: 40%;
-  caption-side: top;
-}
-
-@media (max-width: 991px) {
-  .tracking-block {
+@media (max-width: 1200px) {
+  .context-block {
+    flex-wrap: wrap;
+  }
+  .rdv-status-block {
     width: 80%;
-    &.block-2 {
-      margin-top: 30px;
-    }
   }
 }

--- a/app/javascript/stylesheets/pages/_applicants.scss
+++ b/app/javascript/stylesheets/pages/_applicants.scss
@@ -38,6 +38,19 @@
   vertical-align: middle;
 }
 
+.context-header {
+  width: 100%;
+  span {
+    display: block;
+    background-color: $dark-blue;
+    height: 4px;
+      width: 50px;
+    &:nth-child(3) {
+      flex-grow: 1;
+    }
+  }
+}
+
 @media (max-width: 1200px) {
   .context-block {
     flex-wrap: wrap;

--- a/app/javascript/stylesheets/pages/_applicants.scss
+++ b/app/javascript/stylesheets/pages/_applicants.scss
@@ -44,7 +44,7 @@
     display: block;
     background-color: $dark-blue;
     height: 4px;
-      width: 50px;
+    width: 50px;
     &:nth-child(3) {
       flex-grow: 1;
     }

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -1,4 +1,16 @@
-<h5 class="text-center py-4"><%= configuration.context_name %></h5>
+<div class="d-flex align-items-center context-header">
+  <span></span>
+  <h5 class="text-center px-2 py-4"><strong><%= configuration.context_name %></strong></h5>
+  <span></span>
+      <table class="mx-2">
+        <tbody>
+          <tr>
+            <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context) %>" id="js-block-status-<%= configuration.context %>"><em><%= display_context_status(rdv_context) %></em></td>
+          </tr>
+        </tbody>
+      </table>
+  <span></span>
+</div>
 <div class="context-block d-flex justify-content-center">
   <% if configuration.invitation_formats.any? %>
     <%= react_component(
@@ -50,21 +62,6 @@
               <td class="px-4 py-3"></td>
             </tr>
           <% end %>
-        </tbody>
-      </table>
-    </div>
-    <div>
-      <table class="block-white text-center align-middle m-4">
-        <caption></caption>
-        <thead>
-          <tr>
-            <th class="px-4 py-2"><h4>Statut global</h4></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="px-2 py-4 context-status <%= background_class_for_context_status(rdv_context) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context) %></td>
-          </tr>
         </tbody>
       </table>
     </div>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -5,7 +5,7 @@
       <table class="mx-2">
         <tbody>
           <tr>
-            <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context) %>" id="js-block-status-<%= configuration.context %>"><em><%= display_context_status(rdv_context) %></em></td>
+            <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context, configuration.number_of_days_before_action_required) %>" id="js-block-status-<%= configuration.context %>"><em><%= display_context_status(rdv_context, configuration.number_of_days_before_action_required) %></em></td>
           </tr>
         </tbody>
       </table>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -1,7 +1,7 @@
 <h5 class="text-center py-4"><%= configuration.context_name %></h5>
-<div class="d-flex justify-content-around">
+<div class="context-block d-flex justify-content-center">
   <% if configuration.invitation_formats.any? %>
-     <%= react_component(
+    <%= react_component(
       "components/InvitationBlock", {
         applicant: @applicant,
         organisation: @organisation,
@@ -14,8 +14,9 @@
       }
     ) %>
   <% end %>
-  <% if rdv_context&.rdvs.present? %>
-      <table class="tracking-block block-white text-center align-middle mb-4 mx-4">
+  <div class="d-flex justify-content-center rdv-status-block">
+    <div>
+      <table class="block-white text-center align-middle mb-4 mx-4">
         <caption class="text-center">RDVs</caption>
         <thead>
           <tr>
@@ -26,36 +27,46 @@
           </tr>
         </thead>
         <tbody>
-          <% rdv_context.rdvs.each do |rdv| %>
+          <% if rdv_context&.rdvs.present? %>
+            <% rdv_context.rdvs.each do |rdv| %>
+              <tr>
+                <td class="px-4 py-3"><%= format_date(rdv.created_at) %></td>
+                <td class="px-4 py-3"><%= format_date(rdv.starts_at) %></td>
+                <td class="px-4 py-3 <%= background_class_for_rdv_status(rdv) %>"><%= display_rdv_status(rdv) %></td>
+                <td class="px-4 py-3">
+                  <%= link_to rdv.rdv_solidarites_url, target: "_blank" do %>
+                    <button class="btn btn-blue">
+                      Voir sur RDV-S<i class="fas fa-external-link-alt icon-sm"></i>
+                    </button>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% else %>
             <tr>
-              <td class="px-4 py-3"><%= format_date(rdv.created_at) %></td>
-              <td class="px-4 py-3"><%= format_date(rdv.starts_at) %></td>
-              <td class="px-4 py-3 <%= background_class_for_rdv_status(rdv) %>"><%= display_rdv_status(rdv) %></td>
-              <td class="px-4 py-2">
-                <%= link_to rdv.rdv_solidarites_url, target: "_blank" do %>
-                  <button class="btn btn-blue">
-                    Voir sur RDV-S<i class="fas fa-external-link-alt icon-sm"></i>
-                  </button>
-                <% end %>
-              </td>
+              <td class="px-4 py-3">-</td>
+              <td class="px-4 py-3">-</td>
+              <td class="px-4 py-3">-</td>
+              <td class="px-4 py-3"></td>
             </tr>
           <% end %>
         </tbody>
       </table>
-  <% end %>
-  <div className="d-flex justify-content-center">
-    <table class="tracking-block block-white text-center align-middle m-4">
-      <caption></caption>
-      <thead>
-        <tr>
-          <th class="px-4 py-2"><h4>Statut global</h4></th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="p-4 <%= background_class_for_context_status(rdv_context) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context) %></td>
-        </tr>
-      </tbody>
-    </table>
+    </div>
+    <div>
+      <table class="block-white text-center align-middle m-4">
+        <caption></caption>
+        <thead>
+          <tr>
+            <th class="px-4 py-2"><h4>Statut global</h4></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="px-2 py-4 context-status <%= background_class_for_context_status(rdv_context) %>" id="js-block-status-<%= configuration.context %>"><%= display_context_status(rdv_context) %></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -2,13 +2,13 @@
   <span></span>
   <h5 class="text-center px-2 py-4"><strong><%= configuration.context_name %></strong></h5>
   <span></span>
-      <table class="mx-2">
-        <tbody>
-          <tr>
-            <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context, configuration.number_of_days_before_action_required) %>" id="js-block-status-<%= configuration.context %>"><em><%= display_context_status(rdv_context, configuration.number_of_days_before_action_required) %></em></td>
-          </tr>
-        </tbody>
-      </table>
+  <table class="mx-2">
+    <tbody>
+      <tr>
+        <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context, configuration.number_of_days_before_action_required) %>" id="js-block-status-<%= configuration.context %>"><em><%= display_context_status(rdv_context, configuration.number_of_days_before_action_required) %></em></td>
+      </tr>
+    </tbody>
+  </table>
   <span></span>
 </div>
 <div class="context-block d-flex justify-content-center">

--- a/config/locales/models/rdv_context.fr.yml
+++ b/config/locales/models/rdv_context.fr.yml
@@ -5,6 +5,7 @@ fr:
     attributes:
       rdv_context:
         statuses:
+          not_invited: Non invité
           invitation_pending: Invitation en attente de réponse
           rdv_pending: RDV pris
           rdv_needs_status_update: Statut du RDV à préciser


### PR DESCRIPTION
Dans cette PR, je retravaille légèrement les blocs invitations/rdvs/statuts de la page `show` afin de : 
- ne plus rendre l'affichage du bloc rdvs optionnel
- avoir des blocs qui gardent la même largeur d'un bRSA à un autre, pour appréhender plus facilement les infos
- avoir des blocs lisibles en toutes circonstances (par exemple : la case du statut était jusque là un peu étroite ; les retours à la ligne du bouton "voir sur rdv-s" n'étaient pas optimaux)
- avoir un design responsive jusqu'à l'ipad (en-dessous, ça devient difficile, mais ça ne sera sans doute pas consulté sur mobile ; cela permet au moins une bonne consultation quand le navigateur n'est pas en fullscreen)