### PR TITLE
fix(upload): set current configuration on upload when multiple contexts 

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -28,7 +28,7 @@ class UploadsController < ApplicationController
   def set_current_configuration
     @current_configuration = \
       if params[:configuration_id].present?
-        @all_configurations.find(params[:configuration_id])
+        @all_configurations.find { |config| config.id == params[:configuration_id].to_i }
       elsif @all_configurations.length == 1
         @all_configurations.first
       end


### PR DESCRIPTION
Dans cette PR, je corrige un bug qui apparaissait sur la page `upload` au moment de la sélection du contexte au niveau du département.