### PR TITLE
fix(invitations): Fix postal invitations

### DIFF
--- a/app/javascript/react/actions/getInvitationLetter.js
+++ b/app/javascript/react/actions/getInvitationLetter.js
@@ -7,6 +7,7 @@ const getInvitationLetter = async (
   organisation,
   isDepartmentLevel,
   context,
+  numberOfDaysToAcceptInvitation,
   invitationFormat
 ) => {
   const result = await inviteApplicant(
@@ -17,6 +18,7 @@ const getInvitationLetter = async (
     invitationFormat,
     organisation.phone_number,
     context,
+    numberOfDaysToAcceptInvitation,
     "application/json, application/pdf"
   );
   if (result.success === false) {


### PR DESCRIPTION
Permet de régler [cette erreur](https://sentry.incubateur.net/organizations/betagouv/issues/187/?project=16&query=is%3Aunresolved) sur sentry qui fait que les courriers ne peuvent pas être générés.

Je pense qu'on pourrait à l'avenir regrouper les méthodes `handleApplicantInvitation`,  `inviteApplicant` et `getInvitationLetter` au même endroit pour éviter ce genre d'erreur.