### PR TITLE
feat(letters): allow non svg logos for letters

### DIFF
--- a/app/helpers/pdf_helper.rb
+++ b/app/helpers/pdf_helper.rb
@@ -8,6 +8,12 @@ module PdfHelper
   def pdf_image_tag(source)
     return if Rails.env.test?
 
-    image_tag wicked_pdf_asset_pack_path("media/images/#{source}")
+    if Webpacker.manifest.lookup("media/images/logos/#{source}.svg")
+      image_tag wicked_pdf_asset_pack_path("media/images/logos/#{source}.svg")
+    elsif Webpacker.manifest.lookup("media/images/logos/#{source}.png")
+      image_tag wicked_pdf_asset_pack_path("media/images/logos/#{source}.png")
+    elsif Webpacker.manifest.lookup("media/images/logos/#{source}.jpg")
+      image_tag wicked_pdf_asset_pack_path("media/images/logos/#{source}.jpg")
+    end
   end
 end

--- a/app/views/letters/_footer.html.erb
+++ b/app/views/letters/_footer.html.erb
@@ -1,8 +1,8 @@
 <div>
   <div class="left-col department-logo">
-    <%= pdf_image_tag("logos/#{department.name.parameterize}.svg") %>
+    <%= pdf_image_tag(department.name.parameterize) %>
   </div>
   <div class="right-col rdvi-logo">
-    <%= pdf_image_tag('logos/rdv-insertion.svg') %>
+    <%= pdf_image_tag("rdv-insertion") %>
   </div>
 </div>

--- a/app/views/letters/_header.html.erb
+++ b/app/views/letters/_header.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div class="left-col">
     <div class="department-logo">
-      <%= pdf_image_tag("logos/#{department.name.parameterize}.svg") %>
+      <%= pdf_image_tag(department.name.parameterize) %>
     </div>
     <% letter_configuration.direction_names.each do |direction_name| %>
       <p><%= direction_name.upcase %></p>


### PR DESCRIPTION
Dans cette PR, je permet l'utilisation de logos non svg pour les départements dans les courriers. La priorité est donné au logo `svg` ; si un tel logo n'est pas trouvé, l'application cherchera ensuite un logo `png`, puis un logo `jpg`.