### PR TITLE
feat(webhook): Add outgoing webhook mechanism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ gem "sentry-ruby"
 gem "sentry-rails"
 gem "sentry-sidekiq"
 
+# JSON web token
+gem "jwt"
+
 # Forms
 gem "simple_form"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     json (2.5.1)
+    jwt (2.3.0)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -368,6 +369,7 @@ DEPENDENCIES
   factory_bot_rails
   faraday
   jbuilder (~> 2.7)
+  jwt
   kaminari
   letter_opener
   listen (~> 3.2)

--- a/app/controllers/api/v1/applicants_controller.rb
+++ b/app/controllers/api/v1/applicants_controller.rb
@@ -25,6 +25,10 @@ module Api
         create_and_invite_params.to_h.deep_symbolize_keys[:applicants]
       end
 
+      def invitations_params
+        applicants_attributes.pluck(:invitation)
+      end
+
       def set_organisation
         @organisation = Organisation.find_by!(rdv_solidarites_organisation_id: params[:rdv_solidarites_organisation_id])
         authorize @organisation, :create_and_invite_applicants?

--- a/app/controllers/concerns/api/v1/params_validation_concern.rb
+++ b/app/controllers/concerns/api/v1/params_validation_concern.rb
@@ -12,8 +12,20 @@ module Api
       def validate_params
         @params_validation_errors = []
 
+        validate_applicants_length
+        validate_applicants_attributes
+        validate_invitations_params
+      end
+
+      def validate_applicants_length
+        return if applicants_attributes.length <= 25
+
+        @params_validation_errors << "Les allocataires doivent être envoyés par lots de 25 maximum"
+      end
+
+      def validate_applicants_attributes
         applicants_attributes.each_with_index do |applicant_attributes, idx|
-          validator = ParamsValidator.new(applicant_attributes.except(:invitation))
+          validator = ApplicantParamsValidator.new(applicant_attributes.except(:invitation))
           next if validator.valid?
 
           department_internal_id = applicant_attributes[:department_internal_id]
@@ -23,7 +35,19 @@ module Api
         end
       end
 
-      class ParamsValidator
+      def validate_invitations_params
+        possible_contexts = @organisation.configurations.map(&:context)
+
+        invitations_params.each_with_index do |invitation_params, idx|
+          context = invitation_params[:context]
+          # we don't have to precise the context if there is only one context possible
+          next if (context.blank? && possible_contexts.length == 1) || context.in?(possible_contexts)
+
+          @params_validation_errors << { "Entrée #{idx + 1}": "Invitation context #{context} est invalide" }
+        end
+      end
+
+      class ApplicantParamsValidator
         include ActiveModel::Model
         include HasPhoneNumberConcern
 
@@ -31,6 +55,8 @@ module Api
 
         validates_presence_of :first_name, :last_name, :title, :affiliation_number, :role, :department_internal_id
         validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
+        validates :role, inclusion: { in: %w[demandeur conjoint] }
+        validates :title, inclusion: { in: %w[monsieur madame] }
       end
     end
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -66,9 +66,11 @@ class InvitationsController < ApplicationController
   end
 
   def set_rdv_context
-    @rdv_context = RdvContext.find_or_create_by!(
-      context: params[:rdv_context][:context], applicant: @applicant
-    )
+    RdvContext.with_advisory_lock "setting_rdv_context_for_applicant_#{@applicant.id}" do
+      @rdv_context = RdvContext.find_or_create_by!(
+        context: params[:rdv_context][:context], applicant: @applicant
+      )
+    end
   end
 
   def set_department

--- a/app/jobs/send_rdv_webhook_job.rb
+++ b/app/jobs/send_rdv_webhook_job.rb
@@ -1,0 +1,68 @@
+class OutgoingWebhookError < StandardError; end
+
+class SendRdvWebhookJob < ApplicationJob
+  JWT_PAYLOAD_KEYS = [:id, :first_name, :last_name].freeze
+
+  def perform(webhook_endpoint_id, rdv_payload, applicant_ids, meta)
+    @webhook_endpoint_id = webhook_endpoint_id
+    @rdv_payload = rdv_payload.deep_symbolize_keys
+    @applicant_ids = applicant_ids
+    @meta = meta.deep_symbolize_keys
+
+    send_webhook
+  end
+
+  private
+
+  def send_webhook
+    response = Faraday.post(
+      webhook_endpoint.url,
+      webhook_payload.to_json,
+      request_headers
+    )
+    raise OutgoingWebhookError, error_message_for(response) unless response.success?
+  end
+
+  def error_message_for(response)
+    "Could not send webhook to url #{webhook_endpoint.url}\n" \
+      "rdv solidarites rdv id: #{@rdv_payload[:id]}\n" \
+      "response status: #{response.status}\n" \
+      "response body: #{response.body.force_encoding('UTF-8')[0...1000]}"
+  end
+
+  # See https://pad.incubateur.net/s/3lA9V4g5Q#Payload-de-la-requ%C3%AAte
+  def webhook_payload
+    @webhook_payload ||= begin
+      payload = @rdv_payload
+      payload.delete(:users)
+      payload[:applicants] = applicants.map(&:payload)
+      payload[:event] = @meta[:event]
+      payload
+    end
+  end
+
+  def applicants
+    @applicants ||= Applicant.where(id: @applicant_ids)
+  end
+
+  def webhook_endpoint
+    @webhook_endpoint ||= WebhookEndpoint.find(@webhook_endpoint_id)
+  end
+
+  def request_headers
+    {
+      "Content-Type" => "application/json",
+      "Accept" => "application/json",
+      "Authorization" => "Bearer #{generated_jwt}"
+    }
+  end
+
+  def generated_jwt
+    JWT.encode(jwt_payload, webhook_endpoint.secret, 'HS256')
+  end
+
+  def jwt_payload
+    # See https://pad.incubateur.net/s/3lA9V4g5Q#Headers
+    @applicants.first.payload.slice(*JWT_PAYLOAD_KEYS).merge(exp: 10.minutes.from_now.to_i)
+  end
+end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -83,6 +83,14 @@ class Applicant < ApplicationRecord
     rdv_contexts.find { |rc| rc.context == context }
   end
 
+  def payload
+    payload_attributes_keys = [
+      :id, :affiliation_number, :role, :department_internal_id, :first_name,
+      :last_name, :address, :phone_number, :email, :title, :birth_date, :rights_opening_date
+    ]
+    attributes.deep_symbolize_keys.slice(*payload_attributes_keys)
+  end
+
   def as_json(_opts = {})
     super.merge(
       created_at: created_at,

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -35,9 +35,7 @@ class Invitation < ApplicationRecord
   end
 
   def as_json(_opts = {})
-    super.merge(
-      context: context
-    )
+    super.merge(context: context)
   end
 
   private

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,6 +9,8 @@ class Organisation < ApplicationRecord
   has_and_belongs_to_many :applicants, dependent: :nullify
   has_and_belongs_to_many :invitations, dependent: :nullify
   has_and_belongs_to_many :configurations
+  has_and_belongs_to_many :webhook_endpoints
+
   belongs_to :responsible, optional: true
   belongs_to :letter_configuration, optional: true
   has_many :rdvs, dependent: :nullify

--- a/app/models/rdv_solidarites/rdv.rb
+++ b/app/models/rdv_solidarites/rdv.rb
@@ -34,7 +34,7 @@ module RdvSolidarites
       RdvSolidarites::Motif.new(@attributes[:motif])
     end
 
-    def to_rdv_insertion_attributes
+    def payload
       attributes.merge(
         rdv_solidarites_motif_id: motif_id,
         rdv_solidarites_lieu_id: lieu_id

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -1,0 +1,3 @@
+class WebhookEndpoint < ApplicationRecord
+  has_and_belongs_to_many :organisations
+end

--- a/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
+++ b/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
@@ -17,7 +17,7 @@ module Migrations
 
         UpsertRecordJob.perform_async(
           Rdv,
-          rdv.to_rdv_insertion_attributes,
+          rdv.payload,
           { applicant_ids: applicant_ids, organisation_id: @organisation_id }
         )
       end

--- a/db/migrate/20220425164025_create_webhook_endpoints.rb
+++ b/db/migrate/20220425164025_create_webhook_endpoints.rb
@@ -1,0 +1,18 @@
+class CreateWebhookEndpoints < ActiveRecord::Migration[6.1]
+  def change
+    create_table :webhook_endpoints do |t|
+      t.string :url
+      t.string :secret
+
+      t.timestamps
+    end
+
+    create_join_table :organisations, :webhook_endpoints do |t|
+      t.index(
+        [:organisation_id, :webhook_endpoint_id],
+        unique: true,
+        name: "index_webhook_orgas_on_orga_id_and_webhook_id"
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_151557) do
+ActiveRecord::Schema.define(version: 2022_04_25_164025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,6 +157,12 @@ ActiveRecord::Schema.define(version: 2022_04_12_151557) do
     t.index ["responsible_id"], name: "index_organisations_on_responsible_id"
   end
 
+  create_table "organisations_webhook_endpoints", id: false, force: :cascade do |t|
+    t.bigint "organisation_id", null: false
+    t.bigint "webhook_endpoint_id", null: false
+    t.index ["organisation_id", "webhook_endpoint_id"], name: "index_webhook_orgas_on_orga_id_and_webhook_id", unique: true
+  end
+
   create_table "rdv_contexts", force: :cascade do |t|
     t.integer "context"
     t.integer "status"
@@ -201,6 +207,13 @@ ActiveRecord::Schema.define(version: 2022_04_12_151557) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "role"
+  end
+
+  create_table "webhook_endpoints", force: :cascade do |t|
+    t.string "url"
+    t.string "secret"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "applicants", "departments"

--- a/spec/factories/webhook_endpoint.rb
+++ b/spec/factories/webhook_endpoint.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :webhook_endpoint do
+    url { "http://test-departement/api/v1/webhook" }
+    secret { "secret" }
+  end
+end

--- a/spec/jobs/create_and_invite_applicant_job_spec.rb
+++ b/spec/jobs/create_and_invite_applicant_job_spec.rb
@@ -1,30 +1,37 @@
 describe CreateAndInviteApplicantJob, type: :job do
   subject do
     described_class.new.perform(
-      organisation_id, applicant_attributes, invitation_attributes, rdv_solidarites_session_credentials
+      organisation_id, applicant_attributes, invitation_params, rdv_solidarites_session_credentials
     )
   end
 
   let!(:organisation_id) { 99 }
   let!(:department) { create(:department) }
-  let!(:organisation) { create(:organisation, department: department, id: organisation_id, phone_number: "0146292929") }
+  let!(:organisation) do
+    create(
+      :organisation,
+      department: department, configurations: [configuration], id: organisation_id, phone_number: "0146292929"
+    )
+  end
+  let!(:context) { "rsa_orientation" }
+  let!(:configuration) { create(:configuration, context: context) }
   let!(:applicant) { create(:applicant) }
   let!(:applicant_attributes) do
     { department_internal_id: "1919", affiliation_number: "00001", role: "conjoint", phone_number: "07070707",
       email: "john.doe@apijob.com" }
   end
-  let!(:invitation_attributes) { { rdv_solidarites_lieu_id: 888 } }
+  let!(:invitation_params) { { rdv_solidarites_lieu_id: 888 } }
   let!(:sms_invitation_attributes) do
-    invitation_attributes.merge(help_phone_number: "0146292929", context: "RSA orientation", format: "sms")
+    { help_phone_number: "0146292929", format: "sms", rdv_solidarites_lieu_id: 888 }
   end
   let!(:email_invitation_attributes) do
-    invitation_attributes.merge(help_phone_number: "0146292929", context: "RSA orientation", format: "email")
+    { help_phone_number: "0146292929", format: "email", rdv_solidarites_lieu_id: 888 }
   end
   let!(:rdv_solidarites_session_credentials) { session_hash.symbolize_keys }
   let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession) }
 
   before do
-    allow(Applicant).to receive(:new).and_return(applicant)
+    allow(FindOrInitializeApplicant).to receive(:call).and_return(OpenStruct.new(applicant: applicant))
     allow(SaveApplicant).to receive(:call).and_return(OpenStruct.new(success?: true, failure?: false))
     allow(RdvSolidaritesSession).to receive(:new)
       .with(rdv_solidarites_session_credentials)
@@ -46,133 +53,80 @@ describe CreateAndInviteApplicantJob, type: :job do
 
   it "enqueues invite applicant jobs" do
     expect(InviteApplicantJob).to receive(:perform_async)
-      .with(applicant.id, organisation.id, sms_invitation_attributes, rdv_solidarites_session_credentials)
+      .with(applicant.id, organisation.id, sms_invitation_attributes, context, rdv_solidarites_session_credentials)
     expect(InviteApplicantJob).to receive(:perform_async)
-      .with(applicant.id, organisation.id, email_invitation_attributes, rdv_solidarites_session_credentials)
+      .with(applicant.id, organisation.id, email_invitation_attributes, context, rdv_solidarites_session_credentials)
     subject
   end
 
-  context "when the applicant already exists" do
-    context "from department internal id" do
-      let!(:applicant) { create(:applicant, organisations: [organisation], department_internal_id: "1919") }
+  context "when there is no phone" do
+    before { applicant_attributes[:phone_number] = nil }
 
-      before do
-        allow(Applicant).to receive(:find_by).with(department_internal_id: "1919").and_return(applicant)
-      end
+    it "does not enqueue an invite sms job" do
+      expect(InviteApplicantJob).not_to receive(:perform_async)
+        .with(applicant.id, organisation.id, sms_invitation_attributes, context, rdv_solidarites_session_credentials)
+      subject
+    end
+  end
 
-      it "does not instantiate a new appicant" do
-        expect(Applicant).not_to receive(:new)
-        subject
-      end
+  context "when there is no email" do
+    before { applicant_attributes[:email] = nil }
 
-      it "assigns the attributes" do
-        expect(applicant).to receive(:assign_attributes)
-          .with(applicant_attributes.merge(department: department, organisations: [organisation]))
-        subject
-      end
+    it "does not enqueue an invite email job" do
+      expect(InviteApplicantJob).not_to receive(:perform_async)
+        .with(applicant.id, organisation.id,  email_invitation_attributes, context, rdv_solidarites_session_credentials)
+      subject
+    end
+  end
 
-      it "saves the applicant" do
-        expect(SaveApplicant).to receive(:call)
-          .with(applicant: applicant, organisation: organisation, rdv_solidarites_session: rdv_solidarites_session)
-        subject
-      end
+  context "when a context is specified" do
+    let!(:invitation_params) { { rdv_solidarites_lieu_id: 888, context: "rsa_accompagnement" } }
 
-      it "enqueues invite applicant jobs" do
-        expect(InviteApplicantJob).to receive(:perform_async)
-          .with(applicant.id, organisation.id, sms_invitation_attributes, rdv_solidarites_session_credentials)
-        expect(InviteApplicantJob).to receive(:perform_async)
-          .with(applicant.id, organisation.id, email_invitation_attributes, rdv_solidarites_session_credentials)
-        subject
-      end
+    it "enqueues invite applicant jobs with the specified context" do
+      expect(InviteApplicantJob).to receive(:perform_async)
+        .with(
+          applicant.id,
+          organisation.id, sms_invitation_attributes, "rsa_accompagnement", rdv_solidarites_session_credentials
+        )
+      expect(InviteApplicantJob).to receive(:perform_async)
+        .with(
+          applicant.id,
+          organisation.id, email_invitation_attributes, "rsa_accompagnement", rdv_solidarites_session_credentials
+        )
+      subject
+    end
+  end
+
+  context "when the save fails" do
+    let!(:department_mail) { instance_double("mail") }
+
+    before do
+      allow(SaveApplicant).to receive(:call)
+        .and_return(OpenStruct.new(failure?: true, errors: ["could not save applicant"]))
+      allow(Sentry).to receive(:capture_exception)
+      allow(DepartmentMailer).to receive(:create_applicant_error).and_return(department_mail)
+      allow(department_mail).to receive(:deliver_now)
     end
 
-    context "from affiliation_number and role" do
-      let!(:applicant) do
-        create(:applicant, organisations: [organisation], affiliation_number: "00001", role: "conjoint")
-      end
-
-      before do
-        allow(Applicant).to receive(:find_by).with(department_internal_id: "1919").and_return(nil)
-        allow(Applicant).to receive(:find_by).with(affiliation_number: "00001", role: "conjoint").and_return(applicant)
-      end
-
-      it "does not instantiate a new appicant" do
-        expect(Applicant).not_to receive(:new)
-        subject
-      end
-
-      it "assigns the attributes" do
-        expect(applicant).to receive(:assign_attributes)
-          .with(applicant_attributes.merge(department: department, organisations: [organisation]))
-        subject
-      end
-
-      it "saves the applicant" do
-        expect(SaveApplicant).to receive(:call)
-          .with(applicant: applicant, organisation: organisation, rdv_solidarites_session: rdv_solidarites_session)
-        subject
-      end
-
-      it "enqueues invite applicant jobs" do
-        expect(InviteApplicantJob).to receive(:perform_async)
-          .with(applicant.id, organisation.id, sms_invitation_attributes, rdv_solidarites_session_credentials)
-        expect(InviteApplicantJob).to receive(:perform_async)
-          .with(applicant.id, organisation.id, email_invitation_attributes, rdv_solidarites_session_credentials)
-        subject
-      end
+    it "captures the exception" do
+      exception = FailedServiceError.new("Error saving applicant in CreateAndInviteApplicantJob")
+      expect(Sentry).to receive(:capture_exception)
+        .with(
+          exception,
+          extra: {
+            applicant: applicant,
+            service_errors: ["could not save applicant"],
+            organisation: organisation
+          }
+        )
+      subject
     end
 
-    context "when there is no phone" do
-      before { applicant_attributes[:phone_number] = nil }
-
-      it "does not enqueue an invite sms job" do
-        expect(InviteApplicantJob).not_to receive(:perform_async)
-          .with(applicant.id, organisation.id, sms_invitation_attributes, rdv_solidarites_session_credentials)
-        subject
-      end
-    end
-
-    context "when there is no email" do
-      before { applicant_attributes[:email] = nil }
-
-      it "does not enqueue an invite email job" do
-        expect(InviteApplicantJob).not_to receive(:perform_async)
-          .with(applicant.id, organisation.id,  email_invitation_attributes, rdv_solidarites_session_credentials)
-        subject
-      end
-    end
-
-    context "when the save fails" do
-      let!(:department_mail) { instance_double("mail") }
-
-      before do
-        allow(SaveApplicant).to receive(:call)
-          .and_return(OpenStruct.new(failure?: true, errors: ["could not save applicant"]))
-        allow(Sentry).to receive(:capture_exception)
-        allow(DepartmentMailer).to receive(:create_applicant_error).and_return(department_mail)
-        allow(department_mail).to receive(:deliver_now)
-      end
-
-      it "captures the exception" do
-        exception = FailedServiceError.new("Error saving applicant in CreateAndInviteApplicantJob")
-        expect(Sentry).to receive(:capture_exception)
-          .with(
-            exception,
-            extra: {
-              applicant: applicant,
-              service_errors: ["could not save applicant"],
-              organisation: organisation
-            }
-          )
-        subject
-      end
-
-      it "sends an email to the department" do
-        expect(DepartmentMailer).to receive(:create_applicant_error)
-          .with(department, applicant, ["could not save applicant"])
-        expect(department_mail).to receive(:deliver_now)
-        subject
-      end
+    it "sends an email to the department" do
+      expect(DepartmentMailer).to receive(:create_applicant_error)
+        .with(department, applicant, ["could not save applicant"])
+      expect(department_mail).to receive(:deliver_now)
+      subject
     end
   end
 end

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -32,6 +32,13 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
     }.deep_symbolize_keys
   end
 
+  let!(:rdv_payload) do
+    data.merge(
+      rdv_solidarites_motif_id: rdv_solidarites_motif_id,
+      rdv_solidarites_lieu_id: rdv_solidarites_lieu_id
+    )
+  end
+
   let!(:applicant) { create(:applicant, organisations: [organisation], id: 3) }
   let!(:applicant2) { create(:applicant, organisations: [organisation], id: 4) }
 
@@ -68,6 +75,7 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
       allow(UpsertRecordJob).to receive(:perform_async)
       allow(DeleteRdvJob).to receive(:perform_async)
       allow(NotifyApplicantJob).to receive(:perform_async)
+      allow(SendRdvWebhookJob).to receive(:perform_async)
       allow(MattermostClient).to receive(:send_to_notif_channel)
     end
 
@@ -101,18 +109,11 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
     end
 
     context "it udpates the rdv" do
-      let!(:rdv_attributes) do
-        data.merge(
-          rdv_solidarites_motif_id: rdv_solidarites_motif_id,
-          rdv_solidarites_lieu_id: rdv_solidarites_lieu_id
-        )
-      end
-
       it "enqueues an upsert job" do
         expect(UpsertRecordJob).to receive(:perform_async)
           .with(
             "Rdv",
-            rdv_attributes,
+            rdv_payload,
             {
               applicant_ids: [applicant.id, applicant2.id],
               organisation_id: organisation.id,
@@ -200,6 +201,18 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
 
       it "sends a notif to mattermost" do
         expect(MattermostClient).to receive(:send_to_notif_channel)
+        subject
+      end
+    end
+
+    context "when there are webhook endpoints associated to the org" do
+      let!(:webhook_endpoint) do
+        create(:webhook_endpoint, organisations: [organisation])
+      end
+
+      it "enqueues a webhook job" do
+        expect(SendRdvWebhookJob).to receive(:perform_async)
+          .with(webhook_endpoint.id, rdv_payload, [3, 4], meta)
         subject
       end
     end

--- a/spec/jobs/send_rdv_webhook_job_spec.rb
+++ b/spec/jobs/send_rdv_webhook_job_spec.rb
@@ -1,0 +1,103 @@
+describe SendRdvWebhookJob, type: :job do
+  subject do
+    described_class.new.perform(webhook_endpoint_id, rdv_payload, [93], meta)
+  end
+
+  let!(:webhook_endpoint_id) { 2222 }
+  let!(:webhook_url) { "http://some-test-url.com" }
+  let!(:webhook_secret) { "some-secret" }
+  let!(:webhook_endpoint) do
+    create(:webhook_endpoint, id: webhook_endpoint_id, url: webhook_url, secret: webhook_secret)
+  end
+
+  let!(:applicant) { create(:applicant, applicant_payload) }
+
+  let!(:applicant_payload) do
+    {
+      id: 93,
+      affiliation_number: "1231123",
+      role: "demandeur",
+      department_internal_id: "4444",
+      first_name: "john",
+      last_name: "doe",
+      address: "29 rue de la paix",
+      phone_number: "0743399339",
+      email: "john@doe.com",
+      title: "monsieur",
+      birth_date: "1958-11-21",
+      rights_opening_date: "2020-11-21"
+    }
+  end
+
+  let!(:rdv_payload) do
+    {
+      id: 12,
+      users: [
+        { id: 1231, first_name: "john", last_name: "doe" }
+      ],
+      lieu: { id: "1122112", address: "20 avenue de ségur" }
+    }
+  end
+
+  let!(:meta) { { event: "created" } }
+
+  describe "#perform" do
+    let!(:now) { Date.new(2022, 7, 22) }
+    let!(:exp) { (now + 10.minutes).to_i }
+    let!(:jwt_payload) do
+      { id: 93, first_name: "john", last_name: "doe", exp: exp }
+    end
+    let!(:jwt_token) { "stubbed-token" }
+    let!(:webhook_payload) do
+      {
+        id: 12,
+        lieu: { id: "1122112", address: "20 avenue de ségur" },
+        applicants: [applicant_payload],
+        event: "created"
+      }.to_json
+    end
+    let!(:request_headers) do
+      {
+        "Content-Type" => "application/json",
+        "Accept" => "application/json",
+        "Authorization" => "Bearer stubbed-token"
+      }
+    end
+
+    before do
+      travel_to(now)
+
+      allow(JWT).to receive(:encode)
+        .with(jwt_payload, webhook_secret, "HS256")
+        .and_return(jwt_token)
+      allow(Faraday).to receive(:post)
+        .with(webhook_url, webhook_payload, request_headers)
+        .and_return(OpenStruct.new(success?: true))
+    end
+
+    it "sends the webhook" do
+      expect(Faraday).to receive(:post)
+        .with(webhook_url, webhook_payload, request_headers)
+      subject
+    end
+
+    context "when the request fails" do
+      before do
+        allow(Faraday).to receive(:post)
+          .with(webhook_url, webhook_payload, request_headers)
+          .and_return(OpenStruct.new(success?: false, status: "422", body: "something happened"))
+      end
+
+      let!(:error_message) do
+        "Could not send webhook to url http://some-test-url.com\n" \
+          "rdv solidarites rdv id: 12\n" \
+          "response status: 422\n" \
+          "response body: something happened"
+      end
+
+      it "raises an error" do
+        expect { subject }.to raise_error(OutgoingWebhookError, error_message)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
 
   config.include AuthenticationSpecHelper
   config.include ServiceSpecHelper
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Cette PR rajoute le mécanisme de webhook sortant de RDVI (voir  #319), mais également des changements sur l'API pour prendre en compte les changements relatifs aux contextes.

Désolé j'ai pas eu le temps de séparer en 2 PRs, on a besoin des 2 pour la démo avec Marseille demain 😬 . Par contre les 2 commits de cette PR sont bien scopés.

Pour les webhooks j'ajoute une table `webhook_endpoints` comme sur RDV-S, et j'ajoute un job `SendRdvWebhookJob` qui sera appelé à la fin du traitement du webhook reçu depuis RDV-S. De cette façon RDVI jouera vraiment un rôle de "proxy" entre RDV-S et le département en ce qui concerne les webhooks.