### PR TITLE
refactor(webhooks): Change outgoing webhook payload

### DIFF
--- a/app/jobs/send_rdv_solidarites_webhook_job.rb
+++ b/app/jobs/send_rdv_solidarites_webhook_job.rb
@@ -1,13 +1,11 @@
 class OutgoingWebhookError < StandardError; end
 
-class SendRdvWebhookJob < ApplicationJob
-  JWT_PAYLOAD_KEYS = [:id, :first_name, :last_name].freeze
+class SendRdvSolidaritesWebhookJob < ApplicationJob
+  JWT_PAYLOAD_KEYS = [:id, :address, :starts_at].freeze
 
-  def perform(webhook_endpoint_id, rdv_payload, applicant_ids, meta)
+  def perform(webhook_endpoint_id, webhook_payload)
     @webhook_endpoint_id = webhook_endpoint_id
-    @rdv_payload = rdv_payload.deep_symbolize_keys
-    @applicant_ids = applicant_ids
-    @meta = meta.deep_symbolize_keys
+    @webhook_payload = webhook_payload.deep_symbolize_keys
 
     send_webhook
   end
@@ -17,7 +15,7 @@ class SendRdvWebhookJob < ApplicationJob
   def send_webhook
     response = Faraday.post(
       webhook_endpoint.url,
-      webhook_payload.to_json,
+      @webhook_payload.to_json,
       request_headers
     )
     raise OutgoingWebhookError, error_message_for(response) unless response.success?
@@ -25,24 +23,9 @@ class SendRdvWebhookJob < ApplicationJob
 
   def error_message_for(response)
     "Could not send webhook to url #{webhook_endpoint.url}\n" \
-      "rdv solidarites rdv id: #{@rdv_payload[:id]}\n" \
+      "rdv solidarites rdv id: #{@webhook_payload[:data][:id]}\n" \
       "response status: #{response.status}\n" \
       "response body: #{response.body.force_encoding('UTF-8')[0...1000]}"
-  end
-
-  # See https://pad.incubateur.net/s/3lA9V4g5Q#Payload-de-la-requ%C3%AAte
-  def webhook_payload
-    @webhook_payload ||= begin
-      payload = @rdv_payload
-      payload.delete(:users)
-      payload[:applicants] = applicants.map(&:payload)
-      payload[:event] = @meta[:event]
-      payload
-    end
-  end
-
-  def applicants
-    @applicants ||= Applicant.where(id: @applicant_ids)
   end
 
   def webhook_endpoint
@@ -63,6 +46,6 @@ class SendRdvWebhookJob < ApplicationJob
 
   def jwt_payload
     # See https://pad.incubateur.net/s/3lA9V4g5Q#Headers
-    @applicants.first.payload.slice(*JWT_PAYLOAD_KEYS).merge(exp: 10.minutes.from_now.to_i)
+    @webhook_payload[:data].slice(*JWT_PAYLOAD_KEYS).merge(exp: 10.minutes.from_now.to_i)
   end
 end

--- a/app/models/rdv_solidarites/rdv.rb
+++ b/app/models/rdv_solidarites/rdv.rb
@@ -34,7 +34,7 @@ module RdvSolidarites
       RdvSolidarites::Motif.new(@attributes[:motif])
     end
 
-    def payload
+    def to_rdv_insertion_attributes
       attributes.merge(
         rdv_solidarites_motif_id: motif_id,
         rdv_solidarites_lieu_id: lieu_id

--- a/app/models/rdv_solidarites/user.rb
+++ b/app/models/rdv_solidarites/user.rb
@@ -5,5 +5,16 @@ module RdvSolidarites
       :birth_name, :address, :affiliation_number, :created_at, :invited_at, :invitation_accepted_at
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
+
+    def augmented_attributes
+      @attributes.merge(
+        department_internal_id: applicant&.department_internal_id,
+        title: applicant&.title
+      )
+    end
+
+    def applicant
+      @applicant ||= Applicant.find_by(rdv_solidarites_user_id: @id)
+    end
   end
 end

--- a/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
+++ b/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
@@ -17,7 +17,7 @@ module Migrations
 
         UpsertRecordJob.perform_async(
           Rdv,
-          rdv.payload,
+          rdv.to_rdv_insertion_attributes,
           { applicant_ids: applicant_ids, organisation_id: @organisation_id }
         )
       end

--- a/spec/jobs/send_rdv_solidarites_webhook_job_spec.rb
+++ b/spec/jobs/send_rdv_solidarites_webhook_job_spec.rb
@@ -1,6 +1,6 @@
-describe SendRdvWebhookJob, type: :job do
+describe SendRdvSolidaritesWebhookJob, type: :job do
   subject do
-    described_class.new.perform(webhook_endpoint_id, rdv_payload, [93], meta)
+    described_class.new.perform(webhook_endpoint_id, webhook_payload)
   end
 
   let!(:webhook_endpoint_id) { 2222 }
@@ -9,53 +9,26 @@ describe SendRdvWebhookJob, type: :job do
   let!(:webhook_endpoint) do
     create(:webhook_endpoint, id: webhook_endpoint_id, url: webhook_url, secret: webhook_secret)
   end
-
-  let!(:applicant) { create(:applicant, applicant_payload) }
-
-  let!(:applicant_payload) do
+  let!(:webhook_payload) do
     {
-      id: 93,
-      affiliation_number: "1231123",
-      role: "demandeur",
-      department_internal_id: "4444",
-      first_name: "john",
-      last_name: "doe",
-      address: "29 rue de la paix",
-      phone_number: "0743399339",
-      email: "john@doe.com",
-      title: "monsieur",
-      birth_date: "1958-11-21",
-      rights_opening_date: "2020-11-21"
+      data: {
+        id: 12,
+        address: "20 avenue de Ségur 75015 Paris",
+        starts_at: "20-12-2022",
+        lieu: { id: "1122112", address: "20 avenue de ségur" },
+        users: [{ id: 5, department_internal_id: "6" }]
+      },
+      meta: { event: "created" }
     }
   end
-
-  let!(:rdv_payload) do
-    {
-      id: 12,
-      users: [
-        { id: 1231, first_name: "john", last_name: "doe" }
-      ],
-      lieu: { id: "1122112", address: "20 avenue de ségur" }
-    }
-  end
-
-  let!(:meta) { { event: "created" } }
 
   describe "#perform" do
     let!(:now) { Date.new(2022, 7, 22) }
     let!(:exp) { (now + 10.minutes).to_i }
     let!(:jwt_payload) do
-      { id: 93, first_name: "john", last_name: "doe", exp: exp }
+      { id: 12, address: "20 avenue de Ségur 75015 Paris", starts_at: "20-12-2022", exp: exp }
     end
     let!(:jwt_token) { "stubbed-token" }
-    let!(:webhook_payload) do
-      {
-        id: 12,
-        lieu: { id: "1122112", address: "20 avenue de ségur" },
-        applicants: [applicant_payload],
-        event: "created"
-      }.to_json
-    end
     let!(:request_headers) do
       {
         "Content-Type" => "application/json",
@@ -71,20 +44,20 @@ describe SendRdvWebhookJob, type: :job do
         .with(jwt_payload, webhook_secret, "HS256")
         .and_return(jwt_token)
       allow(Faraday).to receive(:post)
-        .with(webhook_url, webhook_payload, request_headers)
+        .with(webhook_url, webhook_payload.to_json, request_headers)
         .and_return(OpenStruct.new(success?: true))
     end
 
     it "sends the webhook" do
       expect(Faraday).to receive(:post)
-        .with(webhook_url, webhook_payload, request_headers)
+        .with(webhook_url, webhook_payload.to_json, request_headers)
       subject
     end
 
     context "when the request fails" do
       before do
         allow(Faraday).to receive(:post)
-          .with(webhook_url, webhook_payload, request_headers)
+          .with(webhook_url, webhook_payload.to_json, request_headers)
           .and_return(OpenStruct.new(success?: false, status: "422", body: "something happened"))
       end
 


### PR DESCRIPTION
Je change le webhook qu'on envoie à la sortie de RDV-Insertion. On reprend exactement le webhook de RDV-S auquel on ne rajoute que le `department_internal_id` et le `title` pour les `users` liés au RDV.