### PR TITLE
chore(ops): Add builpacks to support webpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack
+https://github.com/Scalingo/ruby-buildpack


### PR DESCRIPTION
Webpack étant déprécié sur Rails 7, il faut ajouter les buildpacks Node.js et Ruby pour continuer à l'utiliser avec Scalingo.

Je le mets en attendant de migrer webpack à terme (voir #365 )