### PR TITLE
feat(applicants): Lists all applicants with no rdv contexts

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -9,7 +9,7 @@ class ApplicantsController < ApplicationController
   before_action :set_applicant, only: [:show, :update, :edit]
   before_action :set_variables, only: [:index, :new, :create, :show, :update, :edit]
   before_action :retrieve_applicants, only: [:search]
-  before_action :set_not_invited_list, :set_applicants_and_rdv_contexts, only: [:index]
+  before_action :set_without_context_list, :set_applicants_and_rdv_contexts, only: [:index]
 
   include FilterableApplicantsConcern
 
@@ -133,8 +133,8 @@ class ApplicantsController < ApplicationController
       .find(params[:id])
   end
 
-  def set_not_invited_list
-    @not_invited_list = params[:not_invited] == "true"
+  def set_without_context_list
+    @without_context_list = params[:without_context] == "true"
   end
 
   def set_applicants_and_rdv_contexts # rubocop:disable Metrics/AbcSize
@@ -146,8 +146,8 @@ class ApplicantsController < ApplicationController
         @applicants.where(organisations: @organisation)
       end
 
-    if @not_invited_list
-      @applicants = @applicants.where.missing(:rdv_contexts)
+    if @without_context_list
+      @applicants = @applicants.without_rdv_contexts(@all_configurations.map(&:context))
     else
       @applicants = @applicants.joins(:rdv_contexts).where(rdv_contexts: { context: @current_context })
       @rdv_contexts = RdvContext.where(applicant_id: @applicants.archived(false).ids, context: @current_context)

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -24,7 +24,7 @@ module ApplicantsHelper
   end
 
   def no_search_results?(applicants)
-    applicants.empty? && params[:search_query].present?
+    applicants.to_a.empty? && params[:search_query].present?
   end
 
   def display_back_to_list_button?

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -38,6 +38,9 @@ class Applicant < ApplicationRecord
 
   scope :active, -> { where.not(status: "deleted") }
   scope :archived, ->(archived = true) { where(is_archived: archived) }
+  scope :without_rdv_contexts, lambda { |contexts|
+    where.not(id: joins(:rdv_contexts).where(rdv_contexts: { context: contexts }).ids)
+  }
 
   def orientation_date
     rdvs.find(&:seen?)&.starts_at

--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -2,11 +2,11 @@
   <ul class="nav nav-tabs">
     <% @all_configurations.each do |configuration| %>
       <li class="nav-item">
-        <%= link_to configuration.context_name, compute_index_path(@organisation, @department, context: configuration.context), class:  "nav-link #{!@not_invited_list && configuration.id == @current_configuration.id ? 'active' : ''}"%>
+        <%= link_to configuration.context_name, compute_index_path(@organisation, @department, context: configuration.context), class:  "nav-link #{!@without_context_list && configuration.id == @current_configuration.id ? 'active' : ''}"%>
       </li>
     <% end %>
     <li class="nav-item">
-      <%= link_to "Non invités", compute_index_path(@organisation, @department, not_invited: true), class: "nav-link #{@not_invited_list ? 'active' : ''}" %>
+      <%= link_to "Autres", compute_index_path(@organisation, @department, without_context: true), class: "nav-link #{@without_context_list ? 'active' : ''}" %>
     </li>
   </ul>
   <div class="col-12 text-center">
@@ -19,7 +19,7 @@
           <th scope="col">Prénom</th>
           <th scope="col" class="d-none d-lg-table-cell">Email</th>
           <th scope="col" class="d-none d-lg-table-cell">Téléphone</th>
-          <% unless @not_invited_list %>
+          <% unless @without_context_list %>
             <% if show_sms_invitation?(@current_configuration) %>
               <th scope="col">Dernière invitation SMS</th>
             <% end %>
@@ -44,7 +44,7 @@
               <td><%= display_attribute applicant.first_name %></td>
               <td class="d-none d-lg-table-cell"><%= display_attribute applicant.email %></td>
               <td class="d-none d-lg-table-cell"><%= display_attribute applicant.phone_number %></td>
-              <% unless @not_invited_list %>
+              <% unless @without_context_list %>
                 <% if show_sms_invitation?(@current_configuration) %>
                   <td><%= display_attribute format_date(rdv_context.last_sms_invitation_sent_at) %></td>
                 <% end %>

--- a/app/views/applicants/_search_form.html.erb
+++ b/app/views/applicants/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with method: :get, local: true, url: compute_index_path(@organisation, @department) do |form| %>
   <%= form.text_field :search_query, placeholder: "Prénom, nom, email, numéro allocataire...", class: "form-control mb-1" %>
-  <% if @not_invited_list %>
-    <%= form.hidden_field :not_invited, value: @not_invited_list %>
+  <% if @without_context_list %>
+    <%= form.hidden_field :without_context, value: @without_context_list %>
   <% end %>
   <%= form.hidden_field :context, value: @current_context %>
   <div class="d-flex justify-content-between">

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5 mb-5">
   <div class="row mb-4 block-white justify-content-center">
     <div class="col-4 justify-content-center">
-      <% unless @not_invited_list %>
+      <% unless @without_context_list %>
         <div class="mb-1">
           <%=
             select(
@@ -13,7 +13,7 @@
         </div>
       <% end %>
       <%= render 'search_form' %>
-      <% unless @not_invited_list %>
+      <% unless @without_context_list %>
         <div class=" text-left mt-2">
           <%= check_box("applicants_list", "action_required", class: "js-action-required-checkbox") %>Intervention nécessaire
           <small>

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -447,16 +447,18 @@ describe ApplicantsController, type: :controller do
       end
     end
 
-    context "when not invited list" do
+    context "when without context list" do
       let!(:applicant) do
         create(:applicant, organisations: [organisation], last_name: "Chabat", rdv_contexts: [])
       end
 
-      it "lists the applicants with no rdv contexts" do
-        get :index, params: index_params.merge(not_invited: true)
+      let!(:rdv_context2) { build(:rdv_context, context: "rsa_accompagnement", status: "invitation_pending") }
+
+      it "lists the applicants with no rdv contexts in the contexts of the org configs" do
+        get :index, params: index_params.merge(without_context: true)
 
         expect(response.body).to match(/Chabat/)
-        expect(response.body).not_to match(/Baer/)
+        expect(response.body).to match(/Baer/)
       end
     end
 


### PR DESCRIPTION
Cette PR est liée à #360 .
Lorsqu'on est dans l'onglet des "Autres" (anciennement "Non invités"), on récupère maintenant non seulement les allocataires qui n'ont pas du tout de `rdv_contexts` associés mais **aussi** les allocataires qui ont des `rdv_contexts` associés dans des autres contextes que ceux pour lesquels l'organisation en question peut inviter.

C'est notamment important lorsque l'on va avoir #344  et qu'un allocataire passera d'une org à une autre liée à des contextes différents.  