### PR TITLE
feat(upload): add ods and csv support + hard check file on upload

### DIFF
--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -123,19 +123,24 @@ export default function ApplicantsUpload({ organisation, configuration, departme
     return applicantsFromList.reverse();
   };
 
-  const checkFileFormat = (file, acceptedFormats) => {
-    if (!acceptedFormats.some((format) => file.name.endsWith(format))) {
-      Swal.fire({
-        title: `Le fichier doit être au format ${acceptedFormats.map((format) => ` ${format}`)}`,
-        icon: "error",
-      });
-      return { valid: false };
+  const isFormatValid = (file, acceptedFormats) => {
+    if (acceptedFormats.some((format) => file.name.endsWith(format))) {
+      return { valid: true };
     }
-    return { valid: true };
+    return { valid: false };
+  };
+
+  const displayFormatErrorMessage = (acceptedFormats) => {
+    Swal.fire({
+      title: `Le fichier doit être au format ${acceptedFormats.map((format) => ` ${format}`)}`,
+      icon: "error",
+    });
   };
 
   const handleApplicantsFile = async (file) => {
-    if (!checkFileFormat(file, [".csv", ".xls", ".xlsx", ".ods"]).valid) {
+    const acceptedFormats = [".csv", ".xls", ".xlsx", ".ods"];
+    if (!isFormatValid(file, acceptedFormats).valid) {
+      displayFormatErrorMessage(acceptedFormats);
       return;
     }
 
@@ -158,7 +163,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
   };
 
   const handleContactsFile = async (file) => {
-    if (!checkFileFormat(file, [".csv", ".txt"]).valid) {
+    const acceptedFormats = [".csv", ".txt"];
+    if (!isFormatValid(file, acceptedFormats).valid) {
+      displayFormatErrorMessage(acceptedFormats);
       return;
     }
 

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -82,8 +82,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                   row[parameterizedColumnNames.street_number],
                 // sometimes street type is separated from address
                 streetType:
-                  parameterizedColumnNames.street_type &&
-                  row[parameterizedColumnNames.street_type],
+                  parameterizedColumnNames.street_type && row[parameterizedColumnNames.street_type],
                 // fullAddress is address with postal code and city
                 fullAddress:
                   parameterizedColumnNames.full_address &&
@@ -124,9 +123,23 @@ export default function ApplicantsUpload({ organisation, configuration, departme
     return applicantsFromList.reverse();
   };
 
-  const handleApplicantsFile = async (file) => {
-    setFileSize(file.size);
+  const checkFileFormat = (file, acceptedFormats) => {
+    if (!acceptedFormats.some((format) => file.name.endsWith(format))) {
+      Swal.fire({
+        title: `Le fichier doit être au format ${acceptedFormats.map((format) => ` ${format}`)}`,
+        icon: "error",
+      });
+      return false;
+    }
+    return true;
+  };
 
+  const handleApplicantsFile = async (file) => {
+    if (checkFileFormat(file, [".csv", ".xls", ".xlsx", ".ods"]) === false) {
+      return;
+    }
+
+    setFileSize(file.size);
     dispatchApplicants({ type: "reset" });
     const applicantsFromList = await retrieveApplicantsFromList(file);
     if (applicantsFromList.length === 0) return;
@@ -145,11 +158,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
   };
 
   const handleContactsFile = async (file) => {
-    if (!(file.name.endsWith(".csv") || file.name.endsWith(".txt"))) {
-      Swal.fire({
-        title: "Le fichier doit être au format .txt ou .csv",
-        icon: "error",
-      });
+    if (checkFileFormat(file, [".csv", ".txt"]) === false) {
       return;
     }
 
@@ -196,15 +205,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
           <FileHandler
             handleFile={handleApplicantsFile}
             fileSize={fileSize}
-            accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"
+            accept="text/plain, .csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel, application/vnd.oasis.opendocument.spreadsheet"
             multiple={false}
-            uploadMessage={
-              <span>
-                Choisissez un fichier de nouveaux demandeurs
-                <br />
-                (.xls, xlsx)
-              </span>
-            }
+            uploadMessage={<span>Choisissez un fichier de nouveaux demandeurs</span>}
             pendingMessage="Récupération des informations, merci de patienter"
           />
         </div>

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -125,9 +125,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
 
   const isFormatValid = (file, acceptedFormats) => {
     if (acceptedFormats.some((format) => file.name.endsWith(format))) {
-      return { valid: true };
+      return true;
     }
-    return { valid: false };
+    return false;
   };
 
   const displayFormatErrorMessage = (acceptedFormats) => {
@@ -139,7 +139,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
 
   const handleApplicantsFile = async (file) => {
     const acceptedFormats = [".csv", ".xls", ".xlsx", ".ods"];
-    if (!isFormatValid(file, acceptedFormats).valid) {
+    if (!isFormatValid(file, acceptedFormats)) {
       displayFormatErrorMessage(acceptedFormats);
       return;
     }
@@ -164,7 +164,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
 
   const handleContactsFile = async (file) => {
     const acceptedFormats = [".csv", ".txt"];
-    if (!isFormatValid(file, acceptedFormats).valid) {
+    if (!isFormatValid(file, acceptedFormats)) {
       displayFormatErrorMessage(acceptedFormats);
       return;
     }

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -129,13 +129,13 @@ export default function ApplicantsUpload({ organisation, configuration, departme
         title: `Le fichier doit être au format ${acceptedFormats.map((format) => ` ${format}`)}`,
         icon: "error",
       });
-      return false;
+      return { valid: false };
     }
-    return true;
+    return { valid: true };
   };
 
   const handleApplicantsFile = async (file) => {
-    if (checkFileFormat(file, [".csv", ".xls", ".xlsx", ".ods"]) === false) {
+    if (!checkFileFormat(file, [".csv", ".xls", ".xlsx", ".ods"]).valid) {
       return;
     }
 
@@ -158,7 +158,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
   };
 
   const handleContactsFile = async (file) => {
-    if (checkFileFormat(file, [".csv", ".txt"]) === false) {
+    if (!checkFileFormat(file, [".csv", ".txt"]).valid) {
       return;
     }
 


### PR DESCRIPTION
Dans cette PR, j'ajoute les fichiers `.ods` et `.csv` aux fichiers autorisés pour l'upload des bénéficiaires. Pour éviter que d'autres fichiers soient soumis [(L'attribut `accept` ne valide pas les types de fichiers sélectionnés ; il fournit des indications aux navigateurs pour guider les utilisateurs vers la sélection des bons types de fichiers)](https://developer.mozilla.org/fr/docs/Web/HTML/Attributes/accept), j'ajoute également une validation dans le code, déjà utilisée pour le fichier de contacts