### PR TITLE
refactor(app): Hide stats from homepage

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,13 +1,8 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_agent!
 
-  include StatsConcern
-
   def welcome
     redirect_to(organisations_path) if logged_in?
-
-    collect_datas_for_stats
-    set_stats_datas
   end
 
   def legal_notice; end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -137,8 +137,8 @@ class Stat
   end
 
   def compute_percentage_of_applicants_oriented_in_less_than_30_days(selected_applicants)
-    (applicants_oriented_in_less_than_30_days(selected_applicants).count / (
-      selected_applicants.count.nonzero? || 1
+    (applicants_oriented_in_less_than_30_days(selected_applicants).to_a.length / (
+      selected_applicants.to_a.length.nonzero? || 1
     ).to_f) * 100
   end
 

--- a/app/views/static_pages/welcome.html.erb
+++ b/app/views/static_pages/welcome.html.erb
@@ -44,36 +44,6 @@
     <p class="col-10 text-left mt-4 mb-4">Proposé par data.insertion, une équipe de beta.gouv, ce service est porté par la Direction générale de la Cohésion sociale (DGCS), la Délégation interministérielle à la prévention et à la lutte contre la pauvreté (DILP) et la Délégation générale à l'Emploi et à la Formation professionnelle (DGEFP).</p>
   </div>
 
-  <div class="my-4">
-    <div class="row d-flex justify-content-center">
-      <div class="text-center col-10 col-md-5">
-        <p class="highlight-stat big"><%= @stats.rdvs.to_a.count %></p>
-        <p class="highlight-stat">rendez-vous organisés<br/>via RDV-Insertion</p>
-      </div>
-      <div class="text-center col-10 col-md-5">
-        <p class="highlight-stat big"><%= @stats.average_time_between_invitation_and_rdv_in_days.round %> jours</p>
-        <p class="highlight-stat">délai moyen entre l'invitation<br/>et la prise de rendez-vous</p>
-      </div>
-    </div>
-    <div class="row d-flex justify-content-center">
-      <div class="text-center col-10 col-md-5">
-        <p class="highlight-stat big"><%= @stats.percentage_of_no_show.round %> %</p>
-        <p class="highlight-stat">seulement de rendez-vous<br/>non honorés avec RDV-Insertion</p>
-      </div>
-      <div class="text-center col-10 col-md-5">
-        <p class="highlight-stat big"><%= @stats.percentage_of_applicants_oriented_in_less_than_30_days.round %> %</p>
-        <p class="highlight-stat">de bénéficiaires du RSA <br/><strong>orientés en - de 30 jours</strong></p>
-      </div>
-    </div>
-    <div class="row d-flex justify-content-center">
-      <div class="col-8 col-md-4 col-lg-3 text-center mt-4">
-        <%= link_to stats_path do %>
-          <button class="btn btn-default btn-blue w-100 ">Voir plus de statistiques</button>
-        <% end %>
-      </div>
-    </div>
-  </div>
-
   <div class="row justify-content-center card-demo">
     <h2 class="col-10 text-center text-dark-blue bold mb-4">Ça vous intéresse&nbsp;?</h2>
     <p class="col-10 text-left">Vous souhaitez diminuer le délai d'orientation des bénéficiaires du RSA dans votre département et réduire le taux d'absentéisme du rendez-vous d'orientation ?</p>


### PR DESCRIPTION
On ne loade plus les stats sur la page d'accueil (sinon le chargement de la page est trop long) en attendant #358 