### PR TITLE
fix(view): Redirect to right context when back to list

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -89,6 +89,10 @@ class Applicant < ApplicationRecord
     deleted_at.present?
   end
 
+  def contexts
+    rdv_contexts.map(&:context)
+  end
+
   def as_json(_opts = {})
     super.merge(
       created_at: created_at,

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -2,7 +2,7 @@
 <div class="container label-blue mt-4">
   <div class="d-flex justify-content-between mb-4">
     <div>
-      <%= link_to(compute_index_path(@organisation, @department)) do %>
+      <%= link_to(compute_index_path(@organisation, @department, context: @applicant.contexts.first)) do %>
         <button class="btn btn-blue-out">Retour</button>
       <% end %>
       <%= link_to rdv_solidarites_user_url(@organisation, @applicant), target: "_blank" do %>


### PR DESCRIPTION
Lorsque l'on clique sur le bouton "Retour", on veut que cela nous ramène vers une liste liée au contexte auquel est rattaché l'allocataire.