### PR TITLE
fix(jobs): Maintain fifo when upserting records

### DIFF
--- a/app/jobs/notify_applicant_job.rb
+++ b/app/jobs/notify_applicant_job.rb
@@ -7,8 +7,10 @@ class NotifyApplicantJob < ApplicationJob
     @rdv_solidarites_rdv = RdvSolidarites::Rdv.new(rdv_attributes)
     @event = event
 
-    return send_already_notified_to_mattermost if already_notified?
-    raise NotificationsJobError, notify_applicant.errors.join(" - ") unless notify_applicant.success?
+    Rdv.with_advisory_lock "notifying_for_rdv_#{@rdv_solidarites_rdv.id}" do
+      return send_already_notified_to_mattermost if already_notified?
+      raise NotificationsJobError, notify_applicant.errors.join(" - ") unless notify_applicant.success?
+    end
   end
 
   private

--- a/app/jobs/rdv_solidarites_webhooks/process_organisation_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_organisation_job.rb
@@ -24,7 +24,7 @@ module RdvSolidaritesWebhooks
     end
 
     def update_organisation
-      UpsertRecordJob.perform_async("Organisation", @data)
+      UpsertRecordJob.perform_async("Organisation", @data, { last_webhook_update_received_at: @meta[:timestamp] })
     end
   end
 end

--- a/app/jobs/rdv_solidarites_webhooks/process_user_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_user_job.rb
@@ -26,7 +26,7 @@ module RdvSolidaritesWebhooks
       if event == "destroyed"
         SoftDeleteApplicantJob.perform_async(rdv_solidarites_user_id)
       else
-        UpsertRecordJob.perform_async("Applicant", @data)
+        UpsertRecordJob.perform_async("Applicant", @data, { last_webhook_update_received_at: @meta[:timestamp] })
       end
     end
   end

--- a/app/models/concerns/has_status_concern.rb
+++ b/app/models/concerns/has_status_concern.rb
@@ -25,11 +25,11 @@ module HasStatusConcern
   end
 
   def last_rdv
-    rdvs.last
+    rdvs.max_by(&:created_at)
   end
 
   def last_sent_invitation
-    invitations.select(&:sent_at).last
+    invitations.max_by(&:sent_at)
   end
 
   def invited_after_last_rdv?

--- a/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
+++ b/app/services/migrations/retrieve_and_save_organisation_rdvs.rb
@@ -18,7 +18,11 @@ module Migrations
         UpsertRecordJob.perform_async(
           Rdv,
           rdv.to_rdv_insertion_attributes,
-          { applicant_ids: applicant_ids, organisation_id: @organisation_id }
+          {
+            applicant_ids: applicant_ids,
+            organisation_id: @organisation_id,
+            last_webhook_update_received_at: @meta[:timestamp]
+          }
         )
       end
     end

--- a/app/services/upsert_record.rb
+++ b/app/services/upsert_record.rb
@@ -6,20 +6,35 @@ class UpsertRecord < BaseService
   end
 
   def call
-    record.assign_attributes(
-      @rdv_solidarites_attributes
-        .slice(*@klass::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
-        .compact
-        .transform_values(&:presence)
-        .merge(@additional_attributes)
-    )
-    record.save! if record.changed?
+    @klass.with_advisory_lock(
+      "upserting_#{@klass.name.underscore}_rdv_solidarites_id_#{@rdv_solidarites_attributes[:id]}"
+    ) do
+      return if old_update?
+
+      record.assign_attributes(
+        @rdv_solidarites_attributes
+          .slice(*@klass::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
+          .compact
+          .transform_values(&:presence)
+          .merge(@additional_attributes)
+      )
+      record.save! if record.changed?
+    end
   end
 
   private
 
   def record
     @record ||= @klass.find_or_initialize_by("#{rdv_solidarites_id_attribute_name}": @rdv_solidarites_attributes[:id])
+  end
+
+  def old_update?
+    record.persisted? && record.last_webhook_update_received_at.present? &&
+      timestamp.present? && timestamp < record.last_webhook_update_received_at
+  end
+
+  def timestamp
+    @additional_attributes[:last_webhook_update_received_at]&.to_datetime
   end
 
   def rdv_solidarites_id_attribute_name

--- a/db/migrate/20220530135315_add_webhook_time_stamp.rb
+++ b/db/migrate/20220530135315_add_webhook_time_stamp.rb
@@ -1,0 +1,7 @@
+class AddWebhookTimeStamp < ActiveRecord::Migration[7.0]
+  def change
+    add_column :rdvs, :last_webhook_update_received_at, :datetime
+    add_column :applicants, :last_webhook_update_received_at, :datetime
+    add_column :organisations, :last_webhook_update_received_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_23_193814) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_30_135315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_23_193814) do
     t.string "archiving_reason"
     t.boolean "is_archived", default: false
     t.datetime "deleted_at"
+    t.datetime "last_webhook_update_received_at"
     t.index ["department_id"], name: "index_applicants_on_department_id"
     t.index ["department_internal_id", "department_id"], name: "index_applicants_on_department_internal_id_and_department_id", unique: true
     t.index ["rdv_solidarites_user_id"], name: "index_applicants_on_rdv_solidarites_user_id", unique: true
@@ -151,6 +152,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_23_193814) do
     t.bigint "department_id"
     t.bigint "responsible_id"
     t.bigint "letter_configuration_id"
+    t.datetime "last_webhook_update_received_at"
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["letter_configuration_id"], name: "index_organisations_on_letter_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
@@ -195,6 +197,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_23_193814) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "organisation_id"
+    t.datetime "last_webhook_update_received_at"
     t.index ["created_by"], name: "index_rdvs_on_created_by"
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"
     t.index ["rdv_solidarites_rdv_id"], name: "index_rdvs_on_rdv_solidarites_rdv_id", unique: true

--- a/spec/jobs/rdv_solidarites_webhooks/process_organisation_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_organisation_job_spec.rb
@@ -17,7 +17,8 @@ describe RdvSolidaritesWebhooks::ProcessOrganisationJob, type: :job do
   let!(:meta) do
     {
       "model" => "Organisation",
-      "event" => "updated"
+      "event" => "updated",
+      "timestamp" => "2022-05-30 14:44:22 +0200"
     }.deep_symbolize_keys
   end
 
@@ -30,7 +31,7 @@ describe RdvSolidaritesWebhooks::ProcessOrganisationJob, type: :job do
 
     it "enqueues upsert record job" do
       expect(UpsertRecordJob).to receive(:perform_async)
-        .with("Organisation", data)
+        .with("Organisation", data, { last_webhook_update_received_at: "2022-05-30 14:44:22 +0200" })
       subject
     end
 

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -25,10 +25,12 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
     }.deep_symbolize_keys
   end
 
+  let!(:timestamp) { "2021-05-30 14:44:22 +0200" }
   let!(:meta) do
     {
       "model" => "Rdv",
-      "event" => "created"
+      "event" => "created",
+      "timestamp" => timestamp
     }.deep_symbolize_keys
   end
 
@@ -117,7 +119,8 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
             {
               applicant_ids: [applicant.id, applicant2.id],
               organisation_id: organisation.id,
-              rdv_context_ids: [rdv_context.id, rdv_context2.id]
+              rdv_context_ids: [rdv_context.id, rdv_context2.id],
+              last_webhook_update_received_at: timestamp
             }
           )
         subject
@@ -182,11 +185,6 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
         end
         subject
       end
-
-      it "sends a notif to mattermost" do
-        expect(MattermostClient).to receive(:send_to_notif_channel)
-        subject
-      end
     end
 
     context "with no matching configuration" do
@@ -196,11 +194,6 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
         [UpsertRecordJob, DeleteRdvJob, NotifyApplicantJob].each do |klass|
           expect(klass).not_to receive(:perform_async)
         end
-        subject
-      end
-
-      it "sends a notif to mattermost" do
-        expect(MattermostClient).to receive(:send_to_notif_channel)
         subject
       end
     end

--- a/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
@@ -14,10 +14,12 @@ describe RdvSolidaritesWebhooks::ProcessUserJob, type: :job do
 
   let!(:rdv_solidarites_user_id) { 22 }
 
+  let!(:timestamp) { "2021-05-30 14:44:22 +0200" }
   let!(:meta) do
     {
       "model" => "User",
-      "event" => "updated"
+      "event" => "updated",
+      "timestamp" => timestamp
     }.deep_symbolize_keys
   end
 
@@ -31,7 +33,7 @@ describe RdvSolidaritesWebhooks::ProcessUserJob, type: :job do
 
     it "enqueues upsert record job" do
       expect(UpsertRecordJob).to receive(:perform_async)
-        .with("Applicant", data)
+        .with("Applicant", data, { last_webhook_update_received_at: timestamp })
       subject
     end
 

--- a/spec/services/upsert_record_spec.rb
+++ b/spec/services/upsert_record_spec.rb
@@ -28,7 +28,7 @@ describe UpsertRecord, type: :service do
         .with(rdv_solidarites_rdv_id: rdv_solidarites_rdv_id)
         .and_return(rdv)
       allow(rdv).to receive(:save!)
-      allow(rdv).to receive(:changed?)
+      allow(rdv).to receive(:changed?).and_return(true)
     end
 
     it "retrieves the rdv if present" do
@@ -44,6 +44,25 @@ describe UpsertRecord, type: :service do
       expect(rdv.status).to eq(status)
       expect(rdv.applicant_ids).to eq(applicant_ids)
       expect(rdv.id).not_to eq(rdv_solidarites_rdv_id)
+    end
+
+    it "saves the record" do
+      expect(rdv).to receive(:assign_attributes)
+      expect(rdv).to receive(:save!)
+      subject
+    end
+
+    context "when it is an old update" do
+      let!(:additional_attributes) { { last_webhook_update_received_at: "2021-09-08 11:05:00 UTC" } }
+      let!(:rdv) do
+        create(:rdv, last_webhook_update_received_at: "2021-09-08 11:06:00 UTC")
+      end
+
+      it "does not update the rdv" do
+        expect(rdv).not_to receive(:assign_attributes)
+        expect(rdv).not_to receive(:save!)
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
Dans cette PR je fais en sorte que: 

* L'on prenne en compte l'heure de la réception du webhook qui entraine l'update d'un record en base. On store cet attribut dans les tables `organisations`, `applicants` et `rdvs`. Ainsi on est sûr qu'on updatera pas un record à partir d'un webhook antérieur à celui qui a entrainé le dernier update
* Je lock au moment de l'upsert pour que l'on est pas deux upsert en même qui nous donne les erreurs `ActiveRecord::RecordInvalid` ou `ActiveRecord::RecordNotUnique` (voir sentry)