### PR TITLE
fix(mailer): Restrain promotional language in mails

### DIFF
--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -4,7 +4,7 @@ class InvitationMailer < ApplicationMailer
     @applicant = applicant
     mail(
       to: @applicant.email,
-      subject: "Prenez RDV pour votre RSA"
+      subject: "RDV d'orientation dans le cadre de votre RSA"
     )
   end
 
@@ -13,7 +13,7 @@ class InvitationMailer < ApplicationMailer
     @applicant = applicant
     mail(
       to: @applicant.email,
-      subject: "Prenez RDV pour votre RSA"
+      subject: "RDV d'accompagnement dans le cadre de votre RSA"
     )
   end
 
@@ -22,7 +22,7 @@ class InvitationMailer < ApplicationMailer
     @applicant = applicant
     mail(
       to: @applicant.email,
-      subject: "Prenez un RDV téléphonique pour votre RSA"
+      subject: "RDV d'orientation téléphonique dans le cadre de votre RSA"
     )
   end
 end

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_accompagnement.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_accompagnement.html.erb
@@ -3,7 +3,7 @@
 <p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>. Ce rendez-vous est obligatoire. En l’absence d'action de votre part, le versement de votre RSA pourra être suspendu.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { token: @invitation.token, format: "email" }, host: ENV['HOST']), class: "btn btn-primary" do %>
-    Je prends RDV
+    Choisir un créneau
   <% end %>
 </p>
 <p>En cas de problème technique, contactez le <%= @invitation.help_phone_number_formatted %></p>

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation.html.erb
@@ -3,7 +3,7 @@
 <p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>. Ce rendez-vous est obligatoire.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { token: @invitation.token, format: "email" }, host: ENV['HOST']), class: "btn btn-primary" do %>
-    Je prends RDV
+    Choisir un créneau
   <% end %>
 </p>
 <p>En cas de problème technique, contactez le <%= @invitation.help_phone_number_formatted %></p>

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe InvitationMailer, type: :mailer do
     end
 
     it "renders the subject" do
-      expect(subject.subject).to eq("Prenez RDV pour votre RSA")
+      expect(subject.subject).to eq("RDV d'orientation dans le cadre de votre RSA")
     end
 
     it "renders the body" do
@@ -50,7 +50,7 @@ RSpec.describe InvitationMailer, type: :mailer do
     end
 
     it "renders the subject" do
-      expect(subject.subject).to eq("Prenez RDV pour votre RSA")
+      expect(subject.subject).to eq("RDV d'accompagnement dans le cadre de votre RSA")
     end
 
     it "renders the body" do
@@ -76,7 +76,7 @@ RSpec.describe InvitationMailer, type: :mailer do
     end
 
     it "renders the subject" do
-      expect(subject.subject).to eq("Prenez un RDV téléphonique pour votre RSA")
+      expect(subject.subject).to eq("RDV d'orientation téléphonique dans le cadre de votre RSA")
     end
 
     it "renders the body" do

--- a/spec/mailers/previews/invitation_preview.rb
+++ b/spec/mailers/previews/invitation_preview.rb
@@ -4,4 +4,14 @@ class InvitationPreview < ActionMailer::Preview
     invitation = Invitation.where(format: "email").last # create a local mail invitation if there are none
     InvitationMailer.invitation_for_rsa_orientation(invitation, invitation.applicant)
   end
+
+  def invitation_for_rsa_accompagnement
+    invitation = Invitation.where(format: "email").last # create a local mail invitation if there are none
+    InvitationMailer.invitation_for_rsa_accompagnement(invitation, invitation.applicant)
+  end
+
+  def invitation_for_rsa_orientation_on_phone_platform
+    invitation = Invitation.where(format: "email").last # create a local mail invitation if there are none
+    InvitationMailer.invitation_for_rsa_orientation_on_phone_platform(invitation, invitation.applicant)
+  end
 end


### PR DESCRIPTION
Il s'agit ici d'une n-ième tentative pour que les mails ne tombent pas dans l'onglet "Promotions" de gmail.
En lisant [cette article](https://snov.io/blog/how-to-avoid-gmail-promotions-tab/), j'ai remarqué qu'on avait pas essayé de changer la façon de formuler le mail pour qu'il ait moins l'air moins promotionnel (voir paragraphe `Refrain from promotional language`). 
On voit notamment sur [cette page](https://snov.io/blog/550-spam-trigger-words-to-avoid/) que toutes les formulations "take action" sont à éviter.

De plus, j'ai réalisé un test sur [ce site](https://litmus.com/gmail-tabs) qui semble confirmer cette hypothèse. En effet, les mails d'orientation par rdv téléphonique qui ne contiennent pas de CTA semblent ne pas atterrir dans l'onglet "Promotions"