### PR TITLE
fix(app): Handle deleted applicants re-creation

### DIFF
--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -42,8 +42,8 @@ export default function ApplicantsUpload({ organisation, configuration, departme
 
   const redirectToApplicantList = () => {
     window.location.href = isDepartmentLevel
-      ? `/departments/${department.id}/applicants`
-      : `/organisations/${organisation.id}/applicants`;
+      ? `/departments/${department.id}/applicants?context=${configuration.context}`
+      : `/organisations/${organisation.id}/applicants?context=${configuration.context}`;
   };
 
   const retrieveApplicantsFromList = async (file) => {

--- a/app/jobs/soft_delete_applicant_job.rb
+++ b/app/jobs/soft_delete_applicant_job.rb
@@ -5,6 +5,8 @@ class SoftDeleteApplicantJob < ApplicationJob
 
     applicant.update_columns(
       deleted_at: Time.zone.now,
+      affiliation_number: nil,
+      role: nil,
       uid: nil,
       department_internal_id: nil
     )

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -21,7 +21,6 @@ class Applicant < ApplicationRecord
   validates :rdv_solidarites_user_id, uniqueness: true, allow_nil: true
   validates :department_internal_id, uniqueness: { scope: :department_id }, allow_nil: true
   validates :last_name, :first_name, :title, presence: true
-  validates :affiliation_number, presence: true, allow_nil: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
   validate :birth_date_validity, :uid_or_department_internal_id_presence
 
@@ -118,6 +117,7 @@ class Applicant < ApplicationRecord
   end
 
   def uid_or_department_internal_id_presence
+    return if deleted?
     return if department_internal_id.present? || (affiliation_number.present? && role.present?)
 
     errors.add(:base, "le couple numéro d'allocataire + rôle ou l'ID interne au département doivent être présents.")

--- a/app/views/applicants/_search_form.html.erb
+++ b/app/views/applicants/_search_form.html.erb
@@ -5,7 +5,7 @@
     <%= form.submit "Rechercher", name: nil, class: "btn btn-blue-out" %>
     <% if display_back_to_list_button? %>
       <div class="d-flex justify-content-start">
-        <%= link_to compute_index_path(@organisation, @department), class: "btn btn-blue-out" do %>
+        <%= link_to compute_index_path(@organisation, @department, context: @current_context), class: "btn btn-blue-out" do %>
           Retour à la liste
         <% end %>
       </div>

--- a/spec/jobs/soft_delete_applicant_job_spec.rb
+++ b/spec/jobs/soft_delete_applicant_job_spec.rb
@@ -25,6 +25,8 @@ describe SoftDeleteApplicantJob, type: :job do
       expect(applicant.deleted_at).not_to be_nil
       expect(applicant.uid).to eq(nil)
       expect(applicant.department_internal_id).to eq(nil)
+      expect(applicant.affiliation_number).to eq(nil)
+      expect(applicant.role).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Lorsqu'un allocataire est supprimé, je nullifie son numéro d'allocataire et son rôle, sinon il est retrouvé dans le service `FindOrInitializeApplicant`.
J'en profite pour mettre à jour quelques liens de "retour" à la liste pour qu'ils pointent directement vers le bon contexte.