### PR TITLE
fix(invitations): Retrieve invitation parameters from invitations

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -39,7 +39,7 @@ class Invitation < ApplicationRecord
   end
 
   def invitation_parameters
-    organisations.flat_map(&:invitation_parameters).first
+    organisations.map(&:invitation_parameters).compact.first
   end
 
   private


### PR DESCRIPTION
Je me suis rendu compte qu'on ne récupérait pas le premier record d'`invitation_parameters` **présent** mais seulement le record lié à la première orga. 
Cette PR corrige ça.