### PR TITLE
fix(view): Fix error when retrieving last invitation sent at

### DIFF
--- a/app/models/concerns/invitable_concern.rb
+++ b/app/models/concerns/invitable_concern.rb
@@ -10,7 +10,8 @@ module InvitableConcern
   end
 
   def first_sent_invitation_after_last_seen_rdv_sent_at
-    invitations.select { |invitation| invitation.sent_at > last_seen_rdv.starts_at }.map(&:sent_at).compact.min
+    invitations.select { |invitation| invitation.sent_at && invitation.sent_at > last_seen_rdv.starts_at }
+               .map(&:sent_at).min
   end
 
   def last_sent_invitation


### PR DESCRIPTION
Lié à cette erreur sur sentry: https://sentry.incubateur.net/organizations/betagouv/issues/2333/?query=is%3Aunresolved

Il faut prendre en compte les invitations ou `sent_at` est présent