### PR TITLE
refactor(app): Rename context to motif category

### DIFF
--- a/app/controllers/concerns/api/v1/params_validation_concern.rb
+++ b/app/controllers/concerns/api/v1/params_validation_concern.rb
@@ -36,14 +36,15 @@ module Api
       end
 
       def validate_invitations_params
-        possible_contexts = @organisation.configurations.map(&:context)
+        possible_motif_categories = @organisation.configurations.map(&:motif_category)
 
         invitations_params.each_with_index do |invitation_params, idx|
-          context = invitation_params[:context]
+          motif_category = invitation_params[:motif_category]
           # we don't have to precise the context if there is only one context possible
-          next if (context.blank? && possible_contexts.length == 1) || context.in?(possible_contexts)
+          next if (motif_category.blank? && possible_motif_categories.length == 1) ||
+                  motif_category.in?(possible_motif_categories)
 
-          @params_validation_errors << { "Entrée #{idx + 1}": "Invitation context #{context} est invalide" }
+          @params_validation_errors << { "Entrée #{idx + 1}": "Catégorie de motifs #{motif_category} invalide" }
         end
       end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -68,7 +68,7 @@ class InvitationsController < ApplicationController
   def set_rdv_context
     RdvContext.with_advisory_lock "setting_rdv_context_for_applicant_#{@applicant.id}" do
       @rdv_context = RdvContext.find_or_create_by!(
-        context: params[:rdv_context][:context], applicant: @applicant
+        motif_category: params[:rdv_context][:motif_category], applicant: @applicant
       )
     end
   end

--- a/app/controllers/rdv_contexts_controller.rb
+++ b/app/controllers/rdv_contexts_controller.rb
@@ -15,13 +15,13 @@ class RdvContextsController < ApplicationController
   private
 
   def rdv_context_params
-    params.require(:rdv_context).permit(:context)
+    params.require(:rdv_context).permit(:motif_category)
   end
 
   def set_rdv_context
     @rdv_context = RdvContext.find_or_initialize_by(
       applicant: @applicant,
-      context: rdv_context_params[:context]
+      motif_category: rdv_context_params[:motif_category]
     )
     authorize @rdv_context
   end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -13,7 +13,7 @@ class UploadsController < ApplicationController
     @department = Department.find(params[:department_id])
     authorize @department, :upload?
     @organisation = nil
-    @all_configurations = (policy_scope(::Configuration) & @department.configurations).uniq(&:context)
+    @all_configurations = (policy_scope(::Configuration) & @department.configurations).uniq(&:motif_category)
     set_current_configuration
   end
 
@@ -32,6 +32,6 @@ class UploadsController < ApplicationController
       elsif @all_configurations.length == 1
         @all_configurations.first
       end
-    @context_name = @current_configuration&.context_name
+    @motif_category_human = @current_configuration&.motif_category_human
   end
 end

--- a/app/javascript/lib/retrieveLastInvitationDate.js
+++ b/app/javascript/lib/retrieveLastInvitationDate.js
@@ -1,9 +1,9 @@
-const retrieveLastInvitationDate = (invitations, format = null, context = null) => {
+const retrieveLastInvitationDate = (invitations, format = null, motifCategory = null) => {
   if (format !== null) {
     invitations = invitations.filter((invitation) => invitation.format === format);
   }
-  if (context !== null) {
-    invitations = invitations.filter((invitation) => invitation.context === context);
+  if (motifCategory !== null) {
+    invitations = invitations.filter((invitation) => invitation.motif_category === motifCategory);
   }
   const sentInvitations = invitations.filter((invitation) => !!invitation.sent_at);
   // Trier de la plus récente à la plus ancienne

--- a/app/javascript/react/actions/getInvitationLetter.js
+++ b/app/javascript/react/actions/getInvitationLetter.js
@@ -6,7 +6,7 @@ const getInvitationLetter = async (
   departmentId,
   organisation,
   isDepartmentLevel,
-  context,
+  motifCategory,
   numberOfDaysToAcceptInvitation,
   invitationFormat
 ) => {
@@ -17,7 +17,7 @@ const getInvitationLetter = async (
     isDepartmentLevel,
     invitationFormat,
     organisation.phone_number,
-    context,
+    motifCategory,
     numberOfDaysToAcceptInvitation,
     "application/json, application/pdf"
   );

--- a/app/javascript/react/actions/inviteApplicant.js
+++ b/app/javascript/react/actions/inviteApplicant.js
@@ -7,7 +7,7 @@ const inviteApplicant = async (
   isDepartmentLevel,
   invitationFormat,
   helpPhoneNumber,
-  context,
+  motifCategory,
   numberOfDaysToAcceptInvitation,
   types = "application/json"
 ) => {
@@ -25,7 +25,7 @@ const inviteApplicant = async (
       help_phone_number: helpPhoneNumber,
       number_of_days_to_accept_invitation: numberOfDaysToAcceptInvitation,
       rdv_context: {
-        context,
+        motif_category: motifCategory,
       },
     },
     types

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -77,7 +77,7 @@ export default function Applicant({
       applicant.department.id,
       applicant.currentOrganisation,
       isDepartmentLevel,
-      applicant.currentConfiguration.context,
+      applicant.currentConfiguration.motif_category,
       applicant.currentConfiguration.number_of_days_to_accept_invitation,
     ];
     if (format === "sms") {

--- a/app/javascript/react/components/InvitationBlock.jsx
+++ b/app/javascript/react/components/InvitationBlock.jsx
@@ -11,7 +11,7 @@ export default function InvitationBlock({
   invitations,
   organisation,
   department,
-  context,
+  motifCategory,
   isDepartmentLevel,
   invitationFormats,
   numberOfDaysToAcceptInvitation,
@@ -34,7 +34,7 @@ export default function InvitationBlock({
   );
 
   const updateStatusBlock = () => {
-    const statusBlock = document.getElementById(`js-block-status-${context}`);
+    const statusBlock = document.getElementById(`js-block-status-${motifCategory}`);
     if (statusBlock) {
       statusBlock.textContent = "Invitation en attente de réponse";
       statusBlock.className = "p-4";
@@ -62,7 +62,7 @@ export default function InvitationBlock({
       department.id,
       organisation,
       isDepartmentLevel,
-      context,
+      motifCategory,
       numberOfDaysToAcceptInvitation,
     ];
     let newInvitationDate;
@@ -114,7 +114,7 @@ export default function InvitationBlock({
               invitationsDatesByFormat={invitationsDatesByFormat}
               invitationFormats={invitationFormats}
               index={idx}
-              key={`${context}${idx}`}
+              key={`${motifCategory}${idx}`}
             />
           ))}
           <tr>

--- a/app/javascript/react/lib/handleApplicantInvitation.js
+++ b/app/javascript/react/lib/handleApplicantInvitation.js
@@ -6,7 +6,7 @@ const handleApplicantInvitation = async (
   departmentId,
   organisation,
   isDepartmentLevel,
-  context,
+  motifCategory,
   numberOfDaysToAcceptInvitation,
   invitationFormat
 ) => {
@@ -17,7 +17,7 @@ const handleApplicantInvitation = async (
     isDepartmentLevel,
     invitationFormat,
     organisation.phone_number,
-    context,
+    motifCategory,
     numberOfDaysToAcceptInvitation
   );
   if (result.success) {

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -152,17 +152,17 @@ export default class Applicant {
     this.lastSmsInvitationSentAt = retrieveLastInvitationDate(
       upToDateApplicant.invitations,
       "sms",
-      this.currentConfiguration.context
+      this.currentConfiguration.motif_category
     );
     this.lastEmailInvitationSentAt = retrieveLastInvitationDate(
       upToDateApplicant.invitations,
       "email",
-      this.currentConfiguration.context
+      this.currentConfiguration.motif_category
     );
     this.lastPostalInvitationSentAt = retrieveLastInvitationDate(
       upToDateApplicant.invitations,
       "postal",
-      this.currentConfiguration.context
+      this.currentConfiguration.motif_category
     );
     this.departmentInternalId = upToDateApplicant.department_internal_id;
   }

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -25,7 +25,7 @@ import Applicant from "../models/Applicant";
 
 const reducer = reducerFactory("Expérimentation RSA");
 
-export default function ApplicantsUpload({ organisation, configuration, department, contextName }) {
+export default function ApplicantsUpload({ organisation, configuration, department, motifCategoryHuman }) {
   const columnNames = configuration.column_names;
   const parameterizedColumnNames = parameterizeObjectValues({
     ...columnNames.required,
@@ -43,8 +43,8 @@ export default function ApplicantsUpload({ organisation, configuration, departme
 
   const redirectToApplicantList = () => {
     window.location.href = isDepartmentLevel
-      ? `/departments/${department.id}/applicants?context=${configuration.context}`
-      : `/organisations/${organisation.id}/applicants?context=${configuration.context}`;
+      ? `/departments/${department.id}/applicants?motif_category=${configuration.motif_category}`
+      : `/organisations/${organisation.id}/applicants?motif_category=${configuration.motif_category}`;
   };
 
   const retrieveApplicantsFromList = async (file) => {
@@ -209,7 +209,7 @@ export default function ApplicantsUpload({ organisation, configuration, departme
           <h3 className="new-applicants-title">
             Ajout {isDepartmentLevel ? "au niveau du territoire" : "allocataires"}
           </h3>
-          <h6>({contextName})</h6>
+          <h6>({motifCategoryHuman})</h6>
           <FileHandler
             handleFile={handleApplicantsFile}
             fileSize={fileSize}

--- a/app/jobs/create_and_invite_applicant_job.rb
+++ b/app/jobs/create_and_invite_applicant_job.rb
@@ -43,18 +43,18 @@ class CreateAndInviteApplicantJob < ApplicationJob
     InviteApplicantJob.perform_async(
       applicant.id,
       @organisation.id,
-      @invitation_params.except(:context).merge(
+      @invitation_params.except(:motif_category).merge(
         format: invitation_format,
         help_phone_number: @organisation.phone_number
       ),
-      invitation_context,
+      invitation_motif_category,
       @rdv_solidarites_session_credentials
     )
   end
 
-  def invitation_context
-    # If not specified we invite on the first context found for the org
-    @invitation_params[:context] || @organisation.configurations.first.context
+  def invitation_motif_category
+    # If not specified we invite on the first motif category found for the org
+    @invitation_params[:motif_category] || @organisation.configurations.first.motif_category
   end
 
   def save_applicant

--- a/app/jobs/invite_applicant_job.rb
+++ b/app/jobs/invite_applicant_job.rb
@@ -1,12 +1,12 @@
 class InviteApplicantJob < ApplicationJob
   sidekiq_options retry: 0
 
-  def perform(applicant_id, organisation_id, invitation_attributes, context, rdv_solidarites_session_credentials)
+  def perform(applicant_id, organisation_id, invitation_attributes, motif_category, rdv_solidarites_session_credentials)
     @applicant = Applicant.find(applicant_id)
     @organisation = Organisation.find(organisation_id)
     @department = @organisation.department
     @invitation_attributes = invitation_attributes.deep_symbolize_keys
-    @context = context
+    @motif_category = motif_category
     @rdv_solidarites_session_credentials = rdv_solidarites_session_credentials.deep_symbolize_keys
 
     Invitation.with_advisory_lock "invite_applicant_#{@applicant.id}" do
@@ -36,12 +36,12 @@ class InviteApplicantJob < ApplicationJob
 
   def rdv_context
     RdvContext.with_advisory_lock "setting_rdv_context_for_applicant_#{@applicant.id}" do
-      RdvContext.find_or_create_by!(context: @context, applicant: @applicant)
+      RdvContext.find_or_create_by!(motif_category: @motif_category, applicant: @applicant)
     end
   end
 
   def matching_configuration
-    @matching_configuration ||= @organisation.configurations.find_by!(context: @context)
+    @matching_configuration ||= @organisation.configurations.find_by!(motif_category: @motif_category)
   end
 
   def save_and_send_invitation

--- a/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
@@ -27,11 +27,11 @@ module RdvSolidaritesWebhooks
     end
 
     def matching_configuration
-      organisation.configurations.find_by(context: rdv_solidarites_rdv.category)
+      organisation.configurations.find_by(motif_category: rdv_solidarites_rdv.category)
     end
 
     def unhandled_category?
-      Configuration.contexts.keys.exclude?(rdv_solidarites_rdv.category) || matching_configuration.nil?
+      Configuration.motif_categories.keys.exclude?(rdv_solidarites_rdv.category) || matching_configuration.nil?
     end
 
     def event
@@ -82,7 +82,7 @@ module RdvSolidaritesWebhooks
     def rdv_contexts
       applicants.map do |applicant|
         RdvContext.with_advisory_lock "setting_rdv_context_for_applicant_#{applicant.id}" do
-          RdvContext.find_or_create_by!(applicant: applicant, context: matching_configuration.context)
+          RdvContext.find_or_create_by!(applicant: applicant, motif_category: matching_configuration.motif_category)
         end
       end
     end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -29,8 +29,8 @@ class Applicant < ApplicationRecord
 
   scope :active, -> { where(deleted_at: nil) }
   scope :archived, ->(archived = true) { where(is_archived: archived) }
-  scope :without_rdv_contexts, lambda { |contexts|
-    where.not(id: joins(:rdv_contexts).where(rdv_contexts: { context: contexts }).ids)
+  scope :without_rdv_contexts, lambda { |motif_categories|
+    where.not(id: joins(:rdv_contexts).where(rdv_contexts: { motif_category: motif_categories }).ids)
   }
 
   def orientation_path_starting_date
@@ -38,7 +38,7 @@ class Applicant < ApplicationRecord
   end
 
   def orientations_rdvs
-    rdv_contexts.select(&:context_orientation?).flat_map(&:rdvs)
+    rdv_contexts.select(&:motif_orientation?).flat_map(&:rdvs)
   end
 
   def orientation_date
@@ -80,16 +80,16 @@ class Applicant < ApplicationRecord
     save!
   end
 
-  def rdv_context_for(context)
-    rdv_contexts.find { |rc| rc.context == context }
+  def rdv_context_for(motif_category)
+    rdv_contexts.find { |rc| rc.motif_category == motif_category }
   end
 
   def deleted?
     deleted_at.present?
   end
 
-  def contexts
-    rdv_contexts.map(&:context)
+  def motif_categories
+    rdv_contexts.map(&:motif_category)
   end
 
   def as_json(_opts = {})

--- a/app/models/concerns/has_motif_category_concern.rb
+++ b/app/models/concerns/has_motif_category_concern.rb
@@ -1,17 +1,17 @@
-module HasContextConcern
+module HasMotifCategoryConcern
   extend ActiveSupport::Concern
 
-  CONTEXT_NAMES_MAPPING = {
+  MOTIF_CATEGORIES_NAMES_MAPPING = {
     "rsa_orientation" => "RSA orientation",
     "rsa_accompagnement" => "RSA accompagnement",
     "rsa_orientation_on_phone_platform" => "RSA orientation sur plateforme téléphonique"
   }.freeze
 
   included do
-    enum context: { rsa_orientation: 0, rsa_accompagnement: 1, rsa_orientation_on_phone_platform: 2 }
+    enum motif_category: { rsa_orientation: 0, rsa_accompagnement: 1, rsa_orientation_on_phone_platform: 2 }
   end
 
-  def context_name
-    CONTEXT_NAMES_MAPPING[context]
+  def motif_category_human
+    MOTIF_CATEGORIES_NAMES_MAPPING[motif_category]
   end
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,5 +1,5 @@
 class Configuration < ApplicationRecord
-  include HasContextConcern
+  include HasMotifCategoryConcern
 
   has_and_belongs_to_many :organisations
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -14,7 +14,7 @@ class Department < ApplicationRecord
     "#{name}, #{region}"
   end
 
-  def contexts
-    configurations.map(&:context)
+  def motif_categories
+    configurations.map(&:motif_category)
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,11 +6,11 @@ class Invitation < ApplicationRecord
 
   attr_accessor :content
 
-  validates :help_phone_number, :context, :token, :organisations, :link, :number_of_days_to_accept_invitation,
+  validates :help_phone_number, :token, :organisations, :link, :number_of_days_to_accept_invitation,
             presence: true
   validate :organisations_cannot_be_from_different_departments
 
-  delegate :context, :context_name, to: :rdv_context
+  delegate :motif_category, :motif_category_human, to: :rdv_context
 
   enum format: { sms: 0, email: 1, postal: 2 }, _prefix: :format
   after_commit :set_rdv_context_status
@@ -35,7 +35,7 @@ class Invitation < ApplicationRecord
   end
 
   def as_json(_opts = {})
-    super.merge(context: context)
+    super.merge(motif_category: motif_category)
   end
 
   def invitation_parameters

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -17,8 +17,8 @@ class Organisation < ApplicationRecord
 
   delegate :name, :name_with_region, :number, to: :department, prefix: true
 
-  def contexts
-    configurations.map(&:context)
+  def motif_categories
+    configurations.map(&:motif_category)
   end
 
   def as_json(_opts = {})

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -16,7 +16,7 @@ class Rdv < ApplicationRecord
   validates :applicants, :rdv_solidarites_motif_id, :starts_at, :duration_in_min, presence: true
   validates :rdv_solidarites_rdv_id, uniqueness: true, presence: true
 
-  validate :context_subject_is_uniq
+  validate :motif_category_is_uniq
 
   enum created_by: { agent: 0, user: 1, file_attente: 2 }, _prefix: :created_by
   enum status: { unknown: 0, waiting: 1, seen: 2, excused: 3, revoked: 4, noshow: 5 }
@@ -60,9 +60,9 @@ class Rdv < ApplicationRecord
     RefreshRdvContextStatusesJob.perform_async(rdv_context_ids)
   end
 
-  def context_subject_is_uniq
-    return if rdv_contexts.pluck(:context).uniq.length < 2
+  def motif_category_is_uniq
+    return if rdv_contexts.pluck(:motif_category).uniq.length < 2
 
-    errors.add(:base, "Un RDV ne peut pas être lié à deux sujets différents")
+    errors.add(:base, "Un RDV ne peut pas être lié à deux catégories de motifs différents")
   end
 end

--- a/app/models/rdv_context.rb
+++ b/app/models/rdv_context.rb
@@ -1,5 +1,5 @@
 class RdvContext < ApplicationRecord
-  include HasContextConcern
+  include HasMotifCategoryConcern
   include HasStatusConcern
   include InvitableConcern
 
@@ -7,7 +7,7 @@ class RdvContext < ApplicationRecord
   has_and_belongs_to_many :rdvs
   belongs_to :applicant
 
-  validates :context, presence: true, uniqueness: { scope: :applicant_id }
+  validates :motif_category, presence: true, uniqueness: { scope: :applicant_id }
 
   STATUSES_WITH_ACTION_REQUIRED = %w[
     not_invited rdv_needs_status_update rdv_noshow rdv_revoked rdv_excused multiple_rdvs_cancelled
@@ -34,8 +34,8 @@ class RdvContext < ApplicationRecord
     status.in?(STATUSES_WITH_ATTENTION_NEEDED)
   end
 
-  def context_orientation?
-    context.in?(%w[rsa_orientation rsa_orientation_on_phone_platform])
+  def motif_orientation?
+    motif_category.in?(%w[rsa_orientation rsa_orientation_on_phone_platform])
   end
 
   def first_rdv_creation_date

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -37,7 +37,7 @@ class Stat
   # correctly informed by the organisations/ or are taken in the past (which mess up with the delays)
   def orientation_rdvs
     @orientation_rdvs ||= relevant_rdvs.joins(:rdv_contexts)
-                                       .where(rdv_contexts: { context: %w[rsa_orientation] })
+                                       .where(rdv_contexts: { motif_category: %w[rsa_orientation] })
   end
 
   def orientation_rdvs_by_month
@@ -173,7 +173,7 @@ class Stat
                                        .where("applicants.created_at < ?", 27.days.ago))
                          .joins(:rdv_contexts)
                          .where(rdv_contexts: {
-                                  context: %w[rsa_orientation]
+                                  motif_category: %w[rsa_orientation]
                                 })
   end
   # -----------------------------------------------------------------------------------------

--- a/app/services/create_applicants_csv_export.rb
+++ b/app/services/create_applicants_csv_export.rb
@@ -1,10 +1,10 @@
 require "csv"
 
 class CreateApplicantsCsvExport < BaseService
-  def initialize(applicants:, structure:, context:)
+  def initialize(applicants:, structure:, motif_category:)
     @applicants = applicants
     @structure = structure
-    @context = context
+    @motif_category = motif_category
   end
 
   def call
@@ -78,13 +78,13 @@ class CreateApplicantsCsvExport < BaseService
     if @structure.nil?
       "Liste_beneficiaires.csv"
     else
-      "Liste_beneficiaires_#{context_title}_#{@structure.class.model_name.human.downcase}_" \
+      "Liste_beneficiaires_#{motif_category_title}_#{@structure.class.model_name.human.downcase}_" \
         "#{@structure.name.parameterize(separator: '_')}.csv"
     end
   end
 
-  def context_title
-    @context.presence || "autres"
+  def motif_category_title
+    @motif_category.presence || "autres"
   end
 
   def human_rdv_context_status(applicant)
@@ -106,7 +106,7 @@ class CreateApplicantsCsvExport < BaseService
   end
 
   def rdv_context(applicant)
-    applicant.rdv_context_for(@context)
+    applicant.rdv_context_for(@motif_category)
   end
 
   def format_date(date)

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -43,7 +43,7 @@ module Invitations
         address: address,
         invitation_token: @invitation.token,
         organisation_ids: @invitation.organisations.map(&:rdv_solidarites_organisation_id),
-        motif_category: @invitation.context
+        motif_category: @invitation.motif_category
       }
         .merge(@invitation.rdv_solidarites_lieu_id? ? { lieu_id: @invitation.rdv_solidarites_lieu_id } : geo_attributes)
     end

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -15,7 +15,7 @@ module Invitations
 
     def generate_letter
       @invitation.content = ApplicationController.render(
-        template: "letters/invitation_for_#{@invitation.context}",
+        template: "letters/invitation_for_#{@invitation.motif_category}",
         layout: "pdf",
         locals: {
           invitation: @invitation,

--- a/app/services/invitations/send_email.rb
+++ b/app/services/invitations/send_email.rb
@@ -30,7 +30,7 @@ module Invitations
     end
 
     def send_email
-      InvitationMailer.send(:"invitation_for_#{@invitation.context}", @invitation, applicant).deliver_now
+      InvitationMailer.send(:"invitation_for_#{@invitation.motif_category}", @invitation, applicant).deliver_now
     end
   end
 end

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -31,7 +31,7 @@ module Invitations
     end
 
     def content
-      send(:"content_for_#{@invitation.context}")
+      send(:"content_for_#{@invitation.motif_category}")
     end
 
     def content_for_rsa_orientation
@@ -74,10 +74,6 @@ module Invitations
 
     def applicant
       @invitation.applicant
-    end
-
-    def configuration
-      organisation.configurations.find_by(context: @invitation.context)
     end
 
     def organisation

--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -2,11 +2,11 @@
   <ul class="nav nav-tabs">
     <% @all_configurations.each do |configuration| %>
       <li class="nav-item">
-        <%= link_to configuration.context_name, compute_index_path(@organisation, @department, context: configuration.context), class:  "nav-link #{configuration.id == @current_configuration&.id ? 'active' : ''}"%>
+        <%= link_to configuration.motif_category_human, compute_index_path(@organisation, @department, motif_category: configuration.motif_category), class:  "nav-link #{configuration.id == @current_configuration&.id ? 'active' : ''}"%>
       </li>
     <% end %>
     <li class="nav-item">
-      <%= link_to "Autres", compute_index_path(@organisation, @department, context: "none"), class: "nav-link #{@current_context.nil? ? 'active' : ''}" %>
+      <%= link_to "Autres", compute_index_path(@organisation, @department, motif_category: "none"), class: "nav-link #{@current_motif_category.nil? ? 'active' : ''}" %>
     </li>
   </ul>
   <div class="col-12 text-center">
@@ -20,7 +20,7 @@
           <th scope="col" class="d-none d-lg-table-cell">Email</th>
           <th scope="col" class="d-none d-lg-table-cell">Téléphone</th>
           <th scope="col" class="d-none d-lg-table-cell">Adresse</th>
-          <% if @current_context.present? %>
+          <% if @current_motif_category.present? %>
             <% if show_invitations?(@current_configuration) %>
               <th scope="col">Première invitation</th>
               <th scope="col">Dernière invitation</th>
@@ -34,7 +34,7 @@
         </thead>
         <tbody class="align-middle">
           <% @applicants.each do |applicant| %>
-            <% rdv_context = applicant.rdv_context_for(@current_context) %>
+            <% rdv_context = applicant.rdv_context_for(@current_motif_category) %>
             <tr class="<%= "table-danger" if applicant.is_archived? %>">
               <td><%= display_attribute applicant.last_name %></td>
               <td><%= display_attribute applicant.first_name %></td>
@@ -59,7 +59,7 @@
                   <i class="fas fa-times icon-blue" />
                 <% end %>
               </td>
-              <% if @current_context.present? %>
+              <% if @current_motif_category.present? %>
                 <% if show_invitations?(@current_configuration) %>
                   <td><%= display_attribute(compute_first_invitation_sent_at(rdv_context)) %> </td>
                   <td><%= show_last_invitation_date?(rdv_context) ? display_attribute(format_date(rdv_context.last_invitation_sent_at)) : "-" %></td>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -1,11 +1,11 @@
 <div class="d-flex align-items-center context-header">
   <span></span>
-  <h5 class="text-center px-2 py-4"><strong><%= configuration.context_name %></strong></h5>
+  <h5 class="text-center px-2 py-4"><strong><%= configuration.motif_category_human %></strong></h5>
   <span></span>
   <table class="mx-2">
     <tbody>
       <tr>
-        <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context, configuration.number_of_days_before_action_required) %>" id="js-block-status-<%= configuration.context %>"><em><%= display_context_status(rdv_context, configuration.number_of_days_before_action_required) %></em></td>
+        <td class="px-2 py-1 context-status <%= background_class_for_context_status(rdv_context, configuration.number_of_days_before_action_required) %>" id="js-block-status-<%= configuration.motif_category %>"><em><%= display_context_status(rdv_context, configuration.number_of_days_before_action_required) %></em></td>
       </tr>
     </tbody>
   </table>
@@ -21,7 +21,7 @@
         invitations: rdv_context.nil? ? [] : rdv_context.invitations,
         isDepartmentLevel: department_level?,
         invitationFormats: configuration.invitation_formats,
-        context: configuration.context,
+        motifCategory: configuration.motif_category,
         numberOfDaysToAcceptInvitation: configuration.number_of_days_to_accept_invitation,
         status: rdv_context&.status,
       }

--- a/app/views/applicants/_search_form.html.erb
+++ b/app/views/applicants/_search_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with method: :get, local: true, url: compute_index_path(@organisation, @department) do |form| %>
   <%= form.text_field :search_query, placeholder: "Prénom, nom, email, numéro allocataire...", class: "form-control mb-1" %>
-  <%= form.hidden_field :context, value: @current_context %>
+  <%= form.hidden_field :motif_category, value: @current_motif_category %>
   <div class="d-flex justify-content-between">
     <%= form.submit "Rechercher", name: nil, class: "btn btn-blue-out" %>
     <% if display_back_to_list_button? %>
       <div class="d-flex justify-content-start">
-        <%= link_to compute_index_path(@organisation, @department, context: @current_context), class: "btn btn-blue-out" do %>
+        <%= link_to compute_index_path(@organisation, @department, motif_category: @current_motif_category), class: "btn btn-blue-out" do %>
           Retour à la liste
         <% end %>
       </div>

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5 mb-5">
   <div class="row mb-4 block-white justify-content-center">
     <div class="col-4 justify-content-center">
-      <% if @current_context.present? %>
+      <% if @current_motif_category.present? %>
         <div class="mb-1">
           <%=
             select(
@@ -13,7 +13,7 @@
         </div>
       <% end %>
       <%= render 'search_form' %>
-      <% if @current_context.present? %>
+      <% if @current_motif_category.present? %>
         <div class=" text-left mt-2">
           <%= check_box("applicants_list", "action_required", class: "js-action-required-checkbox") %>Intervention nécessaire
           <small>

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -2,7 +2,7 @@
 <div class="container label-blue mt-4">
   <div class="d-flex justify-content-between mb-4">
     <div>
-      <%= link_to(compute_index_path(@organisation, @department, context: @applicant.contexts.first)) do %>
+      <%= link_to(compute_index_path(@organisation, @department, motif_category: @applicant.motif_categories.first)) do %>
         <button class="btn btn-blue-out">Retour</button>
       <% end %>
       <%= link_to rdv_solidarites_user_url(@organisation, @applicant), target: "_blank" do %>
@@ -81,7 +81,7 @@
     <%= render "add_to_org_button", can_be_added_to_other_org: @can_be_added_to_other_org, department: @department, applicant: @applicant %>
   </div>
   <% @all_configurations.each do |configuration| %>
-    <%= render "rdv_context", rdv_context: @applicant.rdv_context_for(configuration.context), configuration: configuration, applicant: @applicant, department: @department  %>
+    <%= render "rdv_context", rdv_context: @applicant.rdv_context_for(configuration.motif_category), configuration: configuration, applicant: @applicant, department: @department  %>
   <% end %>
 </div>
 

--- a/app/views/applicants_organisations/create.turbo_stream.erb
+++ b/app/views/applicants_organisations/create.turbo_stream.erb
@@ -9,6 +9,6 @@
 <% end %>
 <% if @assign_rdv_context %>
   <%= turbo_stream.replace "remote_modal" do %>
-    <%= render partial: "rdv_contexts/form", locals: { applicant: @applicant, contexts: @organisation.configurations.map(&:context), rdv_context: RdvContext.new } %>
+    <%= render partial: "rdv_contexts/form", locals: { applicant: @applicant, motif_categories: @organisation.motif_categories, rdv_context: RdvContext.new } %>
   <% end %>
 <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -20,12 +20,12 @@
                 <div class="p-3">
                   <ul class="list-inline">
                     <% if organisations.length > 1 %>
-                      <%= link_to department_applicants_path(department, context: department.contexts.first) do %>
+                      <%= link_to department_applicants_path(department, motif_category: department.motif_categories.first) do %>
                         <li class="my-4"><div class="col-5 pb-2 border-bottom">⭐ Toutes les organisations ⭐</div></li>
                       <% end %>
                     <% end %>
                     <% organisations.each do |organisation| %>
-                      <%= link_to organisation_applicants_path(organisation, context: organisation.contexts.first) do %>
+                      <%= link_to organisation_applicants_path(organisation, motif_category: organisation.motif_categories.first) do %>
                         <li class="my-3"><div class="col-5 pb-2 border-bottom"><%= organisation.name %></div></li>
                       <% end %>
                     <% end %>

--- a/app/views/rdv_contexts/_form.html.erb
+++ b/app/views/rdv_contexts/_form.html.erb
@@ -1,9 +1,9 @@
 <%= render "common/remote_modal", title: "Sélectionnez un contexte d'invitation" do %>
   <%= simple_form_for(rdv_context, url: applicant_rdv_contexts_path(applicant), html: { method: :post }, data: { "turbo-frame" => "_top" }) do |f| %>
       <div class="form-group">
-        <%= f.input :context,
+        <%= f.input :motif_category,
                     as: :select,
-                    collection: contexts.map { |c| [Configuration::CONTEXT_NAMES_MAPPING[c], c] },
+                    collection: motif_categories.map { |c| [Configuration::MOTIF_CATEGORIES_NAMES_MAPPING[c], c] },
                     include_blank: false,
                     input_html: { class: "form-control" }
         %>

--- a/app/views/uploads/_category_selection.html.erb
+++ b/app/views/uploads/_category_selection.html.erb
@@ -10,7 +10,7 @@
       <% @all_configurations.each do |configuration| %>
         <div>
           <%= link_to(department_level? ? new_department_upload_path(@department, configuration_id: configuration.id) : new_organisation_upload_path(@organisation, configuration_id: configuration.id), class: "btn btn-blue-out") do %>
-            <%= configuration.context_name %>
+            <%= configuration.motif_category_human %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -1,9 +1,9 @@
 <% if @current_configuration.present? %>
   <%= react_component(
     "pages/ApplicantsUpload", {
-      organisation: @organisation, configuration: @current_configuration, department: @department, contextName: @context_name
+      organisation: @organisation, configuration: @current_configuration, department: @department, motifCategoryHuman: @motif_category_human
     }
   ) %>
 <% else %>
-  <%= render "context_selection" %>
+  <%= render "category_selection" %>
 <% end %>

--- a/db/migrate/20220608090654_rename_context_to_motif_category.rb
+++ b/db/migrate/20220608090654_rename_context_to_motif_category.rb
@@ -1,0 +1,6 @@
+class RenameContextToMotifCategory < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :rdv_contexts, :context, :motif_category
+    rename_column :configurations, :context, :motif_category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_07_105632) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_08_090654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,7 +74,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_105632) do
     t.json "column_names"
     t.string "invitation_formats", default: ["sms", "email", "postal"], null: false, array: true
     t.boolean "notify_applicant", default: false
-    t.integer "context", default: 0
+    t.integer "motif_category", default: 0
     t.integer "number_of_days_to_accept_invitation", default: 3
     t.integer "number_of_days_before_action_required", default: 3
     t.string "signature_lines", array: true
@@ -104,7 +104,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_105632) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "letter_sender_name"
-    t.string "sender_address_lines"
+    t.string "sender_address_lines", array: true
     t.string "sms_sender_name"
     t.string "signature_lines", array: true
   end
@@ -168,13 +168,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_105632) do
   end
 
   create_table "rdv_contexts", force: :cascade do |t|
-    t.integer "context"
+    t.integer "motif_category"
     t.integer "status"
     t.bigint "applicant_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["applicant_id"], name: "index_rdv_contexts_on_applicant_id"
-    t.index ["context"], name: "index_rdv_contexts_on_context"
+    t.index ["motif_category"], name: "index_rdv_contexts_on_motif_category"
     t.index ["status"], name: "index_rdv_contexts_on_status"
   end
 
@@ -195,10 +195,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_07_105632) do
     t.string "address"
     t.integer "created_by"
     t.integer "status"
-    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "organisation_id"
+    t.text "context"
     t.datetime "last_webhook_update_received_at"
     t.index ["created_by"], name: "index_rdvs_on_created_by"
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,7 +54,7 @@ drome_orientation_config = Configuration.create!(
     "optional"=>{"department_internal_id"=>"ID Iodas"}},
   notify_applicant: false,
   invitation_formats: ["sms", "email", "postal"],
-  context: "rsa_orientation",
+  motif_category: "rsa_orientation",
   number_of_days_to_accept_invitation: 3,
   number_of_days_before_action_required: 3
 )
@@ -76,7 +76,7 @@ drome_accompagnement_config = Configuration.create!(
     "optional"=>{"department_internal_id"=>"ID Iodas"}},
   notify_applicant: false,
   invitation_formats: ["sms", "email", "postal"],
-  context: "rsa_accompagnement",
+  motif_category: "rsa_accompagnement",
   number_of_days_to_accept_invitation: 3,
   number_of_days_before_action_required: 3
 )
@@ -96,7 +96,7 @@ yonne_orientation_config = Configuration.create!(
     "optional"=>{"birth_name"=>"Nom JF", "department_internal_id"=>"Code individu Iodas"}},
   notify_applicant: true,
   invitation_formats: [],
-  context: "rsa_orientation",
+  motif_category: "rsa_orientation",
   number_of_days_to_accept_invitation: 3,
   number_of_days_before_action_required: 3
 )

--- a/scripts/extract_applicants_to_csv.rb
+++ b/scripts/extract_applicants_to_csv.rb
@@ -8,7 +8,7 @@ require 'csv'
 EMAIL = ARGV[0] == "nil" ? nil : ARGV[0]
 ORGANISATION_ID = ARGV[1] == "nil" ? nil : ARGV[1]
 DEPARTMENT_ID = ARGV[2] == "nil" ? nil : ARGV[2]
-CONTEXT = ARGV[3] == "nil" ? nil : ARGV[3]
+MOTIF_CATEGORY = ARGV[3] == "nil" ? nil : ARGV[3]
 
 structure = if DEPARTMENT_ID.present?
               Department.find(DEPARTMENT_ID)
@@ -18,12 +18,12 @@ structure = if DEPARTMENT_ID.present?
 
 applicants = structure&.applicants || Applicant.order(:department_id)
 context_applicants = if CONTEXT.present?
-                       applicants.joins(:rdv_contexts).where(rdv_contexts: { context: CONTEXT })
+                       applicants.joins(:rdv_contexts).where(rdv_contexts: { motif_category: MOTIF_CATEGORY })
                      else
                        applicants.where.missing(:rdv_contexts)
                      end
 
-result = CreateApplicantsCsvExport.call(applicants: context_applicants, structure: structure, context: CONTEXT)
+result = CreateApplicantsCsvExport.call(applicants: context_applicants, structure: structure, motif_category: MOTIF_CATEGORY)
 
 if EMAIL.present?
   CsvExportMailer.applicants_csv_export(EMAIL, result.csv, result.filename).deliver_now

--- a/scripts/extract_applicants_to_csv.rb
+++ b/scripts/extract_applicants_to_csv.rb
@@ -23,7 +23,9 @@ context_applicants = if CONTEXT.present?
                        applicants.where.missing(:rdv_contexts)
                      end
 
-result = CreateApplicantsCsvExport.call(applicants: context_applicants, structure: structure, motif_category: MOTIF_CATEGORY)
+result = CreateApplicantsCsvExport.call(
+  applicants: context_applicants, structure: structure, motif_category: MOTIF_CATEGORY
+)
 
 if EMAIL.present?
   CsvExportMailer.applicants_csv_export(EMAIL, result.csv, result.filename).deliver_now

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -3,7 +3,7 @@ describe ApplicantsController, type: :controller do
   let!(:configuration) do
     create(
       :configuration,
-      context: "rsa_orientation",
+      motif_category: "rsa_orientation",
       number_of_days_before_action_required: number_of_days_before_action_required
     )
   end
@@ -303,9 +303,9 @@ describe ApplicantsController, type: :controller do
     end
 
     context "it shows the different contexts" do
-      let!(:configuration) { create(:configuration, context: "rsa_orientation", invitation_formats: %w[sms email]) }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_orientation", invitation_formats: %w[sms email]) }
       let!(:configuration2) do
-        create(:configuration, context: "rsa_accompagnement", invitation_formats: %w[sms email postal])
+        create(:configuration, motif_category: "rsa_accompagnement", invitation_formats: %w[sms email postal])
       end
 
       let!(:organisation) do
@@ -314,7 +314,7 @@ describe ApplicantsController, type: :controller do
       end
 
       let!(:rdv_context) do
-        create(:rdv_context, status: "rdv_seen", applicant: applicant, context: "rsa_orientation")
+        create(:rdv_context, status: "rdv_seen", applicant: applicant, motif_category: "rsa_orientation")
       end
       let!(:invitation_orientation) do
         create(:invitation, sent_at: "2021-10-20", format: "sms", rdv_context: rdv_context)
@@ -337,7 +337,7 @@ describe ApplicantsController, type: :controller do
       end
 
       let!(:rdv_context2) do
-        create(:rdv_context, status: "invitation_pending", applicant: applicant, context: "rsa_accompagnement")
+        create(:rdv_context, status: "invitation_pending", applicant: applicant, motif_category: "rsa_accompagnement")
       end
 
       let!(:invitation_accompagnement) do
@@ -374,7 +374,7 @@ describe ApplicantsController, type: :controller do
         organisations: [organisation], department: department, last_name: "Chabat", rdv_contexts: [rdv_context1]
       )
     end
-    let!(:rdv_context1) { build(:rdv_context, context: "rsa_orientation", status: "rdv_seen") }
+    let!(:rdv_context1) { build(:rdv_context, motif_category: "rsa_orientation", status: "rdv_seen") }
 
     let!(:applicant2) do
       create(
@@ -383,8 +383,8 @@ describe ApplicantsController, type: :controller do
       )
     end
 
-    let!(:rdv_context2) { build(:rdv_context, context: "rsa_orientation", status: "invitation_pending") }
-    let!(:index_params) { { organisation_id: organisation.id, context: "rsa_orientation" } }
+    let!(:rdv_context2) { build(:rdv_context, motif_category: "rsa_orientation", status: "invitation_pending") }
+    let!(:index_params) { { organisation_id: organisation.id, motif_category: "rsa_orientation" } }
 
     render_views
 
@@ -402,11 +402,11 @@ describe ApplicantsController, type: :controller do
     end
 
     context "when a context is specified" do
-      let!(:rdv_context2) { build(:rdv_context, context: "rsa_accompagnement", status: "invitation_pending") }
-      let!(:configuration) { create(:configuration, context: "rsa_accompagnement") }
+      let!(:rdv_context2) { build(:rdv_context, motif_category: "rsa_accompagnement", status: "invitation_pending") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement") }
 
       it "returns the list of applicants in the current context" do
-        get :index, params: index_params.merge(context: "rsa_accompagnement")
+        get :index, params: index_params.merge(motif_category: "rsa_accompagnement")
 
         expect(response).to be_successful
         expect(response.body).not_to match(/Chabat/)
@@ -415,7 +415,9 @@ describe ApplicantsController, type: :controller do
     end
 
     context "when a search query is specified" do
-      let!(:index_params) { { organisation_id: organisation.id, search_query: "chabat", context: "rsa_orientation" } }
+      let!(:index_params) do
+        { organisation_id: organisation.id, search_query: "chabat", motif_category: "rsa_orientation" }
+      end
 
       it "searches the applicants" do
         get :index, params: index_params
@@ -426,7 +428,7 @@ describe ApplicantsController, type: :controller do
 
     context "when a status is passed" do
       let!(:index_params) do
-        { organisation_id: organisation.id, status: "invitation_pending", context: "rsa_orientation" }
+        { organisation_id: organisation.id, status: "invitation_pending", motif_category: "rsa_orientation" }
       end
 
       it "filters by status" do
@@ -437,7 +439,9 @@ describe ApplicantsController, type: :controller do
     end
 
     context "when action_required is passed" do
-      let!(:index_params) { { organisation_id: organisation.id, action_required: "true", context: "rsa_orientation" } }
+      let!(:index_params) do
+        { organisation_id: organisation.id, action_required: "true", motif_category: "rsa_orientation" }
+      end
       let!(:number_of_days_before_action_required) { 4 }
 
       context "when the invitation has been sent before the number of days defined in the configuration ago" do
@@ -462,7 +466,7 @@ describe ApplicantsController, type: :controller do
     end
 
     context "when department level" do
-      let!(:index_params) { { department_id: department.id, context: "rsa_orientation" } }
+      let!(:index_params) { { department_id: department.id, motif_category: "rsa_orientation" } }
 
       it "renders the index page" do
         get :index, params: index_params
@@ -477,10 +481,10 @@ describe ApplicantsController, type: :controller do
         create(:applicant, organisations: [organisation], last_name: "Chabat", rdv_contexts: [])
       end
 
-      let!(:rdv_context2) { build(:rdv_context, context: "rsa_accompagnement", status: "invitation_pending") }
+      let!(:rdv_context2) { build(:rdv_context, motif_category: "rsa_accompagnement", status: "invitation_pending") }
 
       it "lists the applicants with no rdv contexts in the contexts of the org configs" do
-        get :index, params: index_params.merge(context: nil)
+        get :index, params: index_params.merge(motif_category: nil)
 
         expect(response.body).to match(/Chabat/)
         expect(response.body).to match(/Baer/)

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -303,7 +303,9 @@ describe ApplicantsController, type: :controller do
     end
 
     context "it shows the different contexts" do
-      let!(:configuration) { create(:configuration, motif_category: "rsa_orientation", invitation_formats: %w[sms email]) }
+      let!(:configuration) do
+        create(:configuration, motif_category: "rsa_orientation", invitation_formats: %w[sms email])
+      end
       let!(:configuration2) do
         create(:configuration, motif_category: "rsa_accompagnement", invitation_formats: %w[sms email postal])
       end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -10,7 +10,7 @@ describe InvitationsController, type: :controller do
     let!(:organisations) { Organisation.where(id: organisation.id) }
     let!(:agent) { create(:agent, organisations: organisations) }
     let!(:applicant) { create(:applicant, id: applicant_id, organisations: [organisation]) }
-    let!(:context) { "rsa_orientation" }
+    let!(:motif_category) { "rsa_orientation" }
 
     let!(:create_params) do
       {
@@ -21,7 +21,7 @@ describe InvitationsController, type: :controller do
           help_phone_number: help_phone_number
         },
         rdv_context: {
-          context: context
+          motif_category: motif_category
         }
       }
     end
@@ -34,13 +34,13 @@ describe InvitationsController, type: :controller do
       )
     end
 
-    let!(:rdv_context) { build(:rdv_context, applicant: applicant, context: context) }
+    let!(:rdv_context) { build(:rdv_context, applicant: applicant, motif_category: motif_category) }
 
     before do
       sign_in(agent)
       setup_rdv_solidarites_session(rdv_solidarites_session)
       allow(RdvContext).to receive(:find_or_create_by!)
-        .with(context: context, applicant: applicant)
+        .with(motif_category: motif_category, applicant: applicant)
         .and_return(rdv_context)
       allow(Invitation).to receive(:new)
         .with(
@@ -55,7 +55,7 @@ describe InvitationsController, type: :controller do
     context "organisation level" do
       it "finds or create a context" do
         expect(RdvContext).to receive(:find_or_create_by!)
-          .with(context: context, applicant: applicant)
+          .with(motif_category: motif_category, applicant: applicant)
         post :create, params: create_params
       end
 
@@ -89,14 +89,14 @@ describe InvitationsController, type: :controller do
             help_phone_number: help_phone_number
           },
           rdv_context: {
-            context: context
+            motif_category: motif_category
           }
         }
       end
 
       it "finds or create a context" do
         expect(RdvContext).to receive(:find_or_create_by!)
-          .with(context: context, applicant: applicant)
+          .with(motif_category: motif_category, applicant: applicant)
         post :create, params: create_params
       end
 
@@ -150,7 +150,7 @@ describe InvitationsController, type: :controller do
               format: "postal",
               help_phone_number: help_phone_number
             },
-            rdv_context: { context: context }
+            rdv_context: { motif_category: motif_category }
           }
         end
 

--- a/spec/controllers/rdv_contexts_controller_spec.rb
+++ b/spec/controllers/rdv_contexts_controller_spec.rb
@@ -4,7 +4,7 @@ describe RdvContextsController, type: :controller do
   let!(:applicant) { create(:applicant, department: department, id: applicant_id) }
   let!(:agent) { create(:agent, organisations: [organisation]) }
   let!(:organisation) { create(:organisation, department: department) }
-  let!(:rdv_context) { create(:rdv_context, applicant: applicant, context: "rsa_accompagnement") }
+  let!(:rdv_context) { create(:rdv_context, applicant: applicant, motif_category: "rsa_accompagnement") }
   let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession) }
 
   render_views
@@ -18,14 +18,14 @@ describe RdvContextsController, type: :controller do
     subject do
       post :create, params: {
         applicant_id: applicant_id, rdv_context: {
-          context: "rsa_accompagnement"
+          motif_category: "rsa_accompagnement"
         }, format: "turbo_stream"
       }
     end
 
     before do
       allow(RdvContext).to receive(:find_or_initialize_by)
-        .with(context: "rsa_accompagnement", applicant: applicant)
+        .with(motif_category: "rsa_accompagnement", applicant: applicant)
         .and_return(rdv_context)
       allow(rdv_context).to receive(:save)
         .and_return(true)

--- a/spec/factories/configuration.rb
+++ b/spec/factories/configuration.rb
@@ -2,8 +2,6 @@ FactoryBot.define do
   factory :configuration do
     sheet_name { 'LISTE DEMANDEURS' }
     invitation_formats { %w[sms] }
-    # rubocop:disable RSpec/EmptyExampleGroup, RSpec/MissingExampleGroupArgument
-    context { "rsa_orientation" }
-    # rubocop:enable RSpec/EmptyExampleGroup, RSpec/MissingExampleGroupArgument
+    motif_category { "rsa_orientation" }
   end
 end

--- a/spec/factories/rdv_context.rb
+++ b/spec/factories/rdv_context.rb
@@ -1,9 +1,7 @@
 FactoryBot.define do
   factory :rdv_context do
     association :applicant
-    # rubocop:disable RSpec/EmptyExampleGroup, RSpec/MissingExampleGroupArgument
-    context { "rsa_orientation" }
-    # rubocop:enable RSpec/EmptyExampleGroup, RSpec/MissingExampleGroupArgument
+    motif_category { "rsa_orientation" }
 
     after(:build) do |a|
       # https://github.com/thoughtbot/factory_bot/issues/931#issuecomment-307542965

--- a/spec/jobs/create_and_invite_applicant_job_spec.rb
+++ b/spec/jobs/create_and_invite_applicant_job_spec.rb
@@ -13,8 +13,8 @@ describe CreateAndInviteApplicantJob, type: :job do
       department: department, configurations: [configuration], id: organisation_id, phone_number: "0146292929"
     )
   end
-  let!(:context) { "rsa_orientation" }
-  let!(:configuration) { create(:configuration, context: context) }
+  let!(:motif_category) { "rsa_orientation" }
+  let!(:configuration) { create(:configuration, motif_category: motif_category) }
   let!(:applicant) { create(:applicant) }
   let!(:applicant_attributes) do
     { department_internal_id: "1919", affiliation_number: "00001", role: "conjoint", phone_number: "07070707",
@@ -53,9 +53,13 @@ describe CreateAndInviteApplicantJob, type: :job do
 
   it "enqueues invite applicant jobs" do
     expect(InviteApplicantJob).to receive(:perform_async)
-      .with(applicant.id, organisation.id, sms_invitation_attributes, context, rdv_solidarites_session_credentials)
+      .with(
+        applicant.id, organisation.id, sms_invitation_attributes, motif_category, rdv_solidarites_session_credentials
+      )
     expect(InviteApplicantJob).to receive(:perform_async)
-      .with(applicant.id, organisation.id, email_invitation_attributes, context, rdv_solidarites_session_credentials)
+      .with(
+        applicant.id, organisation.id, email_invitation_attributes, motif_category, rdv_solidarites_session_credentials
+      )
     subject
   end
 
@@ -64,7 +68,9 @@ describe CreateAndInviteApplicantJob, type: :job do
 
     it "does not enqueue an invite sms job" do
       expect(InviteApplicantJob).not_to receive(:perform_async)
-        .with(applicant.id, organisation.id, sms_invitation_attributes, context, rdv_solidarites_session_credentials)
+        .with(
+          applicant.id, organisation.id, sms_invitation_attributes, motif_category, rdv_solidarites_session_credentials
+        )
       subject
     end
   end
@@ -74,13 +80,16 @@ describe CreateAndInviteApplicantJob, type: :job do
 
     it "does not enqueue an invite email job" do
       expect(InviteApplicantJob).not_to receive(:perform_async)
-        .with(applicant.id, organisation.id,  email_invitation_attributes, context, rdv_solidarites_session_credentials)
+        .with(
+          applicant.id, organisation.id,
+          email_invitation_attributes, motif_category, rdv_solidarites_session_credentials
+        )
       subject
     end
   end
 
-  context "when a context is specified" do
-    let!(:invitation_params) { { rdv_solidarites_lieu_id: 888, context: "rsa_accompagnement" } }
+  context "when a motif category is specified" do
+    let!(:invitation_params) { { rdv_solidarites_lieu_id: 888, motif_category: "rsa_accompagnement" } }
 
     it "enqueues invite applicant jobs with the specified context" do
       expect(InviteApplicantJob).to receive(:perform_async)

--- a/spec/jobs/invite_applicant_job_spec.rb
+++ b/spec/jobs/invite_applicant_job_spec.rb
@@ -15,7 +15,10 @@ describe InviteApplicantJob, type: :job do
   end
   let!(:number_of_days_to_accept_invitation) { 11 }
   let!(:configuration) do
-    create(:configuration, motif_category: motif_category, number_of_days_to_accept_invitation: number_of_days_to_accept_invitation)
+    create(
+      :configuration,
+      motif_category: motif_category, number_of_days_to_accept_invitation: number_of_days_to_accept_invitation
+    )
   end
   let!(:rdv_solidarites_session_credentials) { session_hash.symbolize_keys }
   let!(:invitation_format) { "sms" }

--- a/spec/jobs/invite_applicant_job_spec.rb
+++ b/spec/jobs/invite_applicant_job_spec.rb
@@ -1,13 +1,13 @@
 describe InviteApplicantJob, type: :job do
   subject do
     described_class.new.perform(
-      applicant_id, organisation_id, invitation_attributes, context, rdv_solidarites_session_credentials
+      applicant_id, organisation_id, invitation_attributes, motif_category, rdv_solidarites_session_credentials
     )
   end
 
   let!(:applicant_id) { 9999 }
   let!(:organisation_id) { 999 }
-  let!(:context) { "rsa_orientation" }
+  let!(:motif_category) { "rsa_orientation" }
   let!(:department) { create(:department) }
   let!(:applicant) { create(:applicant, id: applicant_id) }
   let!(:organisation) do
@@ -15,7 +15,7 @@ describe InviteApplicantJob, type: :job do
   end
   let!(:number_of_days_to_accept_invitation) { 11 }
   let!(:configuration) do
-    create(:configuration, context: context, number_of_days_to_accept_invitation: number_of_days_to_accept_invitation)
+    create(:configuration, motif_category: motif_category, number_of_days_to_accept_invitation: number_of_days_to_accept_invitation)
   end
   let!(:rdv_solidarites_session_credentials) { session_hash.symbolize_keys }
   let!(:invitation_format) { "sms" }
@@ -27,7 +27,7 @@ describe InviteApplicantJob, type: :job do
       number_of_days_to_accept_invitation: number_of_days_to_accept_invitation
     }
   end
-  let!(:rdv_context) { create(:rdv_context, context: context, applicant: applicant) }
+  let!(:rdv_context) { create(:rdv_context, motif_category: motif_category, applicant: applicant) }
   let!(:invitation) { create(:invitation) }
   let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession) }
 
@@ -98,12 +98,12 @@ describe InviteApplicantJob, type: :job do
       end
     end
 
-    context "when no matching configuration for context" do
-      let!(:other_context) { "rsa_accompagnement" }
+    context "when no matching configuration for motif category" do
+      let!(:other_motif_category) { "rsa_accompagnement" }
       let!(:configuration) do
         create(
           :configuration,
-          context: other_context,
+          motif_category: other_motif_category,
           number_of_days_to_accept_invitation: number_of_days_to_accept_invitation
         )
       end

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -44,7 +44,7 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
   let!(:applicant) { create(:applicant, organisations: [organisation], id: 3) }
   let!(:applicant2) { create(:applicant, organisations: [organisation], id: 4) }
 
-  let!(:configuration) { create(:configuration, notify_applicant: true, context: "rsa_orientation") }
+  let!(:configuration) { create(:configuration, notify_applicant: true, motif_category: "rsa_orientation") }
   let!(:organisation) do
     create(
       :organisation,
@@ -52,11 +52,11 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
     )
   end
   let!(:rdv_context) do
-    build(:rdv_context, context: "rsa_orientation", applicant: applicant, id: 28)
+    build(:rdv_context, motif_category: "rsa_orientation", applicant: applicant, id: 28)
   end
 
   let!(:rdv_context2) do
-    build(:rdv_context, context: "rsa_orientation", applicant: applicant2, id: 99)
+    build(:rdv_context, motif_category: "rsa_orientation", applicant: applicant2, id: 99)
   end
 
   describe "#perform" do
@@ -69,10 +69,10 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob, type: :job do
         .with(rdv_solidarites_user_id: user_ids)
         .and_return([applicant, applicant2])
       allow(RdvContext).to receive(:find_or_create_by!)
-        .with(applicant: applicant, context: "rsa_orientation")
+        .with(applicant: applicant, motif_category: "rsa_orientation")
         .and_return(rdv_context)
       allow(RdvContext).to receive(:find_or_create_by!)
-        .with(applicant: applicant2, context: "rsa_orientation")
+        .with(applicant: applicant2, motif_category: "rsa_orientation")
         .and_return(rdv_context2)
       allow(UpsertRecordJob).to receive(:perform_async)
       allow(DeleteRdvJob).to receive(:perform_async)

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -3,7 +3,7 @@ describe Invitation do
     let!(:department) { create(:department) }
     let!(:organisation) { create(:organisation, department: department) }
     let!(:applicant) { create(:applicant) }
-    let!(:rdv_context) { build(:rdv_context, context: "rsa_orientation") }
+    let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_orientation") }
     let!(:invitation) do
       build(
         :invitation,

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -16,7 +16,9 @@ describe Stat do
     create(:rdv_context, motif_category: "rsa_orientation", created_at: DateTime.new(2022, 4, 4, 10, 0))
   end
   let!(:rdv_context_orientation_platform) do
-    create(:rdv_context, motif_category: "rsa_orientation_on_phone_platform", created_at: DateTime.new(2022, 5, 7, 10, 0))
+    create(
+      :rdv_context, motif_category: "rsa_orientation_on_phone_platform", created_at: DateTime.new(2022, 5, 7, 10, 0)
+    )
   end
   let!(:rdv_context_accompagnement) { create(:rdv_context, motif_category: "rsa_accompagnement") }
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -13,12 +13,12 @@ describe Stat do
   let!(:irrelevant_organisation) { create(:organisation, configurations: [configuration_notify]) }
 
   let!(:rdv_context_orientation) do
-    create(:rdv_context, context: "rsa_orientation", created_at: DateTime.new(2022, 4, 4, 10, 0))
+    create(:rdv_context, motif_category: "rsa_orientation", created_at: DateTime.new(2022, 4, 4, 10, 0))
   end
   let!(:rdv_context_orientation_platform) do
-    create(:rdv_context, context: "rsa_orientation_on_phone_platform", created_at: DateTime.new(2022, 5, 7, 10, 0))
+    create(:rdv_context, motif_category: "rsa_orientation_on_phone_platform", created_at: DateTime.new(2022, 5, 7, 10, 0))
   end
-  let!(:rdv_context_accompagnement) { create(:rdv_context, context: "rsa_accompagnement") }
+  let!(:rdv_context_accompagnement) { create(:rdv_context, motif_category: "rsa_accompagnement") }
 
   let!(:invitation) do
     create(:invitation, sent_at: DateTime.new(2022, 4, 4, 10, 0), rdv_context: rdv_context_orientation)
@@ -175,7 +175,7 @@ describe Stat do
   end
 
   describe "#relevant_rdv_contexts" do
-    let!(:rdv_context_with_no_rdv) { create(:rdv_context, context: "rsa_accompagnement") }
+    let!(:rdv_context_with_no_rdv) { create(:rdv_context, motif_category: "rsa_accompagnement") }
     let!(:invitation3) do
       create(:invitation, sent_at: DateTime.new(2022, 5, 7, 10, 0), rdv_context: rdv_context_with_no_rdv)
     end
@@ -184,7 +184,7 @@ describe Stat do
                          invitations: [invitation3],
                          rdv_contexts: [rdv_context_with_no_rdv])
     end
-    let!(:rdv_context_with_no_invitation) { create(:rdv_context, context: "rsa_accompagnement") }
+    let!(:rdv_context_with_no_invitation) { create(:rdv_context, motif_category: "rsa_accompagnement") }
     let!(:accompagnement_rdv) { create(:rdv, rdv_contexts: [rdv_context_with_no_invitation]) }
     let!(:relevant_applicant3) do
       create(:applicant, organisations: [relevant_organisation],
@@ -283,9 +283,9 @@ describe Stat do
   end
 
   describe "#applicants_for_30_days_orientation_scope" do
-    let!(:rdv_context_orientation2) { create(:rdv_context, context: "rsa_orientation") }
-    let!(:rdv_context_orientation3) { create(:rdv_context, context: "rsa_orientation") }
-    let!(:rdv_context_orientation4) { create(:rdv_context, context: "rsa_orientation") }
+    let!(:rdv_context_orientation2) { create(:rdv_context, motif_category: "rsa_orientation") }
+    let!(:rdv_context_orientation3) { create(:rdv_context, motif_category: "rsa_orientation") }
+    let!(:rdv_context_orientation4) { create(:rdv_context, motif_category: "rsa_orientation") }
     let!(:relevant_applicant2) do
       create(:applicant, organisations: [relevant_organisation],
                          rdv_contexts: [rdv_context_orientation2],
@@ -347,7 +347,7 @@ describe Stat do
   end
 
   describe "applicants oriented in time limit" do
-    let!(:rdv_context_orientation2) { create(:rdv_context, context: "rsa_orientation") }
+    let!(:rdv_context_orientation2) { create(:rdv_context, motif_category: "rsa_orientation") }
     let!(:orientation_rdv2) do
       create(:rdv, rdv_contexts: [rdv_context_orientation2],
                    created_at: DateTime.new(2022, 4, 16, 10, 0),

--- a/spec/requests/api/v1/applicants_request_spec.rb
+++ b/spec/requests/api/v1/applicants_request_spec.rb
@@ -9,7 +9,7 @@ describe "api/v1/applicants/create_and_invite_many requests", type: :request do
     )
   end
   let!(:configuration) do
-    create(:configuration, context: "rsa_orientation")
+    create(:configuration, motif_category: "rsa_orientation")
   end
   let!(:applicants_params) { { applicants: [applicant1_params, applicant2_params] } }
 
@@ -177,14 +177,14 @@ describe "api/v1/applicants/create_and_invite_many requests", type: :request do
 
       context "with invalid invitation context for organisation" do
         before do
-          applicant1_params[:invitation][:context] = "rsa_accompagnement"
+          applicant1_params[:invitation][:motif_category] = "rsa_accompagnement"
         end
 
         it "returns 422" do
           subject
           expect(response.status).to eq(422)
           result = JSON.parse(response.body)
-          expect(result["errors"]).to include({ "Entrée 1" => "Invitation context rsa_accompagnement est invalide" })
+          expect(result["errors"]).to include({ "Entrée 1" => "Catégorie de motifs rsa_accompagnement invalide" })
         end
 
         it "does not enqueue jobs" do

--- a/spec/services/create_applicants_csv_export_spec.rb
+++ b/spec/services/create_applicants_csv_export_spec.rb
@@ -1,7 +1,7 @@
 describe CreateApplicantsCsvExport, type: :service do
-  subject { described_class.call(applicants: applicants, structure: structure, context: context) }
+  subject { described_class.call(applicants: applicants, structure: structure, motif_category: motif_category) }
 
-  let!(:context) { "rsa_orientation" }
+  let!(:motif_category) { "rsa_orientation" }
   let!(:organisation) { create(:organisation, name: "Drome RSA") }
   let!(:structure) { organisation }
   let(:applicant1) { create(:applicant, last_name: "Dhobb", organisations: [organisation]) }

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -20,7 +20,7 @@ describe Invitations::ComputeLink, type: :service do
   let!(:applicant) do
     create(:applicant, address: address, department: department)
   end
-  let!(:rdv_context) { build(:rdv_context, context: "rsa_accompagnement") }
+  let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_accompagnement") }
   let!(:invitation) do
     create(
       :invitation,

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -41,7 +41,7 @@ describe Invitations::GenerateLetter, type: :service do
 
     context "when the context is orientation" do
       context "when the help address is configured" do
-        let!(:rdv_context) { create(:rdv_context, context: "rsa_orientation") }
+        let!(:rdv_context) { create(:rdv_context, motif_category: "rsa_orientation") }
         let!(:invitation_parameters) do
           create(:invitation_parameters, help_address: "10, rue du Conseil départemental 75001 Paris")
         end
@@ -55,7 +55,7 @@ describe Invitations::GenerateLetter, type: :service do
 
     context "when the context is accompagnement" do
       context "when the help address is configured" do
-        let!(:rdv_context) { create(:rdv_context, context: "rsa_accompagnement") }
+        let!(:rdv_context) { create(:rdv_context, motif_category: "rsa_accompagnement") }
         let!(:invitation_parameters) do
           create(:invitation_parameters, help_address: "10, rue du Conseil départemental 75001 Paris")
         end

--- a/spec/services/invitations/send_email_spec.rb
+++ b/spec/services/invitations/send_email_spec.rb
@@ -13,7 +13,7 @@ describe Invitations::SendEmail, type: :service do
         create(
           :invitation,
           applicant: applicant, format: "email",
-          rdv_context: build(:rdv_context, context: "rsa_orientation")
+          rdv_context: build(:rdv_context, motif_category: "rsa_orientation")
         )
       end
 
@@ -69,7 +69,7 @@ describe Invitations::SendEmail, type: :service do
       create(
         :invitation,
         applicant: applicant, format: "email",
-        rdv_context: build(:rdv_context, context: "rsa_accompagnement")
+        rdv_context: build(:rdv_context, motif_category: "rsa_accompagnement")
       )
     end
 
@@ -94,7 +94,7 @@ describe Invitations::SendEmail, type: :service do
       create(
         :invitation,
         applicant: applicant, format: "email",
-        rdv_context: build(:rdv_context, context: "rsa_orientation_on_phone_platform")
+        rdv_context: build(:rdv_context, motif_category: "rsa_orientation_on_phone_platform")
       )
     end
 

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -23,7 +23,7 @@ describe Invitations::SendSms, type: :service do
       region: "Auvergne-Rhône-Alpes"
     )
   end
-  let!(:configuration) { create(:configuration, context: "rsa_orientation") }
+  let!(:configuration) { create(:configuration, motif_category: "rsa_orientation") }
   let!(:organisation) { create(:organisation, configurations: [configuration], department: department) }
 
   let!(:invitation) do
@@ -35,7 +35,7 @@ describe Invitations::SendSms, type: :service do
     )
   end
 
-  let!(:rdv_context) { build(:rdv_context, context: "rsa_orientation") }
+  let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_orientation") }
   let!(:content) do
     "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
       "d'orientation. Pour choisir la date et l'horaire de votre premier RDV, cliquez sur le lien suivant "\
@@ -99,8 +99,8 @@ describe Invitations::SendSms, type: :service do
     end
 
     context "for rsa accompagnement" do
-      let!(:rdv_context) { build(:rdv_context, context: "rsa_accompagnement") }
-      let!(:configuration) { create(:configuration, context: "rsa_accompagnement") }
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_accompagnement") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
           "d'accompagnement. Pour choisir la date et l'horaire de votre premier RDV, cliquez sur le lien suivant "\
@@ -121,8 +121,8 @@ describe Invitations::SendSms, type: :service do
     end
 
     context "for rsa orientation on phone platform" do
-      let!(:rdv_context) { build(:rdv_context, context: "rsa_orientation_on_phone_platform") }
-      let!(:configuration) { create(:configuration, context: "rsa_orientation_on_phone_platform") }
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_orientation_on_phone_platform") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_orientation_on_phone_platform") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez contacter la plateforme départementale " \
           "afin de démarrer votre parcours d’accompagnement. Pour cela, merci d’appeler le " \
@@ -142,7 +142,7 @@ describe Invitations::SendSms, type: :service do
     end
 
     context "when the sms sender name is defined in organisation configuration" do
-      let!(:configuration) { create(:configuration, context: "rsa_orientation") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_orientation") }
       let!(:invitation_parameters) { create(:invitation_parameters, sms_sender_name: "PoleRSA") }
       let!(:organisation) do
         create(:organisation, configurations: [configuration],


### PR DESCRIPTION
Dans cette PR je renomme la colonne `context` présente dans la table `rdv_contexts` et `configurations` pour la renommer en `motif_category`. Les raisons de ce changements sont: 

- Être iso avec sa définition dans RDV-Solidarités

- Rendre plus claire la notion de contexte. Avant ce changement le contexte pouvait faire référence à la catégorie de motifs mais aussi au `rdv_context` qui englobe les invitations et les rdvs dans une catégorie de motifs spécifiques. Maintenant on a plus que les `rdv_context` pour parler d'un contexte de rdv

-  on appelle plus `rdv_context.context` qui n'est pas très intuitif.
