### PR TITLE
feat(upload): remove 13 characters limit for NIR

### DIFF
--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -101,7 +101,7 @@ export default class Applicant {
   }
 
   formatAffiliationNumber(affiliationNumber) {
-    if (affiliationNumber && [13, 15].includes(affiliationNumber.length)) {
+    if (affiliationNumber && affiliationNumber.length === 15) {
       // This means it is a NIR, we replace it by a custom ID if present
       if (this.departmentInternalId) {
         return `CUS-${this.departmentInternalId}`;

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -36,7 +36,7 @@ export default class Applicant {
     this.fullAddress = formattedAttributes.fullAddress || this.formatFullAddress();
     this.departmentInternalId = formattedAttributes.departmentInternalId;
     this.rightsOpeningDate = formattedAttributes.rightsOpeningDate;
-    this.affiliationNumber = this.formatAffiliationNumber(formattedAttributes.affiliationNumber);
+    this.affiliationNumber = formattedAttributes.affiliationNumber;
     this.phoneNumber = formatPhoneNumber(formattedAttributes.phoneNumber);
     this.role = this.formatRole(formattedAttributes.role);
     this.shortRole = this.role ? (this.role === "demandeur" ? "DEM" : "CJT") : null;
@@ -98,17 +98,6 @@ export default class Applicant {
 
   set organisations(organisations) {
     this._organisations = organisations;
-  }
-
-  formatAffiliationNumber(affiliationNumber) {
-    if (affiliationNumber && affiliationNumber.length === 15) {
-      // This means it is a NIR, we replace it by a custom ID if present
-      if (this.departmentInternalId) {
-        return `CUS-${this.departmentInternalId}`;
-      }
-      return null;
-    }
-    return affiliationNumber;
   }
 
   formatTitle(title) {


### PR DESCRIPTION
Pour permettre au 93 d'upload ses bRSA sans intervention manuelle sur le numéro CAF à chaque fois, nous autorisions les numéros d'affiliation dont la longueur est égale à 13 caractères (cas du 93, qui rajoute des 0).