### PR TITLE
refactor(applicant): Do not send empty attributes to RDV-S

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -24,6 +24,8 @@ class Applicant < ApplicationRecord
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
   validate :birth_date_validity, :uid_or_department_internal_id_presence
 
+  delegate :name, :number, to: :department, prefix: true
+
   enum role: { demandeur: 0, conjoint: 1 }
   enum title: { monsieur: 0, madame: 1 }
 

--- a/app/services/save_applicant.rb
+++ b/app/services/save_applicant.rb
@@ -36,7 +36,11 @@ class SaveApplicant < BaseService
   end
 
   def rdv_solidarites_user_attributes
-    user_attributes = @applicant.attributes.symbolize_keys.slice(*Applicant::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
+    user_attributes = @applicant.attributes
+                                .symbolize_keys
+                                .slice(*Applicant::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
+                                .transform_values(&:presence)
+                                .compact
     return user_attributes if @applicant.demandeur?
 
     # we do not send the email to rdv-s for the conjoint

--- a/app/services/upsert_rdv_solidarites_user.rb
+++ b/app/services/upsert_rdv_solidarites_user.rb
@@ -32,7 +32,8 @@ class UpsertRdvSolidaritesUser < BaseService
     # If the user already exists in RDV-S, we check if he is in RDVI. If not we assign the user to the org
     # by creating the user profile and we then update the user.
     if email_taken_error?
-      fail!("l'allocataire existe déjà: id #{applicant.id}") if applicant.present?
+      fail!("l'allocataire existe déjà sur RDVI: id #{applicant.id}, départment #{applicant.department_number}") \
+        if applicant.present?
       return assign_to_org_and_udpate
     end
 

--- a/spec/services/save_applicant_spec.rb
+++ b/spec/services/save_applicant_spec.rb
@@ -54,7 +54,7 @@ describe SaveApplicant, type: :service do
         .with(
           rdv_solidarites_session: rdv_solidarites_session,
           rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
-          rdv_solidarites_user_attributes: rdv_solidarites_user_attributes,
+          rdv_solidarites_user_attributes: rdv_solidarites_user_attributes.except(:birth_name),
           rdv_solidarites_user_id: nil
         )
       subject
@@ -92,7 +92,7 @@ describe SaveApplicant, type: :service do
       it "creates the user without the email" do
         expect(UpsertRdvSolidaritesUser).to receive(:call)
           .with(
-            rdv_solidarites_user_attributes: rdv_solidarites_user_attributes.except(:email),
+            rdv_solidarites_user_attributes: rdv_solidarites_user_attributes.except(:email, :birth_name),
             rdv_solidarites_session: rdv_solidarites_session,
             rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
             rdv_solidarites_user_id: nil

--- a/spec/services/upsert_rdv_solidarites_user_spec.rb
+++ b/spec/services/upsert_rdv_solidarites_user_spec.rb
@@ -140,14 +140,17 @@ describe UpsertRdvSolidaritesUser, type: :service do
           end
 
           context "when there is an applicant linked to this user" do
-            let!(:applicant) { create(:applicant, id: 23, rdv_solidarites_user_id: existing_user_id) }
+            let!(:department) { create(:department, number: "95") }
+            let!(:applicant) do
+              create(:applicant, id: 23, rdv_solidarites_user_id: existing_user_id, department: department)
+            end
 
             it "is a failure" do
               is_a_failure
             end
 
             it "stores the error" do
-              expect(subject.errors).to eq(["l'allocataire existe déjà: id 23"])
+              expect(subject.errors).to eq(["l'allocataire existe déjà sur RDVI: id 23, départment 95"])
             end
           end
 


### PR DESCRIPTION
On n'envoie pas les attributs vide lorsque l'on met à jour l'utilisateur sur RDV-S. Ça permet de ne pas écraser ces attributs si ceux-ci sont présents dans RDV-S.

Du coup, si on veut nullifier un attribut commun à RDVI et RDVS, il faut le faire depuis RDVS (et le webhook le nullifiera sur RDVI).