### PR TITLE
fix(migration): update number_of_days_before_action_required migration

### DIFF
--- a/db/migrate/20220613120827_add_valid_until_to_invitations.rb
+++ b/db/migrate/20220613120827_add_valid_until_to_invitations.rb
@@ -3,7 +3,9 @@ class AddValidUntilToInvitations < ActiveRecord::Migration[7.0]
     add_column :invitations, :valid_until, :datetime
     change_column_default :configurations, :number_of_days_before_action_required, from: 3, to: 10
     up_only do
-      ::Configuration.find_each { |c| c.update! number_of_days_before_action_required: 10 }
+      ::Configuration.find_each do |c|
+        c.update! number_of_days_before_action_required: 10 if c.number_of_days_before_action_required <= 3
+      end
     end
   end
 end


### PR DESCRIPTION
Pour la migration en prod, on ne change le nombre de jours avant intervention nécessaire que s'il est inférieur à 3.