### PR TITLE
feat(app): Assign organisation by search term

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
     "no-param-reassign": "off",
     "class-methods-use-this": "off",
-    "no-nested-ternary": "off"
+    "no-nested-ternary": "off",
+    "no-use-before-define": "off"
   }
 }

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -24,6 +24,16 @@ class OrganisationsController < ApplicationController
     end
   end
 
+  def search
+    @department_organisations = policy_scope(Organisation).where(department: department)
+    @matching_organisations = @department_organisations.search_by_text(params[:search_terms])
+    render json: {
+      success: true,
+      matching_organisations: @matching_organisations,
+      department_organisations: @department_organisations
+    }
+  end
+
   private
 
   def department

--- a/app/javascript/components/choose-organisation-modal.js
+++ b/app/javascript/components/choose-organisation-modal.js
@@ -1,13 +1,6 @@
 import Swal from "sweetalert2";
 
-const chooseOrganisationModal = async (organisations, address, errors = []) => {
-  const title =
-    errors && errors.length > 0
-      ? errors.join(", ")
-      : "Il n'y a pas d'organisation spécifique à ce secteur.";
-
-  const text = `Veuillez choisir une organisation pour l'adresse: <strong>${address}</strong>`;
-
+const chooseOrganisationModal = async (organisations, title, text) => {
   const organisationsObject = {};
   organisations.forEach((o) => {
     organisationsObject[o.id] = o.name;

--- a/app/javascript/lib/retrieveRelevantOrganisation.js
+++ b/app/javascript/lib/retrieveRelevantOrganisation.js
@@ -1,26 +1,66 @@
 import chooseOrganisationModal from "../components/choose-organisation-modal";
 import retrieveGeolocatedOrganisations from "../react/actions/retrieveGeolocatedOrganisations";
+import searchOrganisations from "../react/actions/searchOrganisations";
 
-const retrieveRelevantOrganisation = async (departmentNumber, applicantFullAddress) => {
-  const result = await retrieveGeolocatedOrganisations(departmentNumber, applicantFullAddress);
-
-  if (result.success) {
-    if (result.geolocated_organisations.length === 1) {
-      return result.geolocated_organisations[0];
-    }
-
-    return chooseOrganisationModal(
-      result.geolocated_organisations.length > 1
-        ? result.geolocated_organisations
-        : result.department_organisations,
-      applicantFullAddress
-    );
+const retrieveRelevantOrganisation = async (
+  departmentNumber,
+  organisationSearchTerms,
+  applicantFullAddress
+) => {
+  if (organisationSearchTerms) {
+    return retrieveThroughSearchTerms(departmentNumber, organisationSearchTerms);
   }
 
+  return retrieveThroughGeolocalisation(departmentNumber, applicantFullAddress);
+};
+
+const retrieveThroughSearchTerms = async (departmentNumber, organisationSearchTerms) => {
+  const result = await searchOrganisations(departmentNumber, organisationSearchTerms);
+  if (result.success && result.matching_organisations.length === 1) {
+    return result.matching_organisations[0];
+  }
+
+  let modalTitle;
+
+  if (result.errors && result.errors.length > 0) {
+    modalTitle = result.errors.join(", ");
+  } else {
+    modalTitle = `Aucune organisation ne correspond à <strong>${organisationSearchTerms}</strong>.`;
+  }
+  const modalText = "Veuillez choisir une organisation parmi les suivantes:";
+
   return chooseOrganisationModal(
-    result.department_organisations,
-    applicantFullAddress,
-    result.errors
+    result.matching_organisations && result.matching_organisations.length > 1
+      ? result.matching_organisations
+      : result.department_organisations,
+    modalTitle,
+    modalText
+  );
+};
+
+const retrieveThroughGeolocalisation = async (departmentNumber, applicantFullAddress) => {
+  const result = await retrieveGeolocatedOrganisations(departmentNumber, applicantFullAddress);
+
+  if (result.success && result.geolocated_organisations.length === 1) {
+    return result.geolocated_organisations[0];
+  }
+
+  let modalTitle;
+
+  if (result.errors && result.errors.length > 0) {
+    modalTitle = result.errors.join(", ");
+  } else {
+    modalTitle = "Il n'y a pas d'organisation spécifique à ce secteur.";
+  }
+
+  const modalText = `Veuillez choisir une organisation pour l'adresse: <strong>${applicantFullAddress}</strong>`;
+
+  return chooseOrganisationModal(
+    result.geolocated_organisations && result.geolocated_organisations.length > 1
+      ? result.geolocated_organisations
+      : result.department_organisations,
+    modalTitle,
+    modalText
   );
 };
 

--- a/app/javascript/react/actions/searchOrganisations.js
+++ b/app/javascript/react/actions/searchOrganisations.js
@@ -1,0 +1,10 @@
+import appFetch from "../../lib/appFetch";
+
+const searchOrganisations = async (departmentNumber, searchTerms) =>
+  appFetch(
+    `/organisations/search?department_number=${encodeURIComponent(
+      departmentNumber
+    )}&search_terms=${encodeURIComponent(searchTerms)}`
+  );
+
+export default searchOrganisations;

--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -77,7 +77,7 @@ export default function Applicant({
       applicant.department.id,
       applicant.currentOrganisation,
       isDepartmentLevel,
-      applicant.currentConfiguration.motif_category
+      applicant.currentConfiguration.motif_category,
     ];
     if (format === "sms") {
       const invitation = await handleApplicantInvitation(...invitationParams, "sms");
@@ -102,8 +102,10 @@ export default function Applicant({
     if (!applicant.currentOrganisation) {
       applicant.currentOrganisation = await retrieveRelevantOrganisation(
         applicant.departmentNumber,
+        applicant.linkedOrganisationSearchTerms,
         applicant.fullAddress
       );
+
       // If there is still no organisation it means the assignation was cancelled by agent
       if (!applicant.currentOrganisation) {
         setIsLoading({ ...isLoading, accountCreation: false });

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -40,6 +40,8 @@ export default class Applicant {
     this.phoneNumber = formatPhoneNumber(formattedAttributes.phoneNumber);
     this.role = this.formatRole(formattedAttributes.role);
     this.shortRole = this.role ? (this.role === "demandeur" ? "DEM" : "CJT") : null;
+    this.linkedOrganisationSearchTerms = formattedAttributes.linkedOrganisationSearchTerms;
+
     this.department = department;
     this.departmentNumber = department.number;
     // when creating/inviting we always consider an applicant in the scope of only one organisation

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -25,7 +25,12 @@ import Applicant from "../models/Applicant";
 
 const reducer = reducerFactory("Expérimentation RSA");
 
-export default function ApplicantsUpload({ organisation, configuration, department, motifCategoryHuman }) {
+export default function ApplicantsUpload({
+  organisation,
+  configuration,
+  department,
+  motifCategoryHuman,
+}) {
   const columnNames = configuration.column_names;
   const parameterizedColumnNames = parameterizeObjectValues({
     ...columnNames.required,
@@ -108,6 +113,9 @@ export default function ApplicantsUpload({ organisation, configuration, departme
                   parameterizedColumnNames.rights_opening_date &&
                   row[parameterizedColumnNames.rights_opening_date] &&
                   excelDateToString(row[parameterizedColumnNames.rights_opening_date]),
+                linkedOrganisationSearchTerms:
+                  parameterizedColumnNames.organisation_search_terms &&
+                  row[parameterizedColumnNames.organisation_search_terms],
               },
               department,
               organisation,

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,21 +1,27 @@
 class Organisation < ApplicationRecord
+  include PgSearch::Model
+
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:name, :phone_number, :email].freeze
 
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, presence: true
 
   belongs_to :department
+  belongs_to :invitation_parameters, optional: true
+  has_many :rdvs, dependent: :nullify
   has_and_belongs_to_many :agents, dependent: :nullify
   has_and_belongs_to_many :applicants, dependent: :nullify
   has_and_belongs_to_many :invitations, dependent: :nullify
   has_and_belongs_to_many :configurations
   has_and_belongs_to_many :webhook_endpoints
 
-  belongs_to :responsible, optional: true
-  belongs_to :invitation_parameters, optional: true
-  has_many :rdvs, dependent: :nullify
-
   delegate :name, :name_with_region, :number, to: :department, prefix: true
+
+  pg_search_scope(
+    :search_by_text,
+    using: { tsearch: { prefix: true } },
+    against: [:name, :slug]
+  )
 
   def motif_categories
     configurations.map(&:motif_category)

--- a/app/models/responsible.rb
+++ b/app/models/responsible.rb
@@ -1,8 +1,0 @@
-class Responsible < ApplicationRecord
-  has_many :organisations, dependent: :nullify
-  validates :first_name, :last_name, :role, presence: true
-
-  def full_name
-    "#{first_name.downcase.capitalize} #{last_name.downcase.capitalize}"
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
 
   resources :organisations, only: [:index] do
     get :geolocated, on: :collection
+    get :search, on: :collection
     resources :applicants, only: [:index, :create, :show, :update, :edit, :new] do
       collection do
         resources :uploads, only: [:new]

--- a/db/migrate/20220629133900_add_slug_to_organisations.rb
+++ b/db/migrate/20220629133900_add_slug_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddSlugToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :slug, :string
+  end
+end

--- a/db/migrate/20220629134039_remove_responsibles.rb
+++ b/db/migrate/20220629134039_remove_responsibles.rb
@@ -1,0 +1,11 @@
+class RemoveResponsibles < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :organisations, :responsible, foreign_key: true
+    drop_table :responsibles do |t|
+      t.string :first_name
+      t.string :last_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_21_131006) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_29_134039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -154,13 +154,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_131006) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "department_id"
-    t.bigint "responsible_id"
     t.bigint "invitation_parameters_id"
     t.datetime "last_webhook_update_received_at"
+    t.string "slug"
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["invitation_parameters_id"], name: "index_organisations_on_invitation_parameters_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true
-    t.index ["responsible_id"], name: "index_organisations_on_responsible_id"
   end
 
   create_table "organisations_webhook_endpoints", id: false, force: :cascade do |t|
@@ -206,14 +205,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_131006) do
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"
     t.index ["rdv_solidarites_rdv_id"], name: "index_rdvs_on_rdv_solidarites_rdv_id", unique: true
     t.index ["status"], name: "index_rdvs_on_status"
-  end
-
-  create_table "responsibles", force: :cascade do |t|
-    t.string "first_name"
-    t.string "last_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "role"
   end
 
   create_table "stats", force: :cascade do |t|
@@ -263,7 +254,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_21_131006) do
   add_foreign_key "notifications", "applicants"
   add_foreign_key "organisations", "departments"
   add_foreign_key "organisations", "invitation_parameters", column: "invitation_parameters_id"
-  add_foreign_key "organisations", "responsibles"
   add_foreign_key "rdv_contexts", "applicants"
   add_foreign_key "rdvs", "organisations"
   add_foreign_key "webhook_receipts", "webhook_endpoints"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -108,12 +108,6 @@ invitation_parameters = InvitationParameters.create!(
     "SERVICE ORIENTATION ET ACCOMPAGNEMENT VERS L’EMPLOI"]
 )
 
-responsible_drome = Responsible.create!(
-  first_name: "Fabienne",
-  last_name: "Bouchet",
-  role: "Responsable Plate-forme mutualisée d'orientation"
-)
-
 # --------------------------------------------------------------------------------------------------------------------
 puts "Creating organisations..."
 drome1_organisation = Organisation.create!(
@@ -123,8 +117,7 @@ drome1_organisation = Organisation.create!(
   # rdv_solidarites_organisation_id: vérifier l'id de l'organisation correspondante sur RDV-Solidarites
   department_id: drome.id,
   configuration_ids: [drome_orientation_config.id, drome_accompagnement_config.id],
-  invitation_parameters_id: invitation_parameters.id,
-  responsible_id: responsible_drome.id
+  invitation_parameters_id: invitation_parameters.id
 )
 
 drome2_organisation = Organisation.create!(
@@ -134,8 +127,7 @@ drome2_organisation = Organisation.create!(
   # rdv_solidarites_organisation_id: vérifier l'id de l'organisation correspondante sur RDV-Solidarites
   department_id: drome.id,
   configuration_ids: [drome_orientation_config.id, drome_accompagnement_config.id],
-  invitation_parameters_id: invitation_parameters.id,
-  responsible_id: responsible_drome.id
+  invitation_parameters_id: invitation_parameters.id
 )
 
 yonne_organisation = Organisation.create!(
@@ -145,8 +137,7 @@ yonne_organisation = Organisation.create!(
   # rdv_solidarites_organisation_id: vérifier l'id de l'organisation correspondante sur RDV-Solidarites
   department_id: yonne.id,
   configuration_ids: [yonne_orientation_config.id],
-  invitation_parameters_id: invitation_parameters.id,
-  responsible_id: responsible_drome.id
+  invitation_parameters_id: invitation_parameters.id
 )
 
 puts "Done!"

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -158,4 +158,54 @@ describe OrganisationsController, type: :controller do
       end
     end
   end
+
+  describe "GET #search" do
+    subject { get :search, params: { department_number: "93", search_terms: search_terms } }
+
+    let!(:agent) { create(:agent, organisations: [organisation, organisation2]) }
+    let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession) }
+    let!(:department) { create(:department, number: "93") }
+    let!(:organisation) { create(:organisation, name: "Mission locale", department: department) }
+    let!(:organisation2) { create(:organisation, name: "PIE", department: department) }
+    let!(:search_terms) { "pie" }
+
+    before do
+      sign_in(agent)
+      setup_rdv_solidarites_session(rdv_solidarites_session)
+    end
+
+    it "is a success" do
+      subject
+      expect(response).to be_successful
+      result = JSON.parse(response.body)
+      expect(result["success"]).to eq(true)
+    end
+
+    it "returns the matching organisations along with all the department organisations" do
+      subject
+      result = JSON.parse(response.body)
+      expect(result["matching_organisations"].count).to eq(1)
+      expect(result["matching_organisations"].pluck("id")).to contain_exactly(organisation2.id)
+      expect(result["department_organisations"].count).to eq(2)
+      expect(result["department_organisations"].pluck("id")).to contain_exactly(organisation.id, organisation2.id)
+    end
+
+    context "when the search term is a slug" do
+      let!(:organisation) { create(:organisation, name: "Mission locale", department: department, slug: "ml123") }
+      let!(:search_terms) { "ml123" }
+
+      it "returns the matching organisations along with all the department organisations" do
+        subject
+        expect(response).to be_successful
+
+        result = JSON.parse(response.body)
+        expect(result["success"]).to eq(true)
+
+        expect(result["matching_organisations"].count).to eq(1)
+        expect(result["matching_organisations"].pluck("id")).to contain_exactly(organisation.id)
+        expect(result["department_organisations"].count).to eq(2)
+        expect(result["department_organisations"].pluck("id")).to contain_exactly(organisation.id, organisation2.id)
+      end
+    end
+  end
 end

--- a/spec/factories/responsible.rb
+++ b/spec/factories/responsible.rb
@@ -1,7 +1,0 @@
-FactoryBot.define do
-  factory :responsible do
-    first_name { "Marc" }
-    last_name { "Antoine" }
-    role { "chef de service" }
-  end
-end


### PR DESCRIPTION
Dans cette PR je fais en sorte que les départements puissent affecter l'allocataire dans une organisation en ajoutant une colonne spécifique dans leur fichier Excel.
Cette colonne peut contenir soit le nom, soit un `slug` (nouvel attribut ajouté aux organisations) pour retrouver l'organisation en question.
Pour l'affectation, le principe est à peu près le même que lors de l'affectation: 

* Si un terme est présent dans la colonne, on appelle un endpoint nouvellement créé `organisations#search`
* Si une seule organisation est retrouvée, on crée l'allocataire dans cette organisation
* Si plusieurs organisations sont retrouvées, on affiche une modale pour que l'agent choisisse la bonne organisation 
* Si aucune organisation n'est trouvée, on affiche une modale pour que l'agent choisisse entre toutes les organisations du département

<img width="619" alt="image" src="https://user-images.githubusercontent.com/7602809/176480888-62e1029d-23ec-446c-9c54-c4800855ed59.png">


N.B: Je profite de cette pour droper la table `responsibles` que l'on utilise plus.