### PR TITLE
fix(invitations): disable invite when rdvs present

### DIFF
--- a/app/javascript/controllers/invitations_checkbox_form_controller.js
+++ b/app/javascript/controllers/invitations_checkbox_form_controller.js
@@ -1,8 +1,25 @@
 import { Controller } from "@hotwired/stimulus";
 import { navigator } from "@hotwired/turbo";
+import tippy from "tippy.js";
 import getInvitationLetter from "../react/actions/getInvitationLetter";
 
 export default class extends Controller {
+  connect() {
+    const checkbox = this.element.querySelector("input[type=checkbox]");
+    const { invitationFormat } = this.element.dataset;
+    if (!checkbox) return null;
+
+    if (invitationFormat === "postal") {
+      return tippy(checkbox, {
+        content: "Générer courrier d'invitation",
+      });
+    }
+
+    return tippy(checkbox, {
+      content: `Envoyer ${invitationFormat} d'invitation`,
+    });
+  }
+
   submit() {
     this.element.hidden = true;
     this.element.parentElement.classList.add("spinner-border", "spinner-border-sm");

--- a/app/models/concerns/has_rdvs_concern.rb
+++ b/app/models/concerns/has_rdvs_concern.rb
@@ -28,4 +28,8 @@ module HasRdvsConcern
   def last_rdv_starts_at
     last_rdv&.starts_at
   end
+
+  def rdvs?
+    !rdvs.empty?
+  end
 end

--- a/app/views/invitations/_checkbox_form.html.erb
+++ b/app/views/invitations/_checkbox_form.html.erb
@@ -1,11 +1,11 @@
 <div id="applicant-<%= applicant.id %>-<%= invitation_format %>-invitation">
-  <%= form_with(url: department_level? ? department_applicant_invitations_path(@department, applicant) : organisation_applicant_invitations_path(@organisation, applicant), html: { method: :post }, data: { controller: "invitations-checkbox-form", action: "turbo:submit-start->invitations-checkbox-form#submitStart", applicant_id: applicant.id, department_id: @department.id, organisation_id: @organisation&.id }) do |f| %>
+  <%= form_with(url: department_level? ? department_applicant_invitations_path(@department, applicant) : organisation_applicant_invitations_path(@organisation, applicant), html: { method: :post }, data: { controller: "invitations-checkbox-form", action: "turbo:submit-start->invitations-checkbox-form#submitStart", applicant_id: applicant.id, department_id: @department.id, organisation_id: @organisation&.id, invitation_format: invitation_format }) do |f| %>
     <div class="form-group">
       <%= f.hidden_field :motif_category, value: motif_category %>
       <%= f.hidden_field :help_phone_number, value: department_level? ? applicant.organisations.first.phone_number : @organisation.phone_number %>
       <%= f.hidden_field :invitation_format, value: invitation_format %>
       <div>
-        <%= f.check_box :invite, { checked: invited, disabled: invited || applicant.inactive?, data: { controller: "invitations-checkbox-form", action: "change->invitations-checkbox-form#submit" } }, invited %>
+        <%= f.check_box :invite, { checked: invited, disabled: (invited || applicant.inactive? || applicant.rdv_context_for(motif_category).rdvs?), data: { controller: "invitations-checkbox-form", action: "change->invitations-checkbox-form#submit" } }, invited %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
* Je ne permets pas d'inviter depuis la page index quand l'allocataire a déjà rdvs (dans ce cas là il vaut mieux aller voir dans la page show la situation de l'allocataire)
* J'ajoute un tooltip pour dire que cocher les cases génèrent des invitations