### PR TITLE
fix(app): Always Set a current configuration on index page

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -181,7 +181,9 @@ class ApplicantsController < ApplicationController
   end
 
   def set_current_configuration
-    @current_configuration = @all_configurations.find { |c| c.motif_category == params[:motif_category] }
+    @current_configuration = \
+      @all_configurations.find { |c| c.motif_category == params[:motif_category] } ||
+      @all_configurations.first
   end
 
   def set_current_motif_category


### PR DESCRIPTION
Il faut toujours set une configuration sur la page index même quand une catégorie de motif n'est pas passée dans l'URL au risque d'avoir une erreur 500: https://mattermost.incubateur.net/betagouv/pl/aciy4zg7h7nxfjkpancihcw4jo