### PR TITLE
fix(invitations): Always set an expiration on invitations

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -102,10 +102,10 @@ class InvitationsController < ApplicationController
     @motif_category = invitation_params[:motif_category]
   end
 
-  # the validity of an invitation is equal to the number of days before an action is required, unless it's postal
+  # the validity of an invitation is equal to the number of days before an action is required, then the organisation
+  # usually convene the applicant
   def set_invitation_validity_duration
-    @invitation.validity_duration = \
-      @invitation.format_postal? ? nil : @current_configuration.number_of_days_before_action_required.days
+    @invitation.validity_duration = @current_configuration.number_of_days_before_action_required.days
   end
 
   def set_department

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -9,6 +9,7 @@ class Invitation < ApplicationRecord
   validates :help_phone_number, :token, :organisations, :link, :number_of_days_to_accept_invitation,
             presence: true
   validate :organisations_cannot_be_from_different_departments
+  validate :postal_invitation_cannot_expire_in_less_than_5_days
 
   delegate :motif_category, :motif_category_human, to: :rdv_context
 
@@ -65,6 +66,12 @@ class Invitation < ApplicationRecord
     return if organisations.map(&:department_id).uniq == [department_id]
 
     errors.add(:organisations, :invalid)
+  end
+
+  def postal_invitation_cannot_expire_in_less_than_5_days
+    return if !format_postal? || valid_until.blank? || valid_until > 5.days.from_now
+
+    errors.add(:base, "La durée de validité de l'invitation pour un courrier doit être supérieure à 5 jours")
   end
 
   def set_rdv_context_status

--- a/app/services/invitations/assign_attributes.rb
+++ b/app/services/invitations/assign_attributes.rb
@@ -1,5 +1,5 @@
 module Invitations
-  class AssignLinkAndToken < BaseService
+  class AssignAttributes < BaseService
     def initialize(invitation:, rdv_solidarites_session:)
       @invitation = invitation
       @rdv_solidarites_session = rdv_solidarites_session

--- a/app/services/invitations/save_and_send.rb
+++ b/app/services/invitations/save_and_send.rb
@@ -34,7 +34,7 @@ module Invitations
       return if @invitation.link? && @invitation.token?
 
       call_service!(
-        Invitations::AssignLinkAndToken,
+        Invitations::AssignAttributes,
         invitation: @invitation,
         rdv_solidarites_session: @rdv_solidarites_session
       )

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -44,5 +44,15 @@ describe Invitation do
 
       it { expect(invitation).not_to be_valid }
     end
+
+    context "when it is a postal invitation that expires in less than 5 days" do
+      before do
+        travel_to(Time.zone.parse("2022-05-04"))
+        invitation.format = "postal"
+        invitation.valid_until = Time.zone.parse("2022-05-08")
+      end
+
+      it { expect(invitation).not_to be_valid }
+    end
   end
 end

--- a/spec/services/invitations/assign_attributes_spec.rb
+++ b/spec/services/invitations/assign_attributes_spec.rb
@@ -1,4 +1,4 @@
-describe Invitations::AssignLinkAndToken, type: :service do
+describe Invitations::AssignAttributes, type: :service do
   subject do
     described_class.call(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
   end

--- a/spec/services/invitations/save_and_send_spec.rb
+++ b/spec/services/invitations/save_and_send_spec.rb
@@ -11,7 +11,7 @@ describe Invitations::SaveAndSend, type: :service do
 
   describe "#call" do
     before do
-      allow(Invitations::AssignLinkAndToken).to receive(:call)
+      allow(Invitations::AssignAttributes).to receive(:call)
         .with(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
         .and_return(OpenStruct.new(success?: true))
       allow(invitation).to receive(:send_to_applicant)
@@ -29,7 +29,7 @@ describe Invitations::SaveAndSend, type: :service do
     end
 
     it "saves an invitation" do
-      expect(Invitations::AssignLinkAndToken).to receive(:call)
+      expect(Invitations::AssignAttributes).to receive(:call)
         .with(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
       subject
     end
@@ -46,7 +46,7 @@ describe Invitations::SaveAndSend, type: :service do
 
     context "when it fails to save" do
       before do
-        allow(Invitations::AssignLinkAndToken).to receive(:call)
+        allow(Invitations::AssignAttributes).to receive(:call)
           .with(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
           .and_return(OpenStruct.new(success?: false, errors: ["cannot assign token"]))
       end
@@ -89,7 +89,7 @@ describe Invitations::SaveAndSend, type: :service do
       it("is a success") { is_a_success }
 
       it "does not call the assign link and token service" do
-        expect(Invitations::AssignLinkAndToken).not_to receive(:call)
+        expect(Invitations::AssignAttributes).not_to receive(:call)
         subject
       end
     end


### PR DESCRIPTION
Lorsque l'on crée une invitation postal on ne mettait pas de durée d'expiration ce qui crée plusieurs problèmes: 

- Si la personne n'est invité que par courrier, le token n'expire jamais ce qui peut poser problème, surtout maintenant que l'on va procéder aux convocations
- Si un invitation est invitée par mail et/ou sms après ça, le token expire quand même alors que l'expiration n'est pas marquée au niveau de l'invitation

On s'est dit avec Rémi qu'il valait mieux mettre la même expiration sur les courriers. On pourra revoir cette logique si un département le demande explicitement.