### PR TITLE
fix(stats): add option to hide departments in stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,7 +3,7 @@ class StatsController < ApplicationController
   before_action :set_department, only: [:show]
 
   def index
-    @department_count = Department.count
+    @department_count = Department.displayed_in_stats.count
     @stat = Stat.find_by(department_number: "all")
   end
 

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -1,6 +1,6 @@
 module StatsHelper
   def options_for_department_select
-    Department.all
+    Department.displayed_in_stats
               .order(:number)
               .map { |d| ["#{d.number} - #{d.name}", d.id] }
               .unshift(["Tous les départements", "0"])

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -10,6 +10,8 @@ class Department < ApplicationRecord
   has_many :rdvs, through: :organisations
   has_many :rdv_contexts, through: :applicants
 
+  scope :displayed_in_stats, -> { where(display_in_stats: true) }
+
   def name_with_region
     "#{name}, #{region}"
   end

--- a/db/migrate/20220907144848_add_display_stats_to_departments.rb
+++ b/db/migrate/20220907144848_add_display_stats_to_departments.rb
@@ -1,0 +1,5 @@
+class AddDisplayStatsToDepartments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :departments, :display_in_stats, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_30_110610) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_07_144848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -96,6 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_30_110610) do
     t.string "pronoun"
     t.string "email"
     t.string "phone_number"
+    t.boolean "display_in_stats", default: true
   end
 
   create_table "invitation_parameters", force: :cascade do |t|


### PR DESCRIPTION
Dans cette PR, afin de répondre à l'issue #499, j'ajoute une colonne `display_in_stats` au modèle `department` afin de pouvoir choisir, sans intervenir dans le code, d'afficher ou non certains départements sur la page `/stats`.
Par défaut, la valeur de `display_in_stats` est fixée à `true` (c'est donc un opt-out, en quelque sorte).