### PR TITLE
refactor(app): Simplify applicants controller before actions

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -7,10 +7,11 @@ class ApplicantsController < ApplicationController
     :status, :rights_opening_date, :archiving_reason, :is_archived
   ].freeze
   before_action :set_applicant, only: [:show, :update, :edit]
-  before_action :set_organisation, :set_department, :set_all_configurations, :set_current_configuration,
-                :set_current_motif_category, only: [:index, :new, :create, :show, :update, :edit]
+  before_action :set_organisation, :set_department, only: [:index, :new, :create, :show, :update, :edit]
+  before_action :set_all_configurations, :set_current_configuration, :set_current_motif_category,
+                only: [:index]
   before_action :set_organisations, only: [:new, :create]
-  before_action :set_can_be_added_to_other_org, only: [:show]
+  before_action :set_rdv_contexts, :set_can_be_added_to_other_org, only: [:show]
   before_action :retrieve_applicants, only: [:search]
   before_action :set_applicants_and_rdv_contexts, only: [:index]
 
@@ -143,7 +144,7 @@ class ApplicantsController < ApplicationController
 
   def set_organisation_at_department_level
     return set_organisation_through_form if params[:action] == "create"
-    return if @applicant.nil?
+    return if @applicant.nil? # no need to set an organisation if we are not in an applicant-level page
 
     @organisation = policy_scope(Organisation)
                     .find_by(id: @applicant.organisation_ids, department_id: params[:department_id])
@@ -188,6 +189,10 @@ class ApplicantsController < ApplicationController
 
   def set_current_motif_category
     @current_motif_category = @current_configuration&.motif_category
+  end
+
+  def set_rdv_contexts
+    @rdv_contexts = @applicant.rdv_contexts
   end
 
   def set_can_be_added_to_other_org

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -3,18 +3,6 @@ module ApplicantsHelper
     date&.strftime("%d/%m/%Y")
   end
 
-  def show_sms_invitation?(configuration)
-    configuration.invitation_formats.include?("sms")
-  end
-
-  def show_email_invitation?(configuration)
-    configuration.invitation_formats.include?("email")
-  end
-
-  def show_postal_invitation?(configuration)
-    configuration.invitation_formats.include?("postal")
-  end
-
   def show_notification?(configuration)
     configuration.notify_applicant?
   end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -3,6 +3,11 @@ class Applicant < ApplicationRecord
     :first_name, :last_name, :birth_date, :email, :phone_number, :address, :affiliation_number, :birth_name
   ].freeze
   RDV_SOLIDARITES_CLASS_NAME = "User".freeze
+  ATTRIBUTES_FOR_INVITATION_FORMATS = {
+    "sms" => :phone_number,
+    "email" => :email,
+    "postal" => :address
+  }.freeze
 
   include SearchableConcern
   include NotificableConcern
@@ -15,6 +20,7 @@ class Applicant < ApplicationRecord
   has_and_belongs_to_many :organisations
   has_many :invitations, dependent: :destroy
   has_many :rdv_contexts, dependent: :destroy
+  has_many :configurations, through: :organisations
   has_and_belongs_to_many :rdvs
   belongs_to :department
 
@@ -81,6 +87,10 @@ class Applicant < ApplicationRecord
 
   def motif_categories
     rdv_contexts.map(&:motif_category)
+  end
+
+  def attribute_for_invitation_format(invitation_format)
+    send(ATTRIBUTES_FOR_INVITATION_FORMATS[invitation_format])
   end
 
   def as_json(_opts = {})

--- a/app/views/applicants/_applicant_form.html.erb
+++ b/app/views/applicants/_applicant_form.html.erb
@@ -1,7 +1,7 @@
 <div class="container applicant-form label-blue mt-4">
   <div class="d-flex justify-content-between mb-4">
     <div>
-      <%= link_to(redirect_path) do %>
+      <%= link_to(return_path) do %>
         <button class="btn btn-blue-out" type="button">Annuler</button>
       <% end %>
     </div>

--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -15,7 +15,7 @@
           <th scope="col">Nom</th>
           <th scope="col">Prénom</th>
           <%  @current_configuration.invitation_formats.each do |invitation_format| %>
-            <th scope="col" class="d-none d-lg-table-cell"><%= translate(".#{invitation_format}_column_title") %></th>
+            <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
           <% end  %>
           <% if show_invitations?(@current_configuration) %>
             <th scope="col">Première invitation</th>

--- a/app/views/applicants/_applicants_list.html.erb
+++ b/app/views/applicants/_applicants_list.html.erb
@@ -14,9 +14,9 @@
         <thead class="text-dark-blue">
           <th scope="col">Nom</th>
           <th scope="col">Prénom</th>
-          <th scope="col" class="d-none d-lg-table-cell">📱 SMS</th>
-          <th scope="col" class="d-none d-lg-table-cell">📧 Email</th>
-          <th scope="col" class="d-none d-lg-table-cell">📮 Courrier</th>
+          <%  @current_configuration.invitation_formats.each do |invitation_format| %>
+            <th scope="col" class="d-none d-lg-table-cell"><%= translate(".#{invitation_format}_column_title") %></th>
+          <% end  %>
           <% if show_invitations?(@current_configuration) %>
             <th scope="col">Première invitation</th>
             <th scope="col">Dernière invitation</th>
@@ -33,26 +33,15 @@
             <tr class="<%= "table-danger" if applicant.is_archived? %>">
               <td><%= display_attribute applicant.last_name %></td>
               <td><%= display_attribute applicant.first_name %></td>
-              <td class="d-none d-lg-table-cell">
-                <% if applicant.phone_number.present? %>
-                  <%= render "invitations/checkbox_form", applicant: applicant, invitation_format: "sms", motif_category: @current_motif_category, rdv_context: rdv_context, already_invited: rdv_context.invited_through?("sms") %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
-              <td class="d-none d-lg-table-cell">
-                <% if applicant.email.present? %>
-                  <%= render "invitations/checkbox_form", applicant: applicant, invitation_format: "email", motif_category: @current_motif_category, rdv_context: rdv_context, already_invited: rdv_context.invited_through?("email")  %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
-              <td class="d-none d-lg-table-cell">
-                <% if applicant.address.present? %>
-                  <%= render "invitations/checkbox_form", applicant: applicant, invitation_format: "postal", motif_category: @current_motif_category, rdv_context: rdv_context, already_invited: rdv_context.invited_through?("postal")  %>
-                <% else %>
-                  -
-                <% end %>
+              <% @current_configuration.invitation_formats.each do |invitation_format| %>
+                <td class="d-none d-lg-table-cell">
+                  <% if applicant.attribute_for_invitation_format(invitation_format).present? %>
+                    <%= render "invitations/checkbox_form", applicant: applicant, invitation_format: invitation_format, motif_category: @current_motif_category, rdv_context: rdv_context, already_invited: rdv_context.invited_through?(invitation_format) %>
+                  <% else %>
+                    -
+                  <% end %>
+                </td>
+              <% end %>
               </td>
               <% if show_invitations?(@current_configuration) %>
                 <td id="first-invitation-date-<%= rdv_context.id %>"><%= display_attribute format_date(rdv_context.relevant_first_invitation_sent_at) %></td>

--- a/app/views/applicants/edit.html.erb
+++ b/app/views/applicants/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render 'archive_banner' if @applicant.is_archived? %>
-<%= simple_form_for(@applicant, redirect_path: compute_applicant_path(@applicant, @organisation, @department), url: compute_applicant_path(@applicant, @organisation, @department), html: { method: :patch }) do |f| %>
-  <%= render 'applicant_form', f: f, title: "Modifier allocataire", redirect_path: compute_applicant_path(@applicant, @organisation, @department) %>
+<%= simple_form_for(@applicant, return_path: compute_applicant_path(@applicant, @organisation, @department), url: compute_applicant_path(@applicant, @organisation, @department), html: { method: :patch }) do |f| %>
+  <%= render 'applicant_form', f: f, title: "Modifier allocataire", return_path: compute_applicant_path(@applicant, @organisation, @department) %>
 <% end %>
 

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -1,4 +1,4 @@
 <%= simple_form_for(@applicant, url: department_level? ? department_applicants_path(@department, @applicant) : organisation_applicants_path(@organisation, @applicant), html: { method: :post }) do |f| %>
-  <%= render 'applicant_form', f: f, title: "Créer allocataire", redirect_path: compute_index_path(@organisation, @department) %>
+  <%= render 'applicant_form', f: f, title: "Créer allocataire", return_path: compute_index_path(@organisation, @department) %>
 <% end %>
 

--- a/app/views/applicants/new.html.erb
+++ b/app/views/applicants/new.html.erb
@@ -1,4 +1,4 @@
 <%= simple_form_for(@applicant, url: department_level? ? department_applicants_path(@department, @applicant) : organisation_applicants_path(@organisation, @applicant), html: { method: :post }) do |f| %>
-  <%= render 'applicant_form', f: f, title: "Créer allocataire", redirect_path: compute_index_path(@organisation, @department, motif_category: @all_configurations.first.motif_category) %>
+  <%= render 'applicant_form', f: f, title: "Créer allocataire", redirect_path: compute_index_path(@organisation, @department) %>
 <% end %>
 

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -80,8 +80,8 @@
     </div>
     <%= render "add_to_org_button", can_be_added_to_other_org: @can_be_added_to_other_org, department: @department, applicant: @applicant %>
   </div>
-  <% @all_configurations.each do |configuration| %>
-    <%= render "rdv_context", rdv_context: @applicant.rdv_context_for(configuration.motif_category), configuration: configuration, applicant: @applicant, department: @department  %>
+  <% @rdv_contexts.each do |rdv_context| %>
+    <%= render "rdv_context", rdv_context: rdv_context, configuration: @applicant.configurations.find { |c| c.motif_category == rdv_context.motif_category }, applicant: @applicant, department: @department  %>
   <% end %>
 </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/locales/views/applicant.fr.yml
+++ b/config/locales/views/applicant.fr.yml
@@ -1,0 +1,6 @@
+fr:
+  applicants:
+    applicants_list:
+      sms_column_title: 📱 SMS
+      email_column_title: 📧 Email
+      postal_column_title: 📮 Courrier


### PR DESCRIPTION
Dans cette PR je simplifie le `ApplicantsController` en scopant bien les `before_action` aux bonnes actions.
Ainsi, plus besoin de définir les configurations, la configuration actuelle ou la catégorie du motif pour les pages liées à un allocataire (`show`, `edit`, `update`) maintenant que des `rdv_contexts` sont crées pour chaque catégorie à la création de l'allocataire. 

Je refactor aussi la vue `applicant_list` pour grouper la logique d'invitation sur chaque format et être un peu plus DRY. 