### PR TITLE
fix(job): Update new invitation logic for api

### DIFF
--- a/app/jobs/invite_applicant_job.rb
+++ b/app/jobs/invite_applicant_job.rb
@@ -25,7 +25,7 @@ class InviteApplicantJob < ApplicationJob
       organisations: [@organisation],
       number_of_days_to_accept_invitation: matching_configuration.number_of_days_to_accept_invitation,
       rdv_context: rdv_context,
-      validity_duration: validity_duration,
+      valid_until: matching_configuration.number_of_days_before_action_required.days.from_now,
       **@invitation_attributes
     )
     capture_exception if save_and_send_invitation.failure?
@@ -43,10 +43,6 @@ class InviteApplicantJob < ApplicationJob
 
   def matching_configuration
     @matching_configuration ||= @organisation.configurations.find_by!(motif_category: @motif_category)
-  end
-
-  def validity_duration
-    matching_configuration.number_of_days_before_action_required.days
   end
 
   def save_and_send_invitation

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  config.action_view.raise_on_missing_translations = true
+  # config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/spec/jobs/invite_applicant_job_spec.rb
+++ b/spec/jobs/invite_applicant_job_spec.rb
@@ -13,7 +13,7 @@ describe InviteApplicantJob, type: :job do
   let!(:organisation) do
     create(:organisation, id: organisation_id, department: department, configurations: [configuration])
   end
-  let!(:number_of_days_to_accept_invitation) { 11 }
+  let!(:number_of_days_to_accept_invitation) { 3 }
   let!(:configuration) do
     create(
       :configuration,
@@ -37,11 +37,14 @@ describe InviteApplicantJob, type: :job do
 
   describe "#perform" do
     context "when the applicant has not been invited yet" do
+      let!(:valid_until) { Time.zone.parse("2022-04-15") }
+
       before do
+        travel_to(Time.zone.parse("2022-04-05"))
         allow(Invitation).to receive(:new).with(
           invitation_attributes.merge(
             applicant: applicant, department: department, rdv_context: rdv_context, organisations: [organisation],
-            validity_duration: 10.days
+            valid_until: valid_until
           )
         ).and_return(invitation)
         allow(RdvSolidaritesSession).to receive(:new)
@@ -56,7 +59,7 @@ describe InviteApplicantJob, type: :job do
         expect(Invitation).to receive(:new).with(
           invitation_attributes.merge(
             applicant: applicant, department: department, rdv_context: rdv_context, organisations: [organisation],
-            validity_duration: 10.days
+            valid_until: valid_until
           )
         )
         subject


### PR DESCRIPTION
La logique d'invitation n'a pas été mise à jour au niveau du `InviteApplicantJob`, ce qui a donné lieu à une erreur ce matin: https://sentry.incubateur.net/organizations/betagouv/issues/7238/?project=16&query=is%3Aunresolved

Je règle ça en ajoutant un test pour vérifier que la durée de validité est toujours bien assignée.