### PR TITLE
feat(motifs): add new motif categories

### DIFF
--- a/app/models/concerns/has_motif_category_concern.rb
+++ b/app/models/concerns/has_motif_category_concern.rb
@@ -4,11 +4,17 @@ module HasMotifCategoryConcern
   MOTIF_CATEGORIES_NAMES_MAPPING = {
     "rsa_orientation" => "RSA orientation",
     "rsa_accompagnement" => "RSA accompagnement",
-    "rsa_orientation_on_phone_platform" => "RSA orientation sur plateforme téléphonique"
+    "rsa_orientation_on_phone_platform" => "RSA orientation sur plateforme téléphonique",
+    "rsa_cer_signature" => "RSA signature CER",
+    "rsa_insertion_offer" => "RSA offre insertion pro"
   }.freeze
 
   included do
-    enum motif_category: { rsa_orientation: 0, rsa_accompagnement: 1, rsa_orientation_on_phone_platform: 2 }
+    enum motif_category: { rsa_orientation: 0,
+                           rsa_accompagnement: 1,
+                           rsa_orientation_on_phone_platform: 2,
+                           rsa_cer_signature: 3,
+                           rsa_insertion_offer: 4 }
   end
 
   def motif_category_human


### PR DESCRIPTION
Dans cette PR, je fais en sorte que 2 nouvelles catégories de motifs puissent être prises en compte côté RDV-I (issue #542) : 
- un contexte 'signature CER'
- un contexte 'offre accompagnement pro'

Une autre PR est à merger côté RDV-S pour que l'issue soit résolue dans sa totalité.
A priori c'est la seule chose à faire côté RDV-I mais je suis passé un peu vite dessus, je n'ai pas pu tester fonctionnellement.