### PR TITLE
feat(app): Add motifs

### DIFF
--- a/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
+++ b/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
@@ -1,7 +1,7 @@
 module FilterRdvSolidaritesWebhooksConcern
   extend ActiveSupport::Concern
 
-  SUPPORTED_MODELS_TYPES = %w[Rdv User UserProfile Organisation].freeze
+  SUPPORTED_MODELS_TYPES = %w[Rdv User UserProfile Organisation Motif].freeze
 
   included do
     before_action :check_webhook_auth!

--- a/app/controllers/rdv_solidarites_webhooks_controller.rb
+++ b/app/controllers/rdv_solidarites_webhooks_controller.rb
@@ -16,7 +16,8 @@ class RdvSolidaritesWebhooksController < ApplicationController
       "User" => RdvSolidaritesWebhooks::ProcessUserJob,
       "Rdv" => RdvSolidaritesWebhooks::ProcessRdvJob,
       "UserProfile" => RdvSolidaritesWebhooks::ProcessUserProfileJob,
-      "Organisation" => RdvSolidaritesWebhooks::ProcessOrganisationJob
+      "Organisation" => RdvSolidaritesWebhooks::ProcessOrganisationJob,
+      "Motif" => RdvSolidaritesWebhooks::ProcessMotifJob
     }
   end
 

--- a/app/jobs/rdv_solidarites_webhooks/process_motif_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_motif_job.rb
@@ -1,0 +1,42 @@
+module RdvSolidaritesWebhooks
+  class ProcessMotifJob < ApplicationJob
+    def perform(data, meta)
+      @data = data.deep_symbolize_keys
+      @meta = meta.deep_symbolize_keys
+      return if organisation.blank?
+      return if unhandled_category?
+
+      upsert_motif
+    end
+
+    private
+
+    def rdv_solidarites_organisation_id
+      @data[:organisation_id]
+    end
+
+    def rdv_solidarites_motif
+      RdvSolidarites::Motif.new(@data)
+    end
+
+    def motif_category
+      @data[:category]
+    end
+
+    def unhandled_category?
+      motif_category.nil? || Motif.categories.keys.exclude?(motif_category)
+    end
+
+    def organisation
+      @organisation ||= Organisation.find_by(rdv_solidarites_organisation_id: rdv_solidarites_organisation_id)
+    end
+
+    def upsert_motif
+      UpsertRecordJob.perform_async(
+        "Motif",
+        rdv_solidarites_motif.to_rdv_insertion_attributes,
+        { organisation_id: organisation.id, last_webhook_update_received_at: @meta[:timestamp] }
+      )
+    end
+  end
+end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -1,0 +1,17 @@
+class Motif < ApplicationRecord
+  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
+    :name, :deleted_at, :location_type, :name, :reservable_online, :rdv_solidarites_service_id, :category, :collectif
+  ].freeze
+
+  enum location_type: { public_office: 0, phone: 1, home: 2 }
+  enum category: { rsa_orientation: 0,
+                   rsa_accompagnement: 1,
+                   rsa_orientation_on_phone_platform: 2,
+                   rsa_cer_signature: 3,
+                   rsa_insertion_offer: 4 }
+
+  belongs_to :organisation
+
+  validates :rdv_solidarites_motif_id, uniqueness: true, presence: true
+  validates :name, :category, :location_type, presence: true
+end

--- a/app/models/rdv_solidarites/motif.rb
+++ b/app/models/rdv_solidarites/motif.rb
@@ -1,6 +1,8 @@
 module RdvSolidarites
   class Motif < Base
-    RECORD_ATTRIBUTES = [:id, :deleted_at, :location_type, :name, :reservable_online, :service_id, :category].freeze
+    RECORD_ATTRIBUTES = [
+      :id, :deleted_at, :location_type, :name, :reservable_online, :service_id, :category, :collectif
+    ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 
     def presential?
@@ -9,6 +11,10 @@ module RdvSolidarites
 
     def name_with_location_type
       "#{name}-#{location_type}"
+    end
+
+    def to_rdv_insertion_attributes
+      attributes.merge(rdv_solidarites_service_id: service_id)
     end
   end
 end

--- a/db/migrate/20220922135546_create_motifs.rb
+++ b/db/migrate/20220922135546_create_motifs.rb
@@ -1,0 +1,20 @@
+class CreateMotifs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :motifs do |t|
+      t.bigint :rdv_solidarites_motif_id
+      t.string :name
+      t.boolean :reservable_online
+      t.datetime :deleted_at
+      t.bigint :rdv_solidarites_service_id
+      t.boolean :collectif
+      t.integer :location_type
+      t.integer :category
+      t.datetime :last_webhook_update_received_at
+      t.references :organisation, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index "motifs", ["rdv_solidarites_motif_id"], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_162719) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_22_135546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,6 +140,23 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_162719) do
     t.index ["organisation_id", "invitation_id"], name: "index_invitations_orgas_on_orga_id_and_invitation_id", unique: true
   end
 
+  create_table "motifs", force: :cascade do |t|
+    t.bigint "rdv_solidarites_motif_id"
+    t.string "name"
+    t.boolean "reservable_online"
+    t.datetime "deleted_at"
+    t.bigint "rdv_solidarites_service_id"
+    t.boolean "collectif"
+    t.integer "location_type"
+    t.integer "category"
+    t.datetime "last_webhook_update_received_at"
+    t.bigint "organisation_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organisation_id"], name: "index_motifs_on_organisation_id"
+    t.index ["rdv_solidarites_motif_id"], name: "index_motifs_on_rdv_solidarites_motif_id", unique: true
+  end
+
   create_table "notifications", force: :cascade do |t|
     t.bigint "applicant_id", null: false
     t.integer "event"
@@ -257,6 +274,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_162719) do
   add_foreign_key "invitations", "applicants"
   add_foreign_key "invitations", "departments"
   add_foreign_key "invitations", "rdv_contexts"
+  add_foreign_key "motifs", "organisations"
   add_foreign_key "notifications", "applicants"
   add_foreign_key "organisations", "departments"
   add_foreign_key "organisations", "invitation_parameters", column: "invitation_parameters_id"

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :motif do
+    name { "RSA orientation sur site" }
+    category { "rsa_orientation" }
+    organisation { create(:organisation) }
+  end
+end

--- a/spec/jobs/rdv_solidarites_webhooks/process_motif_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_motif_job_spec.rb
@@ -1,0 +1,63 @@
+describe RdvSolidaritesWebhooks::ProcessMotifJob, type: :job do
+  subject do
+    described_class.new.perform(data, meta)
+  end
+
+  let!(:data) do
+    {
+      "id" => rdv_solidarites_organisation_id,
+      "name" => "RDV d'orientation sur site",
+      "category" => "rsa_orientation",
+      "service_id" => 444,
+      "organisation_id" => rdv_solidarites_organisation_id
+    }.deep_symbolize_keys
+  end
+
+  let!(:rdv_solidarites_organisation_id) { 222 }
+  let!(:rdv_solidarites_motif_id) { 455 }
+
+  let!(:meta) do
+    {
+      "model" => "Motif",
+      "event" => "updated",
+      "timestamp" => "2022-05-30 14:44:22 +0200"
+    }.deep_symbolize_keys
+  end
+
+  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id) }
+
+  describe "#call" do
+    before do
+      allow(UpsertRecordJob).to receive(:perform_async)
+    end
+
+    let!(:motif_attributes) { data.merge(rdv_solidarites_service_id: 444) }
+
+    it "enqueues upsert record job" do
+      expect(UpsertRecordJob).to receive(:perform_async)
+        .with(
+          "Motif", motif_attributes,
+          { organisation_id: organisation.id, last_webhook_update_received_at: "2022-05-30 14:44:22 +0200" }
+        )
+      subject
+    end
+
+    context "when the organisation is not found" do
+      let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: "some-id") }
+
+      it "does not enqueue a job" do
+        expect(UpsertRecordJob).not_to receive(:perform_async)
+        subject
+      end
+    end
+
+    context "when it is an unhandled category" do
+      before { data[:category] = nil }
+
+      it "does not enqueue a job" do
+        expect(UpsertRecordJob).not_to receive(:perform_async)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dans cette PR je crée la table `motifs` analogue à celle de RDV-Solidarités et je mets en place un système de process de webhook pour sauvegarder en cache dans notre BDD les créations, modifications et changement de motifs sur RDV-S.

Cette PR est couplée à [celle-ci](https://github.com/betagouv/rdv-solidarites.fr/pull/2839) sur RDVS.

Une fois les motifs importés (on ne prend en compte que ceux qui sont dans les catégories qui nous intéressent), il faudra rattacher les rdvs que l'on a en base aux records de motifs associés.