### PR TITLE
fix(app): Improve the rdv_context status logic

### DIFF
--- a/app/models/concerns/has_status_concern.rb
+++ b/app/models/concerns/has_status_concern.rb
@@ -52,7 +52,7 @@ module HasStatusConcern
   end
 
   def rdv_status
-    if last_created_rdv.pending?
+    if rdvs.any?(&:pending?)
       :rdv_pending
     elsif last_created_rdv.seen?
       :rdv_seen


### PR DESCRIPTION
Lorsqu'un rdv est en attente il faut toujours que le statut soit en "RDV pris", quelque soit le cas de figure, notamment si des rdvs ont été pris après par inadvertance puis annulé (voir [ici](https://mattermost.incubateur.net/betagouv/pl/rftrh9uz17n4ig5f6584oaua5a)).
J'ai fait donc le correctif en ce sens, et j'ai rajouté/cleané des specs sur la logique de statut pour prendre en compte tous les cas de figure.