### PR TITLE
feat(db): Import all motifs

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_motif_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_motif_job.rb
@@ -4,7 +4,6 @@ module RdvSolidaritesWebhooks
       @data = data.deep_symbolize_keys
       @meta = meta.deep_symbolize_keys
       return if organisation.blank?
-      return if unhandled_category?
 
       upsert_motif
     end
@@ -17,14 +16,6 @@ module RdvSolidaritesWebhooks
 
     def rdv_solidarites_motif
       RdvSolidarites::Motif.new(@data)
-    end
-
-    def motif_category
-      @data[:category]
-    end
-
-    def unhandled_category?
-      motif_category.nil? || Motif.categories.keys.exclude?(motif_category)
     end
 
     def organisation

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -23,5 +23,5 @@ class Motif < ApplicationRecord
   belongs_to :organisation
 
   validates :rdv_solidarites_motif_id, uniqueness: true, presence: true
-  validates :name, :category, :location_type, presence: true
+  validates :name, :location_type, presence: true
 end

--- a/spec/jobs/rdv_solidarites_webhooks/process_motif_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_motif_job_spec.rb
@@ -50,14 +50,5 @@ describe RdvSolidaritesWebhooks::ProcessMotifJob, type: :job do
         subject
       end
     end
-
-    context "when it is an unhandled category" do
-      before { data[:category] = nil }
-
-      it "does not enqueue a job" do
-        expect(UpsertRecordJob).not_to receive(:perform_async)
-        subject
-      end
-    end
   end
 end


### PR DESCRIPTION
Dans cette PR j'enlève la condition sur la catégorie pour qu'un motif puisse être importé.
En effet, imaginons qu'une catégorie soit mise puis retirée sur un motif. Elle serait alors présente dans notre BDD sans catégorie assignée, on ne peut donc pas forcer la mise d'une catégorie.
De plus si on importe pas tous les motifs, certains RDV ne pourront pas être liés à des motifs en BDD (ceux qui ont été pris avant la notion de catégorie).
Autant donc importer tous les motifs, l'idée étant de toutes façons ici d'avoir du cache de RDV-S et de ne pas y associer trop de logique.