### PR TITLE
feat(db): Link rdvs to motifs

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -21,6 +21,7 @@ class Motif < ApplicationRecord
   enum category: CATEGORIES_ENUM
 
   belongs_to :organisation
+  has_many :rdvs, dependent: :nullify
 
   validates :rdv_solidarites_motif_id, uniqueness: true, presence: true
   validates :name, :location_type, presence: true

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -10,10 +10,11 @@ class Rdv < ApplicationRecord
   after_commit :refresh_context_status, on: [:create, :update]
 
   belongs_to :organisation
+  belongs_to :motif
   has_and_belongs_to_many :rdv_contexts
   has_and_belongs_to_many :applicants
 
-  validates :applicants, :rdv_solidarites_motif_id, :starts_at, :duration_in_min, presence: true
+  validates :applicants, :starts_at, :duration_in_min, presence: true
   validates :rdv_solidarites_rdv_id, uniqueness: true, presence: true
 
   validate :motif_category_is_uniq

--- a/app/models/rdv_solidarites/rdv.rb
+++ b/app/models/rdv_solidarites/rdv.rb
@@ -35,10 +35,7 @@ module RdvSolidarites
     end
 
     def to_rdv_insertion_attributes
-      attributes.merge(
-        rdv_solidarites_motif_id: motif_id,
-        rdv_solidarites_lieu_id: lieu_id
-      )
+      attributes.merge(rdv_solidarites_lieu_id: lieu_id)
     end
 
     def agents

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -33,6 +33,7 @@
           <tr>
             <th class="px-4 py-2"><h4>RDV pris le</h4></th>
             <th class="px-4 py-2"><h4>Date du RDV</h4></th>
+            <th class="px-4 py-2"><h4>Motif</h4></th>
             <th class="px-4 py-2"><h4>Statut RDV</h4></th>
             <th class="px-4 py-2"><h4>Lien</h4></th>
           </tr>
@@ -43,6 +44,7 @@
               <tr>
                 <td class="px-4 py-3"><%= format_date(rdv.created_at) %></td>
                 <td class="px-4 py-3"><%= format_date(rdv.starts_at) %></td>
+                <td class="px-4 py-3"><%= rdv.motif.name %></td>
                 <td class="px-4 py-3 <%= background_class_for_rdv_status(rdv) %>"><%= display_rdv_status(rdv) %></td>
                 <td class="px-4 py-3">
                   <%= link_to rdv.rdv_solidarites_url, target: "_blank" do %>

--- a/db/migrate/20220926133354_add_motif_to_rdvs.rb
+++ b/db/migrate/20220926133354_add_motif_to_rdvs.rb
@@ -1,0 +1,18 @@
+class AddMotifToRdvs < ActiveRecord::Migration[7.0]
+  def up
+    add_reference :rdvs, :motif, foreign_key: true
+    Rdv.find_each do |rdv|
+      motif = Motif.find_by(rdv_solidarites_motif_id: rdv.rdv_solidarites_motif_id)
+      rdv.update!(motif_id: motif.id)
+    end
+    remove_column :rdvs, :rdv_solidarites_motif_id
+  end
+
+  def down
+    add_column :rdvs, :rdv_solidarites_motif_id
+    Rdv.find_each do |rdv|
+      rdv.update!(rdv_solidarites_motif_id: rdv.motif.rdv_solidarites_motif_id)
+    end
+    remove_reference :rdvs, :motif, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_22_135546) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_26_133354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -211,18 +211,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_22_135546) do
     t.datetime "starts_at", precision: nil
     t.integer "duration_in_min"
     t.datetime "cancelled_at", precision: nil
-    t.bigint "rdv_solidarites_motif_id"
     t.bigint "rdv_solidarites_lieu_id"
     t.string "uuid"
     t.string "address"
     t.integer "created_by"
     t.integer "status"
-    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "organisation_id"
+    t.text "context"
     t.datetime "last_webhook_update_received_at"
+    t.bigint "motif_id"
     t.index ["created_by"], name: "index_rdvs_on_created_by"
+    t.index ["motif_id"], name: "index_rdvs_on_motif_id"
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"
     t.index ["rdv_solidarites_rdv_id"], name: "index_rdvs_on_rdv_solidarites_rdv_id", unique: true
     t.index ["status"], name: "index_rdvs_on_status"
@@ -279,6 +280,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_22_135546) do
   add_foreign_key "organisations", "departments"
   add_foreign_key "organisations", "invitation_parameters", column: "invitation_parameters_id"
   add_foreign_key "rdv_contexts", "applicants"
+  add_foreign_key "rdvs", "motifs"
   add_foreign_key "rdvs", "organisations"
   add_foreign_key "webhook_receipts", "webhook_endpoints"
 end

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -322,10 +322,12 @@ describe ApplicantsController, type: :controller do
         create(:invitation, sent_at: "2021-10-20", format: "sms", rdv_context: rdv_context)
       end
 
+      let!(:motif) { create(:motif, name: "RSA Orientation sur site") }
+
       let!(:rdv_orientation1) do
         create(
           :rdv,
-          status: "noshow", created_at: "2021-10-21", starts_at: "2021-10-22",
+          status: "noshow", created_at: "2021-10-21", starts_at: "2021-10-22", motif: motif,
           applicants: [applicant], rdv_contexts: [rdv_context], organisation: organisation
         )
       end
@@ -333,7 +335,7 @@ describe ApplicantsController, type: :controller do
       let!(:rdv_orientation2) do
         create(
           :rdv,
-          status: "seen", created_at: "2021-10-23", starts_at: "2021-10-24",
+          status: "seen", created_at: "2021-10-23", starts_at: "2021-10-24", motif: motif,
           applicants: [applicant], rdv_contexts: [rdv_context], organisation: organisation
         )
       end
@@ -365,6 +367,7 @@ describe ApplicantsController, type: :controller do
         expect(response.body).to match(/Statut RDV/)
         expect(response.body).to match(/RSA accompagnement/)
         expect(response.body).to match(/Invitation en attente de réponse/)
+        expect(response.body).to match(/RSA Orientation sur site/)
       end
     end
   end

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
   factory :motif do
+    sequence(:rdv_solidarites_motif_id)
     name { "RSA orientation sur site" }
     category { "rsa_orientation" }
+    location_type { "public_office" }
     organisation { create(:organisation) }
   end
 end

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
     sequence(:rdv_solidarites_rdv_id)
     starts_at { 3.days.from_now }
     duration_in_min { 30 }
-    sequence(:rdv_solidarites_motif_id)
     organisation { create(:organisation) }
+    motif { create(:motif) }
 
     after(:build) do |rdv|
       rdv.applicants = [create(:applicant)]


### PR DESCRIPTION
Cette PR vient après #563 .
Dans cette PR je fais la migration pour lier les RDVs aux motifs correspondants en base.
Je fais aussi en sorte d'ajouter ce lien lorsque l'on process les webhooks liés aux rdvs.

J'affiche également le nom du motif dans la vue du demandeur: 

<img width="850" alt="image" src="https://user-images.githubusercontent.com/7602809/192318026-f58a3823-5f93-4d24-850e-0de4f634b705.png">
