### PR TITLE
feat(invitations) add follow up motif and texts for follow up & insertion offer invitations

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -7,14 +7,16 @@ class Motif < ApplicationRecord
     rsa_accompagnement: 1,
     rsa_orientation_on_phone_platform: 2,
     rsa_cer_signature: 3,
-    rsa_insertion_offer: 4
+    rsa_insertion_offer: 4,
+    rsa_follow_up: 5
   }.freeze
   CATEGORIES_NAMES_MAPPING = {
     "rsa_orientation" => "RSA orientation",
     "rsa_accompagnement" => "RSA accompagnement",
     "rsa_orientation_on_phone_platform" => "RSA orientation sur plateforme téléphonique",
     "rsa_cer_signature" => "RSA signature CER",
-    "rsa_insertion_offer" => "RSA offre insertion pro"
+    "rsa_insertion_offer" => "RSA offre insertion pro",
+    "rsa_follow_up" => "RSA suivi"
   }.freeze
 
   enum location_type: { public_office: 0, phone: 1, home: 2 }

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -42,8 +42,7 @@ module Invitations
       "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement en parcours "\
         "professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons "\
         "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le lien " \
-        "suivant dans un délai de #{number_of_days_to_accept_invitation} jours: " \
-        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "suivant: #{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
     end
 
@@ -98,7 +97,7 @@ module Invitations
     def content_for_rsa_insertion_offer_reminder
       "#{applicant.full_name},\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours "\
         "vous invitant à vous inscrire directement à des ateliers adaptés à votre parcours d'accompagnement." \
-        "Le lien de prise de RDV suivant expire dans #{@invitation.number_of_days_before_expiration} jours: " \
+        "Utilisez le lien suivant pour effectuer votre prise de RDV : " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
     end

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -97,7 +97,7 @@ module Invitations
     def content_for_rsa_insertion_offer_reminder
       "#{applicant.full_name},\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours "\
         "vous invitant à vous inscrire directement à des ateliers adaptés à votre parcours d'accompagnement." \
-        "Utilisez le lien suivant pour effectuer votre prise de RDV : " \
+        "Utilisez le lien suivant pour effectuer votre prise de RDV: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
     end

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -29,12 +29,30 @@ module Invitations
     end
 
     def content_for_rsa_cer_signature
-      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA, et à ce titre vous allez construire et signer "\
+      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et à ce titre vous allez construire et signer "\
         "votre Contrat d'Engagement Réciproque. Pour cela, nous vous invitons à prendre RDV avec votre référent de " \
         "parcours. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans un délai de " \
         "#{number_of_days_to_accept_invitation} jours: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "En l'absence d'action de votre part, le versement de votre RSA pourra être suspendu ou réduit. "\
+        "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
+    end
+
+    def content_for_rsa_insertion_offer
+      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement en parcours "\
+        "professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons "\
+        "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le lien " \
+        "suivant dans un délai de #{number_of_days_to_accept_invitation} jours: " \
+        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
+    end
+
+    def content_for_rsa_follow_up
+      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et à ce titre vous êtes invité "\
+        "par votre référent de parcours à un RDV de suivi. " \
+        "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans un délai de " \
+        "#{number_of_days_to_accept_invitation} jours: " \
+        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
     end
 
@@ -74,6 +92,23 @@ module Invitations
         "Le lien de prise de RDV suivant expire dans #{@invitation.number_of_days_before_expiration} jours: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
+        "#{@invitation.help_phone_number}."
+    end
+
+    def content_for_rsa_insertion_offer_reminder
+      "#{applicant.full_name},\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours "\
+        "vous invitant à vous inscrire directement à des ateliers adaptés à votre parcours d'accompagnement." \
+        "Le lien de prise de RDV suivant expire dans #{@invitation.number_of_days_before_expiration} jours: " \
+        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "En cas de problème technique, contactez le #{@invitation.help_phone_number}."
+    end
+
+    def content_for_rsa_follow_up_reminder
+      "#{applicant.full_name},\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
+        "vous invitant à prendre un RDV de suivi au créneau de votre choix." \
+        "Le lien de prise de RDV suivant expire dans #{@invitation.number_of_days_before_expiration} jours: " \
+        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "En cas de problème technique, contactez le "\
         "#{@invitation.help_phone_number}."
     end
   end

--- a/app/views/letters/invitation_for_rsa_follow_up.html.erb
+++ b/app/views/letters/invitation_for_rsa_follow_up.html.erb
@@ -1,0 +1,22 @@
+<%= render 'letters/header', invitation_parameters: invitation_parameters, department: department, organisation: organisation, applicant: applicant %>
+<div class="mail-object">
+    <%# Remplacer par une variable @motif ? %>
+  <p class="bold-blue"><span class="bold-blue">Objet : Rendez-vous de suivi dans le cadre de votre RSA</span></p>
+  <% if applicant.affiliation_number %>
+    <p>N° allocataire : <%= applicant.affiliation_number %></p>
+  <% end %>
+</div>
+<div class="main-content">
+  <p><%= applicant.title.capitalize %>,</p>
+  <p>Vous êtes allocataire du Revenu de Solidarité Active (RSA) et à ce titre vous êtes invité par votre référent de parcours à un rendez-vous de suivi.</p>
+  <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
+  <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
+  <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
+  <p>Ce code d'invitation est valable <span class="bold-blue"><%= invitation.number_of_days_to_accept_invitation %> jours</span> à réception de ce courrier.</p>
+  <%= render 'letters/help_message', invitation: invitation, invitation_parameters: invitation_parameters %>
+  <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
+  <div class="letter-signature">
+    <%= render 'common/invitations_signature', invitation_parameters: invitation_parameters, department: department %>
+  </div>
+</div>
+<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: invitation_parameters.display_europe_logos %>

--- a/app/views/letters/invitation_for_rsa_follow_up.html.erb
+++ b/app/views/letters/invitation_for_rsa_follow_up.html.erb
@@ -12,7 +12,7 @@
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
-  <p>Ce code d'invitation est valable <span class="bold-blue"><%= invitation.number_of_days_to_accept_invitation %> jours</span> à réception de ce courrier.</p>
+  <p>Vous disposez <span class="bold-blue">d'un délai de <%= invitation.number_of_days_to_accept_invitation %> jours</span> pour prendre rendez-vous à réception de ce courrier.</p>
   <%= render 'letters/help_message', invitation: invitation, invitation_parameters: invitation_parameters %>
   <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
   <div class="letter-signature">

--- a/app/views/letters/invitation_for_rsa_insertion_offer.html.erb
+++ b/app/views/letters/invitation_for_rsa_insertion_offer.html.erb
@@ -1,0 +1,22 @@
+<%= render 'letters/header', invitation_parameters: invitation_parameters, department: department, organisation: organisation, applicant: applicant %>
+<div class="mail-object">
+    <%# Remplacer par une variable @motif ? %>
+  <p class="bold-blue"><span class="bold-blue">Objet : Offre d'insertion dans le cadre de votre RSA</span></p>
+  <% if applicant.affiliation_number %>
+    <p>N° allocataire : <%= applicant.affiliation_number %></p>
+  <% end %>
+</div>
+<div class="main-content">
+  <p><%= applicant.title.capitalize %>,</p>
+  <p>Vous êtes allocataire du Revenu de Solidarité Active (RSA) et bénéficiez d'un accompagnement en parcours professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
+  <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
+  <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
+  <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
+  <p>Ce code d'invitation est valable <span class="bold-blue"><%= invitation.number_of_days_to_accept_invitation %> jours</span> à réception de ce courrier.</p>
+  <%= render 'letters/help_message', invitation: invitation, invitation_parameters: invitation_parameters %>
+  <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
+  <div class="letter-signature">
+    <%= render 'common/invitations_signature', invitation_parameters: invitation_parameters, department: department %>
+  </div>
+</div>
+<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: invitation_parameters.display_europe_logos %>

--- a/app/views/letters/invitation_for_rsa_insertion_offer.html.erb
+++ b/app/views/letters/invitation_for_rsa_insertion_offer.html.erb
@@ -12,7 +12,6 @@
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
-  <p>Ce code d'invitation est valable <span class="bold-blue"><%= invitation.number_of_days_to_accept_invitation %> jours</span> à réception de ce courrier.</p>
   <%= render 'letters/help_message', invitation: invitation, invitation_parameters: invitation_parameters %>
   <p>Veuillez agréer, <%= applicant.title.capitalize %>, l’expression de mes salutations distinguées.</p>
   <div class="letter-signature">

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_accompagnement_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_accompagnement_reminder.html.erb
@@ -1,8 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant
- à prendre RDV afin de démarrer un parcours d’accompagnement.</p>
-<p>Il ne vous reste plus que  <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant.
-<span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
+<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de démarrer un parcours d’accompagnement.</p>
+<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant. <span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
 <p>En l’absence d'action de votre part, le versement de votre RSA pourra être suspendu ou son montant réduit.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_cer_signature_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_cer_signature_reminder.html.erb
@@ -1,8 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant
- à prendre RDV afin de construire et signer votre Contrat d'Engagement Réciproque.</p>
-<p>Il ne vous reste plus que  <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant.
-<span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
+<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de construire et signer votre Contrat d'Engagement Réciproque.</p>
+<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant. <span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
 <p>En l’absence d'action de votre part, le versement de votre RSA pourra être suspendu ou son montant réduit.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_follow_up.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_follow_up.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de démarrer un parcours d’accompagnement.</p>
-<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant. <span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
+<p>Vous êtes bénéficiaire du RSA et à ce titre vous êtes invité par votre référent de parcours à un rendez-vous de suivi.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Choisir un créneau

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_follow_up_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_follow_up_reminder.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de démarrer un parcours d’accompagnement.</p>
-<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant. <span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
+<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à un rendez-vous de suivi.</p>
+<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Choisir un créneau

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>Vous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement en parcours professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
-<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Choisir un créneau

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer.html.erb
@@ -1,0 +1,10 @@
+<h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
+<p>Vous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement en parcours professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>.</p>
+<p class="btn-wrapper">
+  <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
+    Choisir un créneau
+  <% end %>
+</p>
+<p>En cas de problème technique, contactez le <%= @invitation.help_phone_number_formatted %></p>
+<%= render 'common/invitations_signature', invitation_parameters: @invitation_parameters, department: @department %>

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer_reminder.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
-<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Choisir un créneau

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_insertion_offer_reminder.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de démarrer un parcours d’accompagnement.</p>
-<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant. <span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>
+<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
+<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Choisir un créneau

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation_on_phone_platform_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation_on_phone_platform_reminder.html.erb
@@ -1,6 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant
- à contacter la plateforme départementale afin de démarrer un parcours d’accompagnement.</p>
-<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour appeler le  <span class="font-weight-bold"><%= @invitation.help_phone_number %></span>.</p>
+<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à contacter la plateforme départementale afin de démarrer un parcours d’accompagnement.</p>
+<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour appeler le <span class="font-weight-bold"><%= @invitation.help_phone_number %></span>.</p>
 <p> Cet appel est nécessaire pour le traitement de votre dossier.</p>
 <%= render 'common/invitations_signature', invitation_parameters: @invitation_parameters, department: @department %>

--- a/spec/mailers/previews/invitation_preview.rb
+++ b/spec/mailers/previews/invitation_preview.rb
@@ -24,6 +24,18 @@ class InvitationPreview < ActionMailer::Preview
                     .invitation_for_rsa_cer_signature
   end
 
+  def invitation_for_rsa_insertion_offer
+    invitation = Invitation.where(format: "email").last
+    InvitationMailer.with(invitation: invitation, applicant: invitation.applicant)
+                    .invitation_for_rsa_insertion_offer
+  end
+
+  def invitation_for_rsa_follow_up
+    invitation = Invitation.where(format: "email").last
+    InvitationMailer.with(invitation: invitation, applicant: invitation.applicant)
+                    .invitation_for_rsa_follow_up
+  end
+
   ### Reminders
 
   def invitation_for_rsa_orientation_reminder
@@ -48,5 +60,17 @@ class InvitationPreview < ActionMailer::Preview
     invitation = Invitation.where(format: "email").last
     InvitationMailer.with(invitation: invitation, applicant: invitation.applicant)
                     .invitation_for_rsa_cer_signature_reminder
+  end
+
+  def invitation_for_rsa_insertion_offer_reminder
+    invitation = Invitation.where(format: "email").last
+    InvitationMailer.with(invitation: invitation, applicant: invitation.applicant)
+                    .invitation_for_rsa_insertion_offer_reminder
+  end
+
+  def invitation_for_rsa_follow_up_reminder
+    invitation = Invitation.where(format: "email").last
+    InvitationMailer.with(invitation: invitation, applicant: invitation.applicant)
+                    .invitation_for_rsa_follow_up_reminder
   end
 end

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -263,7 +263,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement en parcours "\
           "professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons "\
           "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le " \
-          "lien suivant dans un délai de 9 jours: " \
+          "lien suivant: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
           "En cas de problème technique, contactez le 0147200001."
       end
@@ -282,7 +282,7 @@ describe Invitations::SendSms, type: :service do
         let!(:content) do
           "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
             "vous invitant à vous inscrire directement à des ateliers adaptés à votre parcours d'accompagnement." \
-            "Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "Utilisez le lien suivant pour effectuer votre prise de RDV: " \
             "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
             "En cas de problème technique, contactez le "\
             "0147200001."

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -213,7 +213,7 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_cer_signature") }
       let!(:configuration) { create(:configuration, motif_category: "rsa_cer_signature") }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA, et à ce titre vous allez construire et signer "\
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et à ce titre vous allez construire et signer "\
           "votre Contrat d'Engagement Réciproque. Pour cela, nous vous invitons à prendre RDV avec votre référent de " \
           "parcours. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans un délai de " \
           "9 jours: " \
@@ -239,6 +239,98 @@ describe Invitations::SendSms, type: :service do
             "Réciproque. Le lien de prise de RDV suivant expire dans 5 jours: " \
             "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
             "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
+            "0147200001."
+        end
+
+        before do
+          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        end
+
+        it "calls the send transactional service with the right content" do
+          expect(SendTransactionalSms).to receive(:call)
+            .with(phone_number_formatted: phone_number_formatted,
+                  sender_name: "Dept#{department.number}",
+                  content: content)
+          subject
+        end
+      end
+    end
+
+    context "for rsa insertion offer" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_insertion_offer") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_insertion_offer") }
+      let!(:content) do
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement en parcours "\
+          "professionnel ou socio-professionel. Pour profiter au mieux de cet accompagnement, nous vous invitons "\
+          "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le " \
+          "lien suivant dans un délai de 9 jours: " \
+          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
+          "En cas de problème technique, contactez le 0147200001."
+      end
+
+      it("is a success") { is_a_success }
+
+      it "calls the send transactional service with the right content" do
+        expect(SendTransactionalSms).to receive(:call)
+          .with(phone_number_formatted: phone_number_formatted,
+                sender_name: "Dept#{department.number}",
+                content: content)
+        subject
+      end
+
+      context "when it is a reminder" do
+        let!(:content) do
+          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
+            "vous invitant à vous inscrire directement à des ateliers adaptés à votre parcours d'accompagnement." \
+            "Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "En cas de problème technique, contactez le "\
+            "0147200001."
+        end
+
+        before do
+          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        end
+
+        it "calls the send transactional service with the right content" do
+          expect(SendTransactionalSms).to receive(:call)
+            .with(phone_number_formatted: phone_number_formatted,
+                  sender_name: "Dept#{department.number}",
+                  content: content)
+          subject
+        end
+      end
+    end
+
+    context "for rsa follow up" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_follow_up") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_follow_up") }
+      let!(:content) do
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et à ce titre vous êtes invité "\
+          "par votre référent de parcours à un RDV de suivi. " \
+          "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans un délai de " \
+          "9 jours: " \
+          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
+          "En cas de problème technique, contactez le 0147200001."
+      end
+
+      it("is a success") { is_a_success }
+
+      it "calls the send transactional service with the right content" do
+        expect(SendTransactionalSms).to receive(:call)
+          .with(phone_number_formatted: phone_number_formatted,
+                sender_name: "Dept#{department.number}",
+                content: content)
+        subject
+      end
+
+      context "when it is a reminder" do
+        let!(:content) do
+          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
+            "vous invitant à prendre un RDV de suivi au créneau de votre choix." \
+            "Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "En cas de problème technique, contactez le "\
             "0147200001."
         end
 


### PR DESCRIPTION
Dans cette PR, j'ajoute le motif `rsa_follow_up` pour les rendez-vous de suivi, et je rajoute les textes pour les invitations relatives à ce motif et au motif `insertion_offer`. Je modifie également quelques détails d'autres textes pour garder plus de cohérence sur la rédaction (l'utilisation de RDV/rendez-vous, notamment).