### PR TITLE
fix(exports): allow csv exports when no structure or motif category are passed

### DIFF
--- a/app/services/exports/generate_applicants_csv.rb
+++ b/app/services/exports/generate_applicants_csv.rb
@@ -93,31 +93,31 @@ module Exports
     end
 
     def motif_category_title
-      @motif_category.presence || "autres"
+      @motif_category.presence
     end
 
     def human_rdv_context_status(applicant)
       return "Archivé" if applicant.archived_at.present?
 
-      return "" if rdv_context(applicant).nil? || @structure.nil?
+      return "" if @motif_category.nil? || rdv_context(applicant).nil?
 
       I18n.t("activerecord.attributes.rdv_context.statuses.#{rdv_context(applicant).status}") +
-        display_context_status_notice(rdv_context(applicant), number_of_days_before_action_required)
+        display_context_status_notice(rdv_context(applicant))
+    end
+
+    def display_context_status_notice(rdv_context)
+      if @structure.present? && rdv_context.invited_before_time_window?(number_of_days_before_action_required) &&
+         rdv_context.invitation_pending?
+        " (Délai dépassé)"
+      else
+        ""
+      end
     end
 
     def number_of_days_before_action_required
       @number_of_days_before_action_required ||= @structure.configurations.find do |c|
         c.motif_category == @motif_category
       end.number_of_days_before_action_required
-    end
-
-    def display_context_status_notice(rdv_context, number_of_days_before_action_required)
-      if rdv_context.invited_before_time_window?(number_of_days_before_action_required) &&
-         rdv_context.invitation_pending?
-        " (Délai dépassé)"
-      else
-        ""
-      end
     end
 
     def display_date(date)
@@ -127,19 +127,19 @@ module Exports
     end
 
     def first_invitation_date(applicant)
-      rdv_context(applicant)&.first_invitation_sent_at || applicant&.first_invitation_sent_at
+      @motif_category.present? ? rdv_context(applicant)&.first_invitation_sent_at : applicant.first_invitation_sent_at
     end
 
     def last_invitation_date(applicant)
-      rdv_context(applicant)&.last_invitation_sent_at || applicant&.last_invitation_sent_at
+      @motif_category.present? ? rdv_context(applicant)&.last_invitation_sent_at : applicant.last_invitation_sent_at
     end
 
     def last_rdv_date(applicant)
-      rdv_context(applicant)&.last_rdv_starts_at || applicant&.last_rdv_starts_at
+      @motif_category.present? ? rdv_context(applicant)&.last_rdv_starts_at : applicant.last_rdv_starts_at
     end
 
     def last_rdv(applicant)
-      rdv_context(applicant)&.last_rdv || applicant&.last_rdv
+      @motif_category.present? ? rdv_context(applicant)&.last_rdv : applicant.last_rdv
     end
 
     def rdv_taken_in_autonomy?(applicant)

--- a/app/services/exports/generate_applicants_csv.rb
+++ b/app/services/exports/generate_applicants_csv.rb
@@ -85,7 +85,7 @@ module Exports
 
     def filename
       if @structure.present?
-        "Export_beneficiaires_#{motif_category_title}_#{@structure.class.model_name.human.downcase}_" \
+        "Export_beneficiaires_#{motif_category_title}#{@structure.class.model_name.human.downcase}_" \
           "#{@structure.name.parameterize(separator: '_')}.csv"
       else
         "Export_beneficiaires_#{Time.zone.now.to_i}.csv"
@@ -93,7 +93,7 @@ module Exports
     end
 
     def motif_category_title
-      @motif_category.presence
+      @motif_category.present? ? "#{@motif_category}_" : ""
     end
 
     def human_rdv_context_status(applicant)

--- a/spec/services/exports/generate_applicants_csv_spec.rb
+++ b/spec/services/exports/generate_applicants_csv_spec.rb
@@ -124,6 +124,7 @@ describe Exports::GenerateApplicantsCsv, type: :service do
         it "displays the invitations infos" do
           expect(csv).to include("21/05/2022") # first invitation date
           expect(csv).to include("22/05/2022") # last invitation date
+          expect(csv).not_to include("(Délai dépassé)") # invitation delay
         end
 
         it "displays the rdvs infos" do
@@ -205,8 +206,9 @@ describe Exports::GenerateApplicantsCsv, type: :service do
         end
 
         it "does not displays 'délai dépassé' warnings" do
-          expect(subject.csv).to include("Invitation en attente de réponse") # rdv_context status
-          expect(subject.csv).not_to include("Invitation en attente de réponse (Délai dépassé)")
+          csv = subject.csv
+          expect(csv).to include("Invitation en attente de réponse") # rdv_context status
+          expect(csv).not_to include("(Délai dépassé)")
         end
       end
 

--- a/spec/services/exports/generate_applicants_csv_spec.rb
+++ b/spec/services/exports/generate_applicants_csv_spec.rb
@@ -135,19 +135,6 @@ describe Exports::GenerateApplicantsCsv, type: :service do
           expect(csv).to include("25/05/2022;oui;Statut du RDV à préciser;oui;25/05/2022") # orientation date
         end
 
-        context "when the invitation deadline has passed" do
-          let!(:rdv_context) do
-            create(
-              :rdv_context, rdvs: [], invitations: [first_invitation, last_invitation],
-                            applicant: applicant1, status: "invitation_pending"
-            )
-          end
-
-          it "displays 'délai dépassé'" do
-            expect(subject.csv).to include("Invitation en attente de réponse (Délai dépassé)") # rdv_context status
-          end
-        end
-
         it "displays the archiving infos" do
           expect(csv).to include("25/05/2022;\"\"") # archiving status
           expect(csv).to include("25/05/2022;\"\";;") # archiving reason
@@ -161,6 +148,19 @@ describe Exports::GenerateApplicantsCsv, type: :service do
         it "displays the organisation infos" do
           expect(csv).to include("1")
           expect(csv).to include("Drome RSA")
+        end
+
+        context "when the invitation deadline has passed" do
+          let!(:rdv_context) do
+            create(
+              :rdv_context, rdvs: [], invitations: [first_invitation, last_invitation],
+                            applicant: applicant1, status: "invitation_pending"
+            )
+          end
+
+          it "displays 'délai dépassé'" do
+            expect(subject.csv).to include("Invitation en attente de réponse (Délai dépassé)") # rdv_context status
+          end
         end
 
         context "when the applicant is archived" do
@@ -220,7 +220,7 @@ describe Exports::GenerateApplicantsCsv, type: :service do
         end
 
         it "generates the right filename" do
-          expect(subject.filename).to eq("Export_beneficiaires__organisation_drome_rsa.csv")
+          expect(subject.filename).to eq("Export_beneficiaires_organisation_drome_rsa.csv")
         end
 
         it "does not display the statuses" do


### PR DESCRIPTION
Dans cette PR, je corrige les bugs listés dans l'issue #550 : 
- le champ rdv honoré en - de jours n'est pas bon, il vérifie juste si un rdv a été honoré
- le cas où une structure n'est pas passé ne marche pas
- le cas où une catégorie de motif n'est pas passé les infos sont incohérentes