### PR TITLE
fix(bug): see only the relevant contexts

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -211,17 +211,17 @@ class ApplicantsController < ApplicationController
     @motif_categories_from_motifs ||= @motifs.map(&:category).uniq.compact
   end
 
-  def motif_categories_from_org
-    @motif_categories_from_org ||= if department_level?
-                                     @organisations.flat_map(&:motif_categories).uniq
-                                   else
-                                     @organisation.motif_categories.uniq
-                                   end
+  def motif_categories_from_configurations
+    @motif_categories_from_configurations ||= if department_level?
+                                                @organisations.flat_map(&:motif_categories).uniq
+                                              else
+                                                @organisation.motif_categories.uniq
+                                              end
   end
 
   def set_applicant_rdv_contexts
     @rdv_contexts = @applicant.rdv_contexts.select do |rdv_context|
-      (motif_categories_from_org & motif_categories_from_motifs).include?(rdv_context.motif_category)
+      (motif_categories_from_configurations & motif_categories_from_motifs).include?(rdv_context.motif_category)
     end
   end
 

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -196,9 +196,7 @@ class ApplicantsController < ApplicationController
   end
 
   def set_applicant_rdv_contexts
-    @rdv_contexts = policy_scope(RdvContext).where(applicant: @applicant).select do |rdv_context|
-      @all_configurations.map(&:motif_category).uniq.include?(rdv_context.motif_category)
-    end
+    @rdv_contexts = RdvContext.where(applicant: @applicant, motif_category: @all_configurations.map(&:motif_category))
   end
 
   def set_can_be_added_to_other_org
@@ -243,11 +241,7 @@ class ApplicantsController < ApplicationController
   end
 
   def order_applicants
-    @applicants = if archived_scope?
-                    @applicants.order(archived_at: :desc)
-                  else
-                    @applicants.order(created_at: :desc)
-                  end
+    @applicants = archived_scope? ? @applicants.order(archived_at: :desc) : @applicants.order(created_at: :desc)
   end
 
   def after_save_path

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -11,11 +11,11 @@ class ApplicantsController < ApplicationController
 
   before_action :set_applicant, only: [:show, :update, :edit]
   before_action :set_organisation, :set_department, only: [:index, :new, :create, :show, :update, :edit]
-  before_action :set_organisations, only: [:new, :index, :show, :create]
-  before_action :set_motifs, only: [:index, :show]
-  before_action :set_applicants_scope, :set_all_configurations, :set_current_configuration,
+  before_action :set_all_configurations, only: [:index, :show]
+  before_action :set_applicants_scope, :set_current_configuration,
                 :set_current_motif_category, :set_applicants, :set_rdv_contexts,
                 :filter_applicants, :order_applicants, only: [:index]
+  before_action :set_organisations, only: [:new, :create]
   before_action :set_applicant_rdv_contexts, :set_can_be_added_to_other_org, only: [:show]
   before_action :retrieve_applicants, only: [:search]
 
@@ -177,13 +177,9 @@ class ApplicantsController < ApplicationController
   def set_all_configurations
     @all_configurations = \
       if department_level?
-        (policy_scope(::Configuration) & @department.configurations).uniq(&:motif_category).select do |config|
-          motif_categories_from_motifs.include?(config.motif_category)
-        end
+        (policy_scope(::Configuration) & @department.configurations).uniq(&:motif_category)
       else
-        @organisation.configurations.select do |config|
-          motif_categories_from_motifs.include?(config.motif_category)
-        end
+        @organisation.configurations
       end
   end
 
@@ -199,29 +195,9 @@ class ApplicantsController < ApplicationController
     @current_motif_category = @current_configuration&.motif_category
   end
 
-  def set_motifs
-    @motifs = if department_level?
-                Motif.where(organisation_id: @organisations.ids)
-              else
-                Motif.where(organisation_id: @organisation.id)
-              end
-  end
-
-  def motif_categories_from_motifs
-    @motif_categories_from_motifs ||= @motifs.map(&:category).uniq.compact
-  end
-
-  def motif_categories_from_configurations
-    @motif_categories_from_configurations ||= if department_level?
-                                                @organisations.flat_map(&:motif_categories).uniq
-                                              else
-                                                @organisation.motif_categories.uniq
-                                              end
-  end
-
   def set_applicant_rdv_contexts
     @rdv_contexts = @applicant.rdv_contexts.select do |rdv_context|
-      (motif_categories_from_configurations & motif_categories_from_motifs).include?(rdv_context.motif_category)
+      @all_configurations.map(&:motif_category).uniq.include?(rdv_context.motif_category)
     end
   end
 

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -196,7 +196,7 @@ class ApplicantsController < ApplicationController
   end
 
   def set_applicant_rdv_contexts
-    @rdv_contexts = @applicant.rdv_contexts.select do |rdv_context|
+    @rdv_contexts = policy_scope(RdvContext).where(applicant: @applicant).select do |rdv_context|
       @all_configurations.map(&:motif_category).uniq.include?(rdv_context.motif_category)
     end
   end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -2,7 +2,6 @@ class Agent < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   has_and_belongs_to_many :organisations
   has_many :departments, through: :organisations
-  has_many :applicants, through: :organisations
   has_many :configurations, through: :organisations
 
   delegate :rdv_solidarites_organisation_id, to: :organisation

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -2,6 +2,8 @@ class Agent < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   has_and_belongs_to_many :organisations
   has_many :departments, through: :organisations
+  has_many :applicants, through: :organisations
+  has_many :configurations, through: :organisations
 
   delegate :rdv_solidarites_organisation_id, to: :organisation
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -3,5 +3,4 @@ class Configuration < ApplicationRecord
 
   has_many :configurations_organisations, dependent: :destroy
   has_many :organisations, through: :configurations_organisations
-  has_many :agents, through: :organisations
 end

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -3,4 +3,5 @@ class Configuration < ApplicationRecord
 
   has_many :configurations_organisations, dependent: :destroy
   has_many :organisations, through: :configurations_organisations
+  has_many :agents, through: :organisations
 end

--- a/app/policies/rdv_context_policy.rb
+++ b/app/policies/rdv_context_policy.rb
@@ -2,4 +2,11 @@ class RdvContextPolicy < ApplicationPolicy
   def create?
     pundit_user.department_ids.include?(record.applicant&.department_id)
   end
+
+  class Scope < Scope
+    def resolve
+      RdvContext.where(applicant_id: pundit_user.applicants.map(&:id))
+                .where(motif_category: pundit_user.configurations.map(&:motif_category).uniq)
+    end
+  end
 end

--- a/app/policies/rdv_context_policy.rb
+++ b/app/policies/rdv_context_policy.rb
@@ -5,7 +5,7 @@ class RdvContextPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      RdvContext.where(applicant_id: pundit_user.applicants.map(&:id))
+      RdvContext.where(applicant_id: Applicant.joins(:organisations).where(organisations: pundit_user.organisations))
                 .where(motif_category: pundit_user.configurations.map(&:motif_category).uniq)
     end
   end

--- a/app/views/applicants/_applicants_list_tabs.html.erb
+++ b/app/views/applicants/_applicants_list_tabs.html.erb
@@ -1,7 +1,7 @@
 <ul class="nav nav-tabs">
   <% @all_configurations.each do |configuration| %>
     <li class="nav-item">
-      <%= link_to configuration.motif_category_human, compute_index_path(@organisation, @department, motif_category: configuration.motif_category), class:  "nav-link #{configuration.id == @current_configuration&.id ? 'active' : ''}"%>
+      <%= link_to configuration.motif_category_human, compute_index_path(@organisation, @department, motif_category: configuration.motif_category), class: "nav-link #{configuration.id == @current_configuration&.id ? 'active' : ''}"%>
     </li>
   <% end %>
   <li class="nav-item">

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -83,7 +83,7 @@
     <%= render "add_to_org_button", can_be_added_to_other_org: @can_be_added_to_other_org, department: @department, applicant: @applicant %>
   </div>
   <% @rdv_contexts.each do |rdv_context| %>
-    <%= render "rdv_context", rdv_context: rdv_context, rdvs: rdv_context.rdvs, convocable_rdvs: rdv_context.rdvs.select(&:convocable?), configuration: @applicant.configurations.find { |c| c.motif_category == rdv_context.motif_category }, applicant: @applicant, department: @department  %>
+    <%= render "rdv_context", rdv_context: rdv_context, rdvs: rdv_context.rdvs, convocable_rdvs: rdv_context.rdvs.select(&:convocable?), configuration: @all_configurations.find { |c| c.motif_category == rdv_context.motif_category }, applicant: @applicant, department: @department  %>
   <% end %>
 </div>
 

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -410,7 +410,7 @@ describe ApplicantsController, type: :controller do
         end
       end
 
-      context "when there is a rdv_context but no matching motif" do
+      context "when there is no matching motif for a rdv_context" do
         let!(:configuration) do
           create(:configuration, motif_category: "rsa_orientation", invitation_formats: %w[sms email])
         end
@@ -426,7 +426,7 @@ describe ApplicantsController, type: :controller do
 
         let!(:motif) { create(:motif, category: "rsa_accompagnement") }
 
-        it "does not displays the context" do
+        it "does not display the context" do
           get :show, params: show_params
 
           expect(response).to be_successful
@@ -435,7 +435,7 @@ describe ApplicantsController, type: :controller do
         end
       end
 
-      context "when there is a rdv_context but no matching configuration" do
+      context "when there is no matching configuration for a rdv_context" do
         let!(:configuration) do
           create(:configuration, motif_category: "rsa_accompagnement", invitation_formats: %w[sms email])
         end
@@ -452,7 +452,7 @@ describe ApplicantsController, type: :controller do
         let!(:motif) { create(:motif, category: "rsa_orientation") }
         let!(:motif2) { create(:motif, category: "rsa_insertion_offer") }
 
-        it "does not displays the context" do
+        it "does not display the context" do
           get :show, params: show_params
 
           expect(response).to be_successful
@@ -529,6 +529,21 @@ describe ApplicantsController, type: :controller do
         RdvContext.statuses.each_key do |status|
           expect(response.body).to match(/"#{status}"/)
         end
+      end
+    end
+
+    context "when a there is no matching motif for a context" do
+      let!(:configuration2) { create(:configuration, motif_category: "rsa_insertion_offer") }
+      let!(:organisation) do
+        create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
+                              department_id: department.id, configurations: [configuration, configuration2])
+      end
+
+      it "does not display the context" do
+        get :index, params: index_params
+
+        expect(response).to be_successful
+        expect(response.body).not_to match(/RSA offre insertion pro/)
       end
     end
 

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -497,21 +497,6 @@ describe ApplicantsController, type: :controller do
       end
     end
 
-    context "when a there is no matching motif for a context" do
-      let!(:configuration2) { create(:configuration, motif_category: "rsa_insertion_offer") }
-      let!(:organisation) do
-        create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
-                              department_id: department.id, configurations: [configuration, configuration2])
-      end
-
-      it "does not display the context" do
-        get :index, params: index_params
-
-        expect(response).to be_successful
-        expect(response.body).not_to match(/RSA offre insertion pro/)
-      end
-    end
-
     context "when a context is specified" do
       let!(:rdv_context2) { build(:rdv_context, motif_category: "rsa_accompagnement", status: "invitation_pending") }
       let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement") }


### PR DESCRIPTION
Cette PR corrige le bug décrit dans l'issue #546 : En tant qu'agent, je ne dois voir que les contextes pour lesquels un motif existe sur mon organisation. En plus de corriger ce bug dans la liste des contextes qui apparaissent sur la page show d'un bénéficiaire, elle corrige également un bug "similaire" dans les onglets de la page index.