### PR TITLE
fix(invitations): do not send sms reminders if phone is not mobile

### DIFF
--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -9,7 +9,9 @@ class SendInvitationRemindersJob < ApplicationJob
       next if applicant.relevant_first_invitation_sent_at.to_date != 3.days.ago.to_date
 
       SendInvitationReminderJob.perform_async(applicant.id, "email") if applicant.email?
-      SendInvitationReminderJob.perform_async(applicant.id, "sms") if applicant.phone_number?
+      if applicant.phone_number? && applicant.phone_number_is_mobile?
+        SendInvitationReminderJob.perform_async(applicant.id, "sms")
+      end
       @sent_reminders_applicant_ids << applicant.id
     end
 

--- a/spec/jobs/send_invitation_reminders_job_spec.rb
+++ b/spec/jobs/send_invitation_reminders_job_spec.rb
@@ -96,12 +96,15 @@ describe SendInvitationRemindersJob, type: :job do
       subject
     end
 
-    context "when the eligible applicants do not have email or phone number" do
+    context "when the eligible applicants do not have email or mobile phone number" do
       let!(:applicant1) { create(:applicant, phone_number: nil, email: "") }
+      let!(:applicant2) { create(:applicant, phone_number: "0123456789", email: "") }
 
       it "does not enqueue reminder jobs" do
         expect(SendInvitationReminderJob).not_to receive(:perform_async)
           .with(applicant1.id, "sms")
+        expect(SendInvitationReminderJob).not_to receive(:perform_async)
+          .with(applicant2.id, "sms")
         expect(SendInvitationReminderJob).not_to receive(:perform_async)
           .with(applicant1.id, "email")
         subject


### PR DESCRIPTION
closes issue #561 
Dans cette PR, je fais en sorte que les relances SMS ne soient pas envoyées si le numéro de téléphone du bRSA n'est pas un mobile.