### PR TITLE
fix(index): reorder status list in filters

### DIFF
--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Metrics/ModuleLength
+
 module ApplicantsHelper
   def format_date(date)
     date&.strftime("%d/%m/%Y")
@@ -32,9 +34,25 @@ module ApplicantsHelper
   end
 
   def options_for_select_status(statuses_count)
-    statuses_count.map do |status, count|
+    ordered_statuses_count(statuses_count).map do |status, count|
+      next if count.nil?
+
       ["#{I18n.t("activerecord.attributes.rdv_context.statuses.#{status}")} (#{count})", status]
-    end
+    end.compact
+  end
+
+  def ordered_statuses_count(statuses_count)
+    [
+      ["not_invited", statuses_count["not_invited"]],
+      ["invitation_pending", statuses_count["invitation_pending"]],
+      ["rdv_pending", statuses_count["rdv_pending"]],
+      ["rdv_needs_status_update", statuses_count["rdv_needs_status_update"]],
+      ["rdv_excused", statuses_count["rdv_excused"]],
+      ["rdv_revoked", statuses_count["rdv_revoked"]],
+      ["multiple_rdvs_cancelled", statuses_count["multiple_rdvs_cancelled"]],
+      ["rdv_noshow", statuses_count["rdv_noshow"]],
+      ["rdv_seen", statuses_count["rdv_seen"]]
+    ].compact
   end
 
   def background_class_for_context_status(context, number_of_days_before_action_required)
@@ -115,3 +133,5 @@ module ApplicantsHelper
     organisation_applicant_path(organisation, applicant)
   end
 end
+
+# rubocop:enable Metrics/ModuleLength

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -424,6 +424,23 @@ describe ApplicantsController, type: :controller do
       expect(response.body).not_to match(/Barthelemy/)
     end
 
+    context "when there is all types of rdv_contexts statuses" do
+      before do
+        RdvContext.statuses.map do |status, _status_id|
+          create(:rdv_context, motif_category: "rsa_orientation",
+                               status: status,
+                               applicant: create(:applicant, organisations: [organisation], department: department))
+        end
+      end
+
+      it "displays all statuses in the filter list" do
+        get :index, params: index_params.merge(motif_category: "rsa_orientation")
+        RdvContext.statuses.map do |status, _status_id|
+          expect(response.body).to match(/"#{status}"/)
+        end
+      end
+    end
+
     context "when a context is specified" do
       let!(:rdv_context2) { build(:rdv_context, motif_category: "rsa_accompagnement", status: "invitation_pending") }
       let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement") }


### PR DESCRIPTION
Dans cette PR, je fais en sorte que la liste des status dans le filtre des status respecte l'ordre du ticket #573 (inversé, comme convenu entre nous).
J'ajoute également un test pour s'assurer qu'on oublie pas de rajouter un nouveau statut dans `ordered_statuses_count` si un nouveau statut est créé.