### PR TITLE
feat(invitations): Remove old invitation logic

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -113,13 +113,7 @@ class InvitationsController < ApplicationController
   end
 
   def set_invitation
-    @invitation = \
-      if params[:uuid].present?
-        # the token passed as a uuid will happen only during the transition for the postal invitation form
-        Invitation.find_by(uuid: params[:uuid]) || Invitation.find_by(token: params[:uuid], format: invitation_format)
-      else
-        Invitation.find_by(format: invitation_format, token: params[:token])
-      end
+    @invitation = Invitation.find_by(uuid: params[:uuid])
     raise ActiveRecord::RecordNotFound unless @invitation
   end
 

--- a/app/jobs/create_and_invite_applicant_job.rb
+++ b/app/jobs/create_and_invite_applicant_job.rb
@@ -35,8 +35,8 @@ class CreateAndInviteApplicantJob < ApplicationJob
   end
 
   def invite_applicant
-    enqueue_invite_job("sms") if @applicant_attributes[:phone_number].present?
-    enqueue_invite_job("email") if @applicant_attributes[:email].present?
+    enqueue_invite_job("sms") if applicant.phone_number_is_mobile?
+    enqueue_invite_job("email") if @applicant.email.present?
   end
 
   def enqueue_invite_job(invitation_format)

--- a/app/jobs/invalidate_invitation_job.rb
+++ b/app/jobs/invalidate_invitation_job.rb
@@ -3,7 +3,7 @@ class InvalidateInvitationJobError < StandardError; end
 class InvalidateInvitationJob < ApplicationJob
   def perform(invitation_id)
     invitation = Invitation.find(invitation_id)
-    return if invitation.valid_until.present? && invitation.valid_until < Time.zone.now
+    return if invitation.expired?
 
     invalidate_invitation = Invitations::InvalidateLink.call(invitation: invitation)
 

--- a/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
@@ -78,7 +78,7 @@ module RdvSolidaritesWebhooks
     end
 
     def related_invitations
-      @related_invitations ||= Invitation.where(rdv_context_id: rdv_context_ids)
+      @related_invitations ||= Invitation.sent.valid.where(rdv_context_id: rdv_context_ids)
     end
 
     def organisation

--- a/app/jobs/send_invitation_reminder_job.rb
+++ b/app/jobs/send_invitation_reminder_job.rb
@@ -28,7 +28,7 @@ class SendInvitationReminderJob < ApplicationJob
       help_phone_number: first_invitation.help_phone_number,
       rdv_solidarites_lieu_id: first_invitation.rdv_solidarites_lieu_id,
       link: first_invitation.link,
-      token: first_invitation.token,
+      rdv_solidarites_token: first_invitation.rdv_solidarites_token,
       valid_until: first_invitation.valid_until
     )
   end

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -41,7 +41,7 @@ module Invitations
       {
         departement: @invitation.department.number,
         address: address,
-        invitation_token: @invitation.token,
+        invitation_token: @invitation.rdv_solidarites_token,
         organisation_ids: @invitation.organisations.map(&:rdv_solidarites_organisation_id),
         motif_category: @invitation.motif_category
       }

--- a/app/services/invitations/save_and_send.rb
+++ b/app/services/invitations/save_and_send.rb
@@ -31,7 +31,7 @@ module Invitations
     end
 
     def assign_link_and_token
-      return if @invitation.link? && @invitation.token?
+      return if @invitation.link? && @invitation.rdv_solidarites_token?
 
       call_service!(
         Invitations::AssignAttributes,

--- a/app/services/rdv_solidarites_api/retrieve_invitation.rb
+++ b/app/services/rdv_solidarites_api/retrieve_invitation.rb
@@ -1,8 +1,8 @@
 module RdvSolidaritesApi
   class RetrieveInvitation < Base
-    def initialize(rdv_solidarites_session:, token:)
+    def initialize(rdv_solidarites_session:, rdv_solidarites_token:)
       @rdv_solidarites_session = rdv_solidarites_session
-      @token = token
+      @rdv_solidarites_token = rdv_solidarites_token
     end
 
     def call
@@ -13,7 +13,7 @@ module RdvSolidaritesApi
     private
 
     def rdv_solidarites_response
-      @rdv_solidarites_response ||= rdv_solidarites_client.get_invitation(@token)
+      @rdv_solidarites_response ||= rdv_solidarites_client.get_invitation(@rdv_solidarites_token)
     end
   end
 end

--- a/config/locales/models/invitation.fr.yml
+++ b/config/locales/models/invitation.fr.yml
@@ -6,7 +6,7 @@ fr:
       invitation:
         help_phone_number: Téléphone de contact
         link: Lien
-        token: Token
+        rdv_solidarites_token: Token RDV-Solidarités
         number_of_days_to_accept_invitation: Nombre de jours pour accepter l'invitation
         formats:
           postal: courrier

--- a/db/migrate/20221013134556_rename_token_to_rdv_solidarites_token.rb
+++ b/db/migrate/20221013134556_rename_token_to_rdv_solidarites_token.rb
@@ -1,0 +1,9 @@
+class RenameTokenToRdvSolidaritesToken < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :invitations, :token, :rdv_solidarites_token
+
+    # we set a validity duration for invitations who have none, the last one being
+    # sent 1 month ago
+    up_only { Invitation.where(valid_until: nil).update_all(valid_until: 1.week.from_now) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_194204) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_13_134556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -102,7 +102,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_194204) do
   create_table "invitations", force: :cascade do |t|
     t.integer "format"
     t.string "link"
-    t.string "token"
+    t.string "rdv_solidarites_token"
     t.datetime "sent_at", precision: nil
     t.bigint "applicant_id", null: false
     t.datetime "created_at", null: false

--- a/scripts/create_applicants_and_rdvs.rb
+++ b/scripts/create_applicants_and_rdvs.rb
@@ -36,7 +36,7 @@ date = 1.year.ago
     created_at: date,
     updated_at: date,
     help_phone_number: "0102030405",
-    token: "sometoken#{i}",
+    rdv_solidarites_token: "sometoken#{i}",
     link: "http://www.test.com/test&id=#{i}",
     number_of_days_to_accept_invitation: 7,
     department_id: 1,

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -244,47 +244,6 @@ describe InvitationsController, type: :controller do
     let!(:invitation) { create(:invitation, format: "sms") }
     let!(:invitation2) { create(:invitation, format: "email") }
 
-    context "when a token is passed" do
-      context "when format is not specified" do
-        let!(:invite_params) { { token: invitation.token } }
-
-        it "marks the sms invitation as clicked" do
-          subject
-          expect(invitation.reload.clicked).to eq(true)
-          expect(invitation2.reload.clicked).to eq(false)
-        end
-
-        it "redirects to the invitation link" do
-          subject
-          expect(response).to redirect_to invitation.link
-        end
-      end
-
-      context "when format is specified" do
-        let!(:invite_params) { { token: invitation.token, format: "email" } }
-
-        it "marks the matching format invitation as clicked" do
-          subject
-          expect(invitation2.reload.clicked).to eq(true)
-          expect(invitation.reload.clicked).to eq(false)
-        end
-
-        it "redirects to the invitation link" do
-          subject
-          expect(response).to redirect_to invitation2.link
-        end
-      end
-
-      context "when no invitation matches the format" do
-        let!(:invitation) { create(:invitation, format: "email") }
-        let!(:invite_params) { { token: invitation.token } }
-
-        it "raises an error" do
-          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
-    end
-
     context "when uuid is passed" do
       let!(:invite_params) { { uuid: invitation2.uuid } }
 

--- a/spec/factories/invitation.rb
+++ b/spec/factories/invitation.rb
@@ -1,12 +1,13 @@
 FactoryBot.define do
   factory :invitation do
-    token { "some_token" }
+    rdv_solidarites_token { "some_token" }
     link { "https://www.rdv_solidarites.com/some_params" }
     format { :sms }
     number_of_days_to_accept_invitation { 3 }
     department { create(:department) }
     association :applicant
     help_phone_number { "0139393939" }
+    valid_until { 1.week.from_now }
     rdv_context { build(:rdv_context) }
     after(:build) do |invitation|
       next if invitation.organisations.present?

--- a/spec/jobs/create_and_invite_applicant_job_spec.rb
+++ b/spec/jobs/create_and_invite_applicant_job_spec.rb
@@ -17,7 +17,7 @@ describe CreateAndInviteApplicantJob, type: :job do
   let!(:configuration) { create(:configuration, motif_category: motif_category) }
   let!(:applicant) { create(:applicant) }
   let!(:applicant_attributes) do
-    { department_internal_id: "1919", affiliation_number: "00001", role: "conjoint", phone_number: "07070707",
+    { department_internal_id: "1919", affiliation_number: "00001", role: "conjoint", phone_number: "0607070707",
       email: "john.doe@apijob.com" }
   end
   let!(:invitation_params) { { rdv_solidarites_lieu_id: 888 } }
@@ -65,6 +65,18 @@ describe CreateAndInviteApplicantJob, type: :job do
 
   context "when there is no phone" do
     before { applicant_attributes[:phone_number] = nil }
+
+    it "does not enqueue an invite sms job" do
+      expect(InviteApplicantJob).not_to receive(:perform_async)
+        .with(
+          applicant.id, organisation.id, sms_invitation_attributes, motif_category, rdv_solidarites_session_credentials
+        )
+      subject
+    end
+  end
+
+  context "when the phone is not a mobile" do
+    before { applicant_attributes[:phone_number] = "0101010101" }
 
     it "does not enqueue an invite sms job" do
       expect(InviteApplicantJob).not_to receive(:perform_async)

--- a/spec/jobs/invalidate_invitation_job_spec.rb
+++ b/spec/jobs/invalidate_invitation_job_spec.rb
@@ -3,21 +3,14 @@ describe InvalidateInvitationJob, type: :job do
     described_class.new.perform(invitation_id)
   end
 
-  let!(:invitation_id) { { id: 1 } }
+  let!(:invitation_id) { 444 }
   let!(:invitation) { create(:invitation, id: invitation_id) }
 
   describe "#perform" do
     before do
-      allow(Invitation).to receive(:find)
-        .and_return(invitation)
       allow(Invitations::InvalidateLink).to receive(:call)
         .with(invitation: invitation)
         .and_return(OpenStruct.new(success?: true))
-    end
-
-    it "finds the matching invitation" do
-      expect(Invitation).to receive(:find)
-      subject
     end
 
     it "calls a InvalidateLink service" do

--- a/spec/jobs/send_invitation_reminder_job_spec.rb
+++ b/spec/jobs/send_invitation_reminder_job_spec.rb
@@ -14,8 +14,8 @@ describe SendInvitationReminderJob, type: :job do
     create(
       :invitation,
       valid_until: Time.zone.parse("2022-05-15 15:05"), sent_at: Time.zone.parse("2022-05-01 14:01"),
-      applicant: applicant, organisations: [organisation], rdv_context: rdv_context, token: "123",
-      link: "www.rdv-insertion.fr/invitations/redirect?token=123",
+      applicant: applicant, organisations: [organisation], rdv_context: rdv_context, rdv_solidarites_token: "123",
+      link: "www.rdv-solidarités.fr/prendre_rdv",
       number_of_days_to_accept_invitation: 3, help_phone_number: "0101010101",
       rdv_solidarites_lieu_id: nil, department: department
     )
@@ -44,8 +44,8 @@ describe SendInvitationReminderJob, type: :job do
         number_of_days_to_accept_invitation: 3,
         help_phone_number: "0101010101",
         rdv_solidarites_lieu_id: nil,
-        link: "www.rdv-insertion.fr/invitations/redirect?token=123",
-        token: "123",
+        link: "www.rdv-solidarités.fr/prendre_rdv",
+        rdv_solidarites_token: "123",
         valid_until: Time.zone.parse("2022-05-15 15:05")
       )
     subject

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -8,14 +8,15 @@ describe Invitation do
       build(
         :invitation,
         organisations: [organisation], department: department, rdv_context: rdv_context,
-        help_phone_number: "0101010101", applicant: applicant, token: "token", link: "https://www.rdv-solidarites.fr"
+        help_phone_number: "0101010101", applicant: applicant, rdv_solidarites_token: "rdv_solidarites_token",
+        link: "https://www.rdv-solidarites.fr"
       )
     end
 
     it { expect(invitation).to be_valid }
 
-    context "when no token" do
-      before { invitation.token = nil }
+    context "when no rdv_solidarites_token" do
+      before { invitation.rdv_solidarites_token = nil }
 
       it { expect(invitation).not_to be_valid }
     end

--- a/spec/services/invitations/compute_link_spec.rb
+++ b/spec/services/invitations/compute_link_spec.rb
@@ -28,14 +28,14 @@ describe Invitations::ComputeLink, type: :service do
       organisations: [organisation1, organisation2],
       applicant: applicant,
       rdv_context: rdv_context,
-      token: invitation_token
+      rdv_solidarites_token: rdv_solidarites_token
     )
   end
 
   let!(:organisation1) { create(:organisation, department: department, rdv_solidarites_organisation_id: 333) }
   let!(:organisation2) { create(:organisation, department: department, rdv_solidarites_organisation_id: 444) }
 
-  let!(:invitation_token) { "sometoken" }
+  let!(:rdv_solidarites_token) { "sometoken" }
 
   describe "#call" do
     before do
@@ -54,7 +54,7 @@ describe Invitations::ComputeLink, type: :service do
     it("is a success") { is_a_success }
 
     it "returns the link" do
-      expect(subject.invitation_link).to include(invitation_token)
+      expect(subject.invitation_link).to include(rdv_solidarites_token)
     end
 
     it "computes the link" do
@@ -106,7 +106,7 @@ describe Invitations::ComputeLink, type: :service do
           organisations: [organisation1, organisation2],
           applicant: applicant,
           rdv_context: rdv_context,
-          token: invitation_token,
+          rdv_solidarites_token: rdv_solidarites_token,
           rdv_solidarites_lieu_id: 5
         )
       end

--- a/spec/services/invitations/save_and_send_spec.rb
+++ b/spec/services/invitations/save_and_send_spec.rb
@@ -16,7 +16,7 @@ describe Invitations::SaveAndSend, type: :service do
         .and_return(OpenStruct.new(success?: true))
       allow(invitation).to receive(:send_to_applicant)
         .and_return(OpenStruct.new(success?: true))
-      allow(invitation).to receive(:token?).and_return(false)
+      allow(invitation).to receive(:rdv_solidarites_token?).and_return(false)
       allow(invitation).to receive(:link?).and_return(false)
     end
 
@@ -82,7 +82,7 @@ describe Invitations::SaveAndSend, type: :service do
 
     context "when there is a token and a link assigned already" do
       before do
-        allow(invitation).to receive(:token?).and_return(true)
+        allow(invitation).to receive(:rdv_solidarites_token?).and_return(true)
         allow(invitation).to receive(:link?).and_return(true)
       end
 

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -29,7 +29,7 @@ describe Invitations::SendSms, type: :service do
   let!(:invitation) do
     create(
       :invitation,
-      applicant: applicant, department: department, token: "123", help_phone_number: help_phone_number,
+      applicant: applicant, department: department, rdv_solidarites_token: "123", help_phone_number: help_phone_number,
       number_of_days_to_accept_invitation: 9, organisations: [organisation],
       link: "https://www.rdv-solidarites.fr/lieux?invitation_token=123", format: "sms", rdv_context: rdv_context
     )


### PR DESCRIPTION
Cette PR est liée à #539 .

Dans cette PR on fait en sorte que:

* On ne supporte + que l'uuid pour retrouver l'invitation et plus le token dans `Invitations#redirect`
* On met une date d'expiration à toutes les invitations en base
* On met à jour `expired?`
* On renomme la colonne `token` en `rdv_solidarites_token`

J'en profite aussi pour vérifier que le numéro est mobile quand on enqueue un job d'invitation depuis par API.

