### PR TITLE
fix(mailers): Prevent svg for mails

### DIFF
--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -81,9 +81,9 @@ class InvitationMailer < ApplicationMailer
   def set_logo_path
     @logo_path = \
       if @invitation.organisations.length == 1 && first_organisation.logo_path.present?
-        first_organisation.logo_path
+        first_organisation.logo_path(%w[png jpg])
       else
-        @department.logo_path
+        @department.logo_path(%w[png jpg])
       end
   end
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -90,7 +90,7 @@ class NotificationMailer < ApplicationMailer
   end
 
   def set_logo_path
-    @logo_path = @rdv.organisation.logo_path || @department.logo_path
+    @logo_path = @rdv.organisation.logo_path(%w[png jpg]) || @department.logo_path(%w[png jpg])
   end
 
   def rdv_by_phone?

--- a/app/models/logo.rb
+++ b/app/models/logo.rb
@@ -5,12 +5,17 @@ class Logo
     @name = name
   end
 
-  def path
-    format.nil? ? nil : "#{BASE_PATH}#{@name}.#{format}"
+  def path(selected_formats = [])
+    return if formats.empty?
+
+    format = selected_formats.any? ? selected_formats.find { |f| f.in?(formats) } : formats.first
+    return if format.nil?
+
+    "#{BASE_PATH}#{@name}.#{format}"
   end
 
-  def format
-    %w[svg png jpg].find do |format|
+  def formats
+    %w[svg png jpg].select do |format|
       Webpacker.manifest.lookup("#{BASE_PATH}#{@name}.#{format}")
     end
   end


### PR DESCRIPTION
J'avais oublié qu'on ne pouvait pas envoyer de svg pour les mails, du coup j'ai fait un fix pour n'envoyer que du png ou du jpg dans ces cas.
À noter que seuls la Drôme et l'Aude ont des logos à ces formats.
