### PR TITLE
refactor(notification): Allow notifications without rdv

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,12 +2,12 @@ class Notification < ApplicationRecord
   include Sendable
 
   belongs_to :applicant
-  belongs_to :rdv
+  belongs_to :rdv, optional: true
 
   enum event: { rdv_created: 0, rdv_updated: 1, rdv_cancelled: 2 }
   enum format: { sms: 0, email: 1 }
 
-  delegate :organisation, :motif_category, to: :rdv
+  delegate :organisation, :motif_category, to: :rdv, allow_nil: true
   delegate :messages_configuration, to: :organisation
 
   # we assume a convocation is a notification of a created rdv

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -7,6 +7,8 @@ class Notification < ApplicationRecord
   enum event: { rdv_created: 0, rdv_updated: 1, rdv_cancelled: 2 }
   enum format: { sms: 0, email: 1 }
 
+  validates :format, :event, presence: true
+
   delegate :organisation, :motif_category, to: :rdv, allow_nil: true
   delegate :messages_configuration, to: :organisation
 

--- a/app/services/notifications/notify_applicant.rb
+++ b/app/services/notifications/notify_applicant.rb
@@ -22,7 +22,9 @@ module Notifications
         rdv: @rdv,
         applicant: @applicant,
         event: @event,
-        format: @format
+        format: @format,
+        # needed in case the rdv gets deleted
+        rdv_solidarites_rdv_id: @rdv.rdv_solidarites_rdv_id
       )
     end
 

--- a/spec/services/notifications/notify_applicant_spec.rb
+++ b/spec/services/notifications/notify_applicant_spec.rb
@@ -33,6 +33,7 @@ describe Notifications::NotifyApplicant, type: :service do
       expect(notification.applicant_id).to eq(applicant.id)
       expect(notification.format).to eq(format)
       expect(notification.event).to eq(event)
+      expect(notification.rdv_solidarites_rdv_id).to eq(rdv.rdv_solidarites_rdv_id)
       expect(notification.sent_at).not_to be_nil
     end
 


### PR DESCRIPTION
Lié à cette erreur sur Sentry lors de la dernière demo: https://sentry.incubateur.net/organizations/betagouv/issues/10758/?project=16&query=is%3Aunresolved

On veut pouvoir garder une notification en db si le rdv est supprimé sans que ça raise une erreur au moment d'essayer d'accéder à des notifications pour une catégorie.
Du coup je réassigne le `rdv_solidarites_rdv_id` à la notification pour retrouver le rdv dans ces cas-là.