### PR TITLE
fix(mails): add follow up mailer methods + missing tests

### DIFF
--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -29,6 +29,13 @@ class InvitationMailer < ApplicationMailer
     )
   end
 
+  def invitation_for_rsa_follow_up
+    mail(
+      to: @applicant.email,
+      subject: "Votre RDV de suivi avec votre référent de parcours"
+    )
+  end
+
   ### Reminders
 
   def invitation_for_rsa_orientation_reminder
@@ -56,6 +63,13 @@ class InvitationMailer < ApplicationMailer
     mail(
       to: @applicant.email,
       subject: "[Rappel]: Votre RDV de signature de Contrat d'Engagement Réciproque dans le cadre de votre RSA"
+    )
+  end
+
+  def invitation_for_rsa_follow_up_reminder
+    mail(
+      to: @applicant.email,
+      subject: "[Rappel]: Votre RDV de suivi avec votre référent de parcours"
     )
   end
 

--- a/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation_on_phone_platform_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/invitation_for_rsa_orientation_on_phone_platform_reminder.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à contacter la plateforme départementale afin de démarrer un parcours d’accompagnement.</p>
-<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour appeler le <span class="font-weight-bold"><%= @invitation.help_phone_number %></span>.</p>
+<p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour appeler le <span class="font-weight-bold"><%= @invitation.help_phone_number_formatted %></span>.</p>
 <p> Cet appel est nécessaire pour le traitement de votre dossier.</p>
 <%= render 'common/organisation_signature', signature_lines: @messages_configuration.signature_lines, department: @department %>

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -118,4 +118,276 @@ RSpec.describe InvitationMailer, type: :mailer do
       end
     end
   end
+
+  describe "#invitation_for_rsa_cer_signature" do
+    subject do
+      described_class
+        .with(invitation: invitation, applicant: applicant)
+        .invitation_for_rsa_cer_signature
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("Votre RDV de signature de Contrat d'Engagement Réciproque" \
+                                    " dans le cadre de votre RSA")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match("01 39 39 39 39")
+      expect(subject.body.encoded).to match(
+        "Vous êtes bénéficiaire du RSA et à ce titre vous allez construire et signer" \
+        " votre Contrat d'Engagement Réciproque."
+      )
+      expect(subject.body.encoded).to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match("dans les 5 jours")
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
+
+  describe "#invitation_for_rsa_follow_up" do
+    subject do
+      described_class
+        .with(invitation: invitation, applicant: applicant)
+        .invitation_for_rsa_follow_up
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("Votre RDV de suivi avec votre référent de parcours")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match("01 39 39 39 39")
+      expect(subject.body.encoded).to match(
+        "Vous êtes bénéficiaire du RSA et à ce titre vous êtes invité par votre référent de parcours" \
+        " à un rendez-vous de suivi."
+      )
+      expect(subject.body.encoded).to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match("dans les 5 jours")
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
+
+  describe "#invitation_for_rsa_orientation_reminder" do
+    subject do
+      described_class.with(invitation: invitation, applicant: applicant).invitation_for_rsa_orientation_reminder
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("[Rappel]: RDV d'orientation dans le cadre de votre RSA")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match("01 39 39 39 39")
+      expect(subject.body.encoded).to match(
+        "En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre" \
+        " rendez-vous afin de démarrer un parcours d’accompagnement."
+      )
+      expect(subject.body.encoded).to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match(
+        "Il ne vous reste plus que <span class=\"font-weight-bold\">#{invitation.number_of_days_before_expiration}" \
+        " jours</span> pour prendre rendez-vous"
+      )
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
+
+  describe "#invitation_for_rsa_accompagnement_reminder" do
+    subject do
+      described_class.with(invitation: invitation, applicant: applicant)
+                     .invitation_for_rsa_accompagnement_reminder
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("[Rappel]: RDV d'accompagnement dans le cadre de votre RSA")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match("01 39 39 39 39")
+      expect(subject.body.encoded).to match(
+        "En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre" \
+        " rendez-vous afin de démarrer un parcours d’accompagnement."
+      )
+      expect(subject.body.encoded).to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match(
+        "Il ne vous reste plus que <span class=\"font-weight-bold\">#{invitation.number_of_days_before_expiration}" \
+        " jours</span> pour prendre rendez-vous"
+      )
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
+
+  describe "#invitation_for_rsa_orientation_on_phone_platform_reminder" do
+    subject do
+      described_class
+        .with(invitation: invitation, applicant: applicant)
+        .invitation_for_rsa_orientation_on_phone_platform_reminder
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("[Rappel]: RDV d'orientation téléphonique dans le cadre de votre RSA")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match(
+        "En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à contacter" \
+        " la plateforme départementale afin de démarrer un parcours d’accompagnement."
+      )
+      expect(subject.body.encoded).not_to match("/invitations/redirect")
+      expect(subject.body.encoded).not_to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match(
+        "Il ne vous reste plus que <span class=\"font-weight-bold\">#{invitation.number_of_days_before_expiration}" \
+        " jours</span> pour appeler le <span class=\"font-weight-bold\">01 39 39 39 39</span>."
+      )
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
+
+  describe "#invitation_for_rsa_cer_signature_reminder" do
+    subject do
+      described_class
+        .with(invitation: invitation, applicant: applicant)
+        .invitation_for_rsa_cer_signature_reminder
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("[Rappel]: Votre RDV de signature de Contrat d'Engagement Réciproque" \
+                                    " dans le cadre de votre RSA")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match("01 39 39 39 39")
+      expect(subject.body.encoded).to match(
+        "En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre" \
+        " rendez-vous afin de construire et signer votre Contrat d'Engagement Réciproque."
+      )
+      expect(subject.body.encoded).to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match(
+        "Il ne vous reste plus que <span class=\"font-weight-bold\">#{invitation.number_of_days_before_expiration}" \
+        " jours</span> pour prendre rendez-vous"
+      )
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
+
+  describe "#invitation_for_rsa_follow_up_reminder" do
+    subject do
+      described_class
+        .with(invitation: invitation, applicant: applicant)
+        .invitation_for_rsa_follow_up_reminder
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([applicant.email])
+    end
+
+    it "renders the subject" do
+      expect(subject.subject).to eq("[Rappel]: Votre RDV de suivi avec votre référent de parcours")
+    end
+
+    it "renders the body" do
+      expect(subject.body.encoded).to match("Bonjour Jean VALJEAN")
+      expect(subject.body.encoded).to match("Le département de la Drôme.")
+      expect(subject.body.encoded).to match("01 39 39 39 39")
+      expect(subject.body.encoded).to match(
+        "En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à" \
+        " un rendez-vous de suivi."
+      )
+      expect(subject.body.encoded).to match("/invitations/redirect")
+      expect(subject.body.encoded).to match("uuid=#{invitation.uuid}")
+      expect(subject.body.encoded).to match(
+        "Il ne vous reste plus que <span class=\"font-weight-bold\">#{invitation.number_of_days_before_expiration}" \
+        " jours</span> pour prendre rendez-vous"
+      )
+    end
+
+    context "when the signature is configured" do
+      let!(:messages_configuration) { create(:messages_configuration, signature_lines: ["Fabienne Bouchet"]) }
+
+      it "renders the mail with the right signature" do
+        expect(subject.body.encoded).to match(/Fabienne Bouchet/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Dans cette PR, j'ajoute les méthodes manquantes pour les rendez-vous de suivi dans le `invitation_mailer`. J'en profite également pour rajouter les tests manquants pour une bonne partie des méthodes de ce mailer, et pour corriger un téléphone non formatté dans une des invitations par mail.