### PR TITLE
feat(stats): display convene applicant organisations in stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -9,7 +9,8 @@ class StatsController < ApplicationController
 
   def show
     @stat = Stat.find_by(department_number: @department.number)
-    @display_all_stats = @department.configurations.none?(&:convene_applicant?)
+    # we don't display all stats for departments who don't invite applicants
+    @display_all_stats = @department.configurations.none? { |configuration| configuration.invitation_formats.blank? }
   end
 
   def deployment_map; end

--- a/app/services/stats/compute_stats.rb
+++ b/app/services/stats/compute_stats.rb
@@ -91,7 +91,7 @@ module Stats
     def relevant_organisations
       @relevant_organisations ||= organisations
                                   .joins(:configurations)
-                                  .where(configurations: { convene_applicant: false })
+                                  .where.not(configurations: { invitation_formats: [] })
     end
 
     # We filter the applicants by organisations and retrieve deleted or archived applicants

--- a/spec/services/stats/compute_stats_spec.rb
+++ b/spec/services/stats/compute_stats_spec.rb
@@ -3,8 +3,8 @@ describe Stats::ComputeStats, type: :service do
 
   before { travel_to("2022-06-10".to_time) }
 
-  let!(:configuration) { create(:configuration, convene_applicant: false) }
-  let!(:configuration_notify) { create(:configuration, convene_applicant: true) }
+  let!(:configuration) { create(:configuration) }
+  let!(:configuration_notify) { create(:configuration, convene_applicant: true, invitation_formats: []) }
   let!(:department) { create(:department) }
   let!(:relevant_organisation) { create(:organisation, configurations: [configuration], department: department) }
   let!(:irrelevant_organisation) do # this organisation is irrelevant because she's notifying the applicants


### PR DESCRIPTION
Dans cette PR, je permets l'affichage complète des stats pour les organisations qui utilisent la nouvelle fonction de convocation des bRSA tout en invitant tout de même les bénéficiaires en première intention. Concrètement, un département comme le Vaucluse ou la Drôme auront toutes leurs stats affichées, mais ce ne sera pas le cas pour l'Yonne.

N.B. pour @aminedhobb : dans `stats_controller`, `@display_all_stats` est set to `false` dès lors qu'une organisation du département n'invite pas.
`@display_all_stats = @department.configurations.none? { |configuration| configuration.invitation_formats.blank? }`
On pourrait peut-être s'interroger sur la possibilité de l'ajouter dès lors qu'une organisation du département invite, pour être moins limitant, je te laisse trancher (ce qui donnerait ça: `@display_all_stats = @department.configurations.any? { |configuration| configuration.invitation_formats.present? }`)