### PR TITLE
feat(invitations): Add new motif categories

### DIFF
--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -6,7 +6,7 @@ class InvitationMailer < ApplicationMailer
 
   before_action :set_motif_category, :set_rdv_title,
                 :set_display_mandatory_warning, :set_display_punishable_warning,
-                :set_invitation_purpose,
+                :set_rdv_purpose,
                 only: [:regular_invitation, :regular_invitation_reminder]
 
   def regular_invitation
@@ -93,8 +93,8 @@ class InvitationMailer < ApplicationMailer
     @display_punishable_warning = display_punishable_warning
   end
 
-  def set_invitation_purpose
-    @invitation_purpose = invitation_purpose
+  def set_rdv_purpose
+    @rdv_purpose = rdv_purpose
   end
 
   def first_organisation

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,7 +6,7 @@ class NotificationMailer < ApplicationMailer
   before_action :set_applicant, :set_rdv, :set_department, :set_motif_category,
                 :set_signature_lines, :set_rdv_title,
                 :set_display_mandatory_warning, :set_display_punishable_warning,
-                :set_logo_path, :verify_phone_number_presence
+                :set_rdv_purpose, :set_logo_path, :verify_phone_number_presence
 
   ### rdv_created ###
   def presential_rdv_created
@@ -82,6 +82,10 @@ class NotificationMailer < ApplicationMailer
 
   def set_display_punishable_warning
     @display_punishable_warning = display_punishable_warning
+  end
+
+  def set_rdv_purpose
+    @rdv_purpose = rdv_purpose
   end
 
   def set_logo_path

--- a/app/models/concerns/templatable.rb
+++ b/app/models/concerns/templatable.rb
@@ -1,5 +1,5 @@
 module Templatable
-  delegate :invitation_purpose, :rdv_title_by_phone, :rdv_title, :display_mandatory_warning,
+  delegate :rdv_purpose, :rdv_title_by_phone, :rdv_title, :display_mandatory_warning,
            :display_punishable_warning,
            to: :message_template
 

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -10,7 +10,9 @@ class Motif < ApplicationRecord
     rsa_insertion_offer: 4,
     rsa_follow_up: 5,
     rsa_accompagnement_social: 6,
-    rsa_accompagnement_sociopro: 7
+    rsa_accompagnement_sociopro: 7,
+    rsa_main_tendue: 8,
+    rsa_atelier_collectif_mandatory: 9
   }.freeze
 
   enum location_type: { public_office: 0, phone: 1, home: 2 }

--- a/app/models/templating/applicant_messages.rb
+++ b/app/models/templating/applicant_messages.rb
@@ -30,38 +30,9 @@ class Templating::ApplicantMessages
     def initialize(motif_category, attributes)
       @motif_category = motif_category
       @attributes = attributes
-    end
-
-    def invitation_purpose
-      fetch("invitation_purpose")
-    end
-
-    def rdv_title
-      fetch("rdv_title")
-    end
-
-    def rdv_title_by_phone
-      fetch("rdv_title_by_phone")
-    end
-
-    def display_mandatory_warning
-      fetch("display_mandatory_warning")
-    end
-
-    def display_punishable_warning
-      fetch("display_punishable_warning")
-    end
-
-    private
-
-    def fetch(attribute_name)
-      attribute = @attributes[attribute_name]
-      raise_for_missing_attribute(attribute_name) if attribute.nil?
-      attribute
-    end
-
-    def raise_for_missing_attribute(attribute)
-      raise TemplatingError, "#{attribute} not found for category #{@motif_category}"
+      @attributes.each_key do |attribute|
+        define_singleton_method(attribute) { @attributes[attribute] }
+      end
     end
   end
 end

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -8,8 +8,8 @@ module Invitations
     private
 
     def regular_invitation_content
-      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un #{rdv_title}." \
-        " Pour choisir la date et l'horaire du RDV, " \
+      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un #{rdv_title} " \
+        "afin de #{rdv_purpose}. Pour choisir la date et l'horaire du RDV, " \
         "cliquez sur le lien suivant dans les #{number_of_days_to_accept_invitation} jours: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "#{mandatory_warning}"\
@@ -36,7 +36,7 @@ module Invitations
 
     def regular_invitation_reminder_content
       "#{applicant.full_name},\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
-        "vous invitant à prendre RDV au créneau de votre choix afin de #{invitation_purpose}." \
+        "vous invitant à prendre RDV au créneau de votre choix afin de #{rdv_purpose}." \
         " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
         "jours: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -67,7 +67,7 @@ module Invitations
         rdv_title: rdv_title,
         display_mandatory_warning: display_mandatory_warning,
         display_punishable_warning: display_punishable_warning,
-        invitation_purpose: invitation_purpose
+        rdv_purpose: rdv_purpose
       )
     end
 

--- a/app/views/letters/regular_invitation.html.erb
+++ b/app/views/letters/regular_invitation.html.erb
@@ -7,7 +7,7 @@
 </div>
 <div class="main-content">
   <p><%= applicant.title.capitalize %>,</p>
-  <p>Vous êtes allocataire du Revenu de Solidarité Active (RSA) et à ce titre vous devez prendre un rendez-vous afin de <%= invitation_purpose %>.</p>
+  <p>Vous êtes allocataire du Revenu de Solidarité Active (RSA) et à ce titre vous devez prendre un rendez-vous afin de <%= rdv_purpose %>.</p>
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>

--- a/app/views/mailers/invitation_mailer/regular_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/regular_invitation.html.erb
@@ -1,17 +1,17 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>Vous êtes bénéficiaire du RSA et vous devez vous présenter à un <%= @rdv_title %>.</p>
-<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>.</p>
-<% if @display_mandatory_warning %>
-  <p>Ce rendez-vous est obligatoire.</p>
-<% end %>
-<% if @display_punishable_warning %>
-  <p>En l’absence d'action de votre part, le versement de votre RSA pourra être suspendu ou son montant réduit.</p>
-<% end  %>
+<p>Vous êtes bénéficiaire du RSA et vous devez vous présenter à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>:</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     Choisir un créneau
   <% end %>
 </p>
+<% if @display_mandatory_warning %>
+  <p><strong>Ce rendez-vous est obligatoire.</strong></p>
+<% end %>
+<% if @display_punishable_warning %>
+  <p>En l’absence d'action de votre part, le versement de votre RSA pourra être suspendu ou son montant réduit.</p>
+<% end  %>
 <p>En cas de problème technique, contactez le <%= @invitation.help_phone_number_formatted %></p>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>
 <% if @logo_path %>

--- a/app/views/mailers/invitation_mailer/regular_invitation_reminder.html.erb
+++ b/app/views/mailers/invitation_mailer/regular_invitation_reminder.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de <%= @invitation_purpose %>.</p>
+<p>En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours vous invitant à prendre rendez-vous afin de <%= @rdv_purpose %>.</p>
 <p>Il ne vous reste plus que <span class="font-weight-bold"><%= @invitation.number_of_days_before_expiration %> jours</span> pour prendre rendez-vous à la date et l'horaire de votre choix en cliquant sur le bouton suivant.</p>
 <% if @display_mandatory_warning %>
   <p><span class="font-weight-bold">Ce rendez-vous est obligatoire.</span></p>

--- a/app/views/mailers/notification_mailer/by_phone_rdv_created.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_rdv_created.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un <%= @rdv_title %>.</p>
+<p>Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
 <p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number_formatted %></span>.</p>
 <% if @display_mandatory_warning %>
   <p><span class="font-weight-bold">Ce rendez-vous est obligatoire</span>.</p>

--- a/app/views/mailers/notification_mailer/presential_rdv_created.html.erb
+++ b/app/views/mailers/notification_mailer/presential_rdv_created.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un <%= @rdv_title %>.</p>
+<p>Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
 <p>Vous êtes attendu(e) <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> à l'adresse suivante: </p>
 <p><h4><%= @rdv.lieu.name %></h4></p>
 <p><h4><%= @rdv.lieu.address %></h4></p>

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -13,3 +13,5 @@ fr:
           rsa_cer_signature: RSA signature CER
           rsa_insertion_offer: RSA offre insertion pro
           rsa_follow_up: RSA suivi
+          rsa_main_tendue: RSA Main Tendue
+          rsa_atelier_collectif_mandatory: RSA Atelier collectif

--- a/config/templates/applicant_messages.yml
+++ b/config/templates/applicant_messages.yml
@@ -1,33 +1,40 @@
 categories:
+  ### Il faut avoir en tête la phrase suivante: "Vous êtes invité/convoqué à un rdv_title afin de rdv_purpose"
   rsa_orientation:
     rdv_title: rendez-vous d'orientation
     rdv_title_by_phone: rendez-vous d'orientation téléphonique
-    invitation_purpose: démarrer un parcours d'accompagnement
+    rdv_purpose: démarrer un parcours d'accompagnement
     display_mandatory_warning: true
     display_punishable_warning: false
   rsa_accompagnement: &rsa_accompagnement_values
     rdv_title: rendez-vous d'accompagnement
     rdv_title_by_phone: rendez-vous d'accompagnement téléphonique
-    invitation_purpose: démarrer un parcours d'accompagnement
+    rdv_purpose: démarrer un parcours d'accompagnement
     display_mandatory_warning: true
     display_punishable_warning: true
   rsa_accompagnement_social: *rsa_accompagnement_values # we reuse the rsa_accompagnement_values
   rsa_accompagnement_sociopro: *rsa_accompagnement_values # we reuse the rsa_accompagnement_values
   rsa_follow_up:
-    rdv_title: rendez-vous de suivi avec votre référent de parcours
-    rdv_title_by_phone: rendez-vous de suivi téléphonique avec votre référent de parcours
-    invitation_purpose: faire un point avec votre référent de parcours
+    rdv_title: rendez-vous de suivi
+    rdv_title_by_phone: rendez-vous de suivi téléphonique
+    rdv_purpose: faire un point avec votre référent de parcours
     display_mandatory_warning: false
     display_punishable_warning: false
   rsa_cer_signature:
-    rdv_title: rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque
-    rdv_title_by_phone: rendez-vous téléphonique pour construire et signer votre Contrat d'Engagement Réciproque
-    invitation_purpose: signer votre Contrat d'Engagement Réciproque
+    rdv_title: rendez-vous de signature de CER
+    rdv_title_by_phone: rendez-vous téléphonique de signature de CER
+    rdv_purpose: construire et signer votre Contrat d'Engagement Réciproque
     display_mandatory_warning: true
     display_punishable_warning: false
-  entretien_main_tendue:
-    rdv_title: entretien de main tendue afin de faire le point sur votre situation
-    rdv_title_by_phone: entretien téléphonique de main tendue afin de faire le point sur votre situation
-    invitation_purpose: faire le point sur votre situation
+  rsa_main_tendue:
+    rdv_title: entretien de main tendue
+    rdv_title_by_phone: entretien téléphonique de main tendue
+    rdv_purpose: faire le point sur votre situation
+    display_mandatory_warning: true
+    display_punishable_warning: false
+  rsa_atelier_collectif_mandatory:
+    rdv_title: atelier collectif
+    rdv_title_by_phone: atelier collectif
+    rdv_purpose: vous aider dans votre parcours d'insertion
     display_mandatory_warning: true
     display_punishable_warning: false

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'orientation"
+          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'orientation" \
+          " afin de démarrer un parcours d'accompagnement"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -81,7 +82,8 @@ RSpec.describe InvitationMailer, type: :mailer do
           expect(body_string).to match("Le département de la Drôme.")
           expect(body_string).to match("01 39 39 39 39")
           expect(body_string).to match(
-            "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'accompagnement"
+            "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'accompagnement" \
+            " afin de démarrer un parcours d'accompagnement"
           )
           expect(body_string).to match("Ce rendez-vous est obligatoire.")
           expect(body_string).to match(
@@ -104,7 +106,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       it "renders the subject" do
         email_subject = CGI.unescapeHTML(subject.subject)
         expect(email_subject).to eq(
-          "[RSA]: Votre rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque" \
+          "[RSA]: Votre rendez-vous de signature de CER" \
           " dans le cadre de votre RSA"
         )
       end
@@ -115,8 +117,8 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous pour "\
-          "construire et signer votre Contrat d'Engagement Réciproque"
+          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous de signature de CER "\
+          "afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -138,7 +140,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       it "renders the subject" do
         email_subject = CGI.unescapeHTML(subject.subject)
         expect(email_subject).to eq(
-          "[RSA]: Votre rendez-vous de suivi avec votre référent de parcours" \
+          "[RSA]: Votre rendez-vous de suivi" \
           " dans le cadre de votre RSA"
         )
       end
@@ -150,9 +152,77 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
           "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-          "de suivi avec votre référent de parcours"
+          "de suivi afin de faire un point avec votre référent de parcours"
         )
         expect(body_string).not_to match("Ce rendez-vous est obligatoire.")
+        expect(body_string).not_to match(
+          "le versement de votre RSA pourra être suspendu ou son montant réduit."
+        )
+        expect(body_string).to match("/invitations/redirect")
+        expect(body_string).to match("uuid=#{invitation.uuid}")
+        expect(body_string).to match("dans les 5 jours")
+      end
+    end
+
+    context "for rsa_main_tendue" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_main_tendue") }
+
+      it "renders the headers" do
+        expect(subject.to).to eq([applicant.email])
+      end
+
+      it "renders the subject" do
+        email_subject = CGI.unescapeHTML(subject.subject)
+        expect(email_subject).to eq(
+          "[RSA]: Votre entretien de main tendue" \
+          " dans le cadre de votre RSA"
+        )
+      end
+
+      it "renders the body" do
+        body_string = CGI.unescapeHTML(subject.body.encoded)
+        expect(body_string).to match("Bonjour Jean VALJEAN")
+        expect(body_string).to match("Le département de la Drôme.")
+        expect(body_string).to match("01 39 39 39 39")
+        expect(body_string).to match(
+          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un entretien de main tendue " \
+          "afin de faire le point sur votre situation"
+        )
+        expect(body_string).to match("Ce rendez-vous est obligatoire.")
+        expect(body_string).not_to match(
+          "le versement de votre RSA pourra être suspendu ou son montant réduit."
+        )
+        expect(body_string).to match("/invitations/redirect")
+        expect(body_string).to match("uuid=#{invitation.uuid}")
+        expect(body_string).to match("dans les 5 jours")
+      end
+    end
+
+    context "for rsa_atelier_collectif_mandatory" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_atelier_collectif_mandatory") }
+
+      it "renders the headers" do
+        expect(subject.to).to eq([applicant.email])
+      end
+
+      it "renders the subject" do
+        email_subject = CGI.unescapeHTML(subject.subject)
+        expect(email_subject).to eq(
+          "[RSA]: Votre atelier collectif" \
+          " dans le cadre de votre RSA"
+        )
+      end
+
+      it "renders the body" do
+        body_string = CGI.unescapeHTML(subject.body.encoded)
+        expect(body_string).to match("Bonjour Jean VALJEAN")
+        expect(body_string).to match("Le département de la Drôme.")
+        expect(body_string).to match("01 39 39 39 39")
+        expect(body_string).to match(
+          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un atelier collectif " \
+          "afin de vous aider dans votre parcours d'insertion"
+        )
+        expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
           "le versement de votre RSA pourra être suspendu ou son montant réduit."
         )
@@ -336,8 +406,8 @@ RSpec.describe InvitationMailer, type: :mailer do
       it "renders the subject" do
         email_subject = CGI.unescapeHTML(subject.subject)
         expect(email_subject).to eq(
-          "[Rappel]: Votre rendez-vous pour construire et signer votre "\
-          "Contrat d'Engagement Réciproque dans le cadre de votre RSA"
+          "[Rappel]: Votre rendez-vous de signature de CER "\
+          "dans le cadre de votre RSA"
         )
       end
 
@@ -348,7 +418,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
           "En tant que bénéficiaire du RSA, vous avez reçu un premier mail il y a 3 jours "\
-          "vous invitant à prendre rendez-vous afin de signer votre Contrat d'Engagement Réciproque."
+          "vous invitant à prendre rendez-vous afin de construire et signer votre Contrat d'Engagement Réciproque."
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -373,7 +443,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       it "renders the subject" do
         email_subject = CGI.unescapeHTML(subject.subject)
         expect(email_subject).to eq(
-          "[Rappel]: Votre rendez-vous de suivi avec votre référent de parcours "\
+          "[Rappel]: Votre rendez-vous de suivi "\
           "dans le cadre de votre RSA"
         )
       end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -29,14 +29,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d&#39;orientation"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d'orientation"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -52,14 +53,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d&#39;accompagnement"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d'accompagnement"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -75,14 +77,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d&#39;accompagnement"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d'accompagnement"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -98,14 +101,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d&#39;accompagnement"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d'accompagnement"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -116,21 +120,21 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous pour construire" \
-          " et signer votre Contrat d'Engagement Réciproque"
+          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous de signature de CER"
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous pour construire" \
-          " et signer votre Contrat d&#39;Engagement Réciproque"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous de signature de CER" \
+          " afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -141,21 +145,21 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous de suivi avec votre référent de parcours" \
-          ""
+          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous de suivi"
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous de suivi" \
-          " avec votre référent de parcours"
+          " afin de faire un point avec votre référent de parcours"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).not_to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).not_to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -186,14 +190,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;orientation dans le cadre de votre RSA a été modifié"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'orientation dans le cadre de votre RSA a été modifié"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -209,14 +214,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement dans le cadre de votre RSA a été modifié"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -232,14 +238,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement dans le cadre de votre RSA a été modifié"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -255,14 +262,15 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement dans le cadre de votre RSA a été modifié"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -273,22 +281,21 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Votre rendez-vous pour construire" \
-          " et signer votre Contrat d'Engagement Réciproque " \
-          "a été modifié."
+          "[Important - RSA] Votre rendez-vous de signature de CER a été modifié."
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous pour construire et signer votre Contrat d&#39;Engagement"\
-          " Réciproque dans le cadre de votre RSA a été modifié."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous de signature de CER" \
+          " dans le cadre de votre RSA a été modifié."
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -299,21 +306,20 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Votre rendez-vous de suivi avec votre référent de parcours" \
-          " a été modifié."
+          "[Important - RSA] Votre rendez-vous de suivi a été modifié."
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous de suivi" \
-          " avec votre référent de parcours dans le cadre de votre RSA a été modifié"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous de suivi dans le cadre de votre RSA a été modifié"
         )
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("DINUM")
-        expect(mail.body.encoded).to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).not_to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("DINUM")
+        expect(body_string).to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).not_to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -344,17 +350,18 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d&#39;orientation" \
-          " téléphonique"
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous d'orientation" \
+          " téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -370,17 +377,18 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) " \
-          "à un rendez-vous d&#39;accompagnement téléphonique"
+          "à un rendez-vous d'accompagnement téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -396,17 +404,18 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) " \
-          "à un rendez-vous d&#39;accompagnement téléphonique"
+          "à un rendez-vous d'accompagnement téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -422,17 +431,18 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) " \
-          "à un rendez-vous d&#39;accompagnement téléphonique"
+          "à un rendez-vous d'accompagnement téléphonique afin de démarrer un parcours d'accompagnement"
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -443,23 +453,23 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous téléphonique pour construire" \
-          " et signer votre Contrat d'Engagement Réciproque"
+          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous téléphonique de signature de CER"
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous téléphonique"\
-          " pour construire et signer votre Contrat d&#39;Engagement Réciproque"
+          " de signature de CER afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -470,23 +480,23 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous de suivi téléphonique avec "\
-          "votre référent de parcours"
+          "[Important - RSA] Vous êtes convoqué(e) à un rendez-vous de suivi téléphonique"
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Vous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué(e) à un rendez-vous de suivi " \
-          "téléphonique avec votre référent de parcours"\
+          "téléphonique afin de faire un point avec votre référent de parcours"\
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).not_to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).not_to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -528,16 +538,17 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;orientation téléphonique dans le cadre de votre RSA a été modifié."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'orientation téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -553,16 +564,17 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement téléphonique dans le cadre de votre RSA a été modifié."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -578,16 +590,17 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement téléphonique dans le cadre de votre RSA a été modifié."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -603,16 +616,17 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement téléphonique dans le cadre de votre RSA a été modifié."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement téléphonique dans le cadre de votre RSA a été modifié."
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -623,23 +637,23 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Votre rendez-vous téléphonique pour construire" \
-          " et signer votre Contrat d'Engagement Réciproque a été modifié."
+          "[Important - RSA] Votre rendez-vous téléphonique de signature de CER a été modifié."
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous téléphonique pour construire et signer votre Contrat d&#39;Engagement Réciproque" \
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous téléphonique de signature de CER" \
           " dans le cadre de votre RSA a été modifié"
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -650,23 +664,23 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Votre rendez-vous de suivi téléphonique avec "\
-          "votre référent de parcours a été modifié."
+          "[Important - RSA] Votre rendez-vous de suivi téléphonique a été modifié."
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
           "Votre rendez-vous de suivi " \
-          "téléphonique avec votre référent de parcours dans le cadre de votre RSA a été modifié"\
+          "téléphonique dans le cadre de votre RSA a été modifié"\
         )
-        expect(mail.body.encoded).to include("Un travailleur social vous appellera")
-        expect(mail.body.encoded).to include("le 20/12/2021 à 12:00")
-        expect(mail.body.encoded).to include("sur votre numéro de téléphone:")
-        expect(mail.body.encoded).to include("+33607070707")
-        expect(mail.body.encoded).not_to include("20 avenue de ségur 75007 Paris")
-        expect(mail.body.encoded).not_to include("Ce rendez-vous est obligatoire")
-        expect(mail.body.encoded).not_to include(
+        expect(body_string).to include("Un travailleur social vous appellera")
+        expect(body_string).to include("le 20/12/2021 à 12:00")
+        expect(body_string).to include("sur votre numéro de téléphone:")
+        expect(body_string).to include("+33607070707")
+        expect(body_string).not_to include("20 avenue de ségur 75007 Paris")
+        expect(body_string).not_to include("Ce rendez-vous est obligatoire")
+        expect(body_string).not_to include(
           "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit."
         )
       end
@@ -708,10 +722,11 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;orientation dans le cadre de votre RSA a été annulé."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'orientation dans le cadre de votre RSA a été annulé."
         )
-        expect(mail.body.encoded).to include("our plus d'informations, veuillez appeler le 0101010101")
+        expect(body_string).to include("Pour plus d'informations, veuillez appeler le 0101010101")
       end
     end
 
@@ -725,10 +740,11 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement dans le cadre de votre RSA a été annulé."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé."
         )
-        expect(mail.body.encoded).to include("our plus d'informations, veuillez appeler le 0101010101")
+        expect(body_string).to include("Pour plus d'informations, veuillez appeler le 0101010101")
       end
     end
 
@@ -742,10 +758,11 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement dans le cadre de votre RSA a été annulé."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé."
         )
-        expect(mail.body.encoded).to include("our plus d'informations, veuillez appeler le 0101010101")
+        expect(body_string).to include("Pour plus d'informations, veuillez appeler le 0101010101")
       end
     end
 
@@ -759,10 +776,11 @@ RSpec.describe NotificationMailer, type: :mailer do
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous d&#39;accompagnement dans le cadre de votre RSA a été annulé."
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé."
         )
-        expect(mail.body.encoded).to include("our plus d'informations, veuillez appeler le 0101010101")
+        expect(body_string).to include("Pour plus d'informations, veuillez appeler le 0101010101")
       end
     end
 
@@ -771,17 +789,17 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Votre rendez-vous pour construire" \
-          " et signer votre Contrat d'Engagement Réciproque a été annulé."
+          "[Important - RSA] Votre rendez-vous de signature de CER a été annulé."
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous pour construire et signer votre Contrat d&#39;Engagement Réciproque" \
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous de signature de CER" \
           " dans le cadre de votre RSA a été annulé"
         )
-        expect(mail.body.encoded).to include("our plus d'informations, veuillez appeler le 0101010101")
+        expect(body_string).to include("Pour plus d'informations, veuillez appeler le 0101010101")
       end
     end
 
@@ -790,17 +808,16 @@ RSpec.describe NotificationMailer, type: :mailer do
 
       it "renders the subject" do
         expect(mail.subject).to eq(
-          "[Important - RSA] Votre rendez-vous de suivi avec "\
-          "votre référent de parcours a été annulé."
+          "[Important - RSA] Votre rendez-vous de suivi a été annulé."
         )
       end
 
       it "renders the body" do
-        expect(mail.body.encoded).to include(
-          "Votre rendez-vous de suivi " \
-          "avec votre référent de parcours dans le cadre de votre RSA a été annulé"\
+        body_string = CGI.unescapeHTML(mail.body.encoded)
+        expect(body_string).to include(
+          "Votre rendez-vous de suivi dans le cadre de votre RSA a été annulé"\
         )
-        expect(mail.body.encoded).to include("our plus d'informations, veuillez appeler le 0101010101")
+        expect(body_string).to include("Pour plus d'informations, veuillez appeler le 0101010101")
       end
     end
   end

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -101,11 +101,10 @@ describe Invitations::GenerateLetter, type: :service do
         subject
         content = CGI.unescapeHTML(invitation.content)
         expect(content).to include(
-          "Objet : Rendez-vous pour construire et signer votre Contrat d'Engagement " \
-          "Réciproque dans le cadre de votre RSA"
+          "Objet : Rendez-vous de signature de CER dans le cadre de votre RSA"
         )
         expect(content).to include(
-          "vous devez prendre un rendez-vous afin de signer votre Contrat d'Engagement Réciproque"
+          "vous devez prendre un rendez-vous afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
         expect(content).to include("Vous devez obligatoirement prendre ce rendez-vous")
         expect(content).not_to include(
@@ -121,7 +120,7 @@ describe Invitations::GenerateLetter, type: :service do
         subject
         content = CGI.unescapeHTML(invitation.content)
         expect(content).to include(
-          "Objet : Rendez-vous de suivi avec votre référent de parcours dans le cadre de votre RSA"
+          "Objet : Rendez-vous de suivi dans le cadre de votre RSA"
         )
         expect(content).to include(
           "vous devez prendre un rendez-vous afin de faire un point avec votre référent de parcours"

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -38,7 +38,8 @@ describe Invitations::SendSms, type: :service do
   let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_orientation") }
   let!(:content) do
     "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-      "d'orientation. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
+      "d'orientation afin de démarrer un parcours d'accompagnement. "\
+      "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
       "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
       "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le 0147200001."
   end
@@ -78,130 +79,52 @@ describe Invitations::SendSms, type: :service do
     end
 
     context "for rsa accompagnement" do
-      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_accompagnement") }
-      let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement") }
+      let!(:rdv_context) { build(:rdv_context) }
+      let!(:configuration) { create(:configuration) }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-          "d'accompagnement. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
+          "d'accompagnement afin de démarrer un parcours d'accompagnement." \
+          " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
           "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
           "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
           "le versement de votre RSA pourra être suspendu ou réduit. " \
           "En cas de problème technique, contactez le 0147200001."
       end
 
-      it("is a success") { is_a_success }
-
-      it "calls the send transactional service with the right content" do
-        expect(Messengers::SendSms).to receive(:call)
-          .with(sendable: invitation, content: content)
-        subject
-      end
-
-      context "when it is a reminder" do
-        let!(:content) do
-          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
-            "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
-            "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
-            "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
-            "le versement de votre RSA pourra être suspendu ou réduit. En cas de problème technique, contactez le "\
-            "0147200001."
-        end
-
+      %w[rsa_accompagnement rsa_accompagnement_social rsa_accompagnement_sociopro].each do |motif_category|
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          rdv_context.motif_category = motif_category
+          configuration.motif_category = motif_category
         end
+
+        it("is a success") { is_a_success }
 
         it "calls the send transactional service with the right content" do
           expect(Messengers::SendSms).to receive(:call)
             .with(sendable: invitation, content: content)
           subject
         end
-      end
-    end
 
-    context "for rsa accompagnement social" do
-      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_accompagnement_social") }
-      let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement_social") }
-      let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-          "d'accompagnement. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
-          "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
-          "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
-          "le versement de votre RSA pourra être suspendu ou réduit. " \
-          "En cas de problème technique, contactez le 0147200001."
-      end
+        context "when it is a reminder" do
+          let!(:content) do
+            "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
+              "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
+              "Le lien de prise de RDV suivant expire dans 5 jours: " \
+              "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+              "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
+              "le versement de votre RSA pourra être suspendu ou réduit. En cas de problème technique, contactez le "\
+              "0147200001."
+          end
 
-      it("is a success") { is_a_success }
+          before do
+            invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          end
 
-      it "calls the send transactional service with the right content" do
-        expect(Messengers::SendSms).to receive(:call)
-          .with(sendable: invitation, content: content)
-        subject
-      end
-
-      context "when it is a reminder" do
-        let!(:content) do
-          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
-            "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
-            "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
-            "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
-            "le versement de votre RSA pourra être suspendu ou réduit. En cas de problème technique, contactez le "\
-            "0147200001."
-        end
-
-        before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
-        end
-
-        it "calls the send transactional service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: invitation, content: content)
-          subject
-        end
-      end
-    end
-
-    context "for rsa accompagnement sociopro" do
-      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_accompagnement_sociopro") }
-      let!(:configuration) { create(:configuration, motif_category: "rsa_accompagnement_sociopro") }
-      let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-          "d'accompagnement. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
-          "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
-          "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
-          "le versement de votre RSA pourra être suspendu ou réduit. " \
-          "En cas de problème technique, contactez le 0147200001."
-      end
-
-      it("is a success") { is_a_success }
-
-      it "calls the send transactional service with the right content" do
-        expect(Messengers::SendSms).to receive(:call)
-          .with(sendable: invitation, content: content)
-        subject
-      end
-
-      context "when it is a reminder" do
-        let!(:content) do
-          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
-            "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
-            "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
-            "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
-            "le versement de votre RSA pourra être suspendu ou réduit. En cas de problème technique, contactez le "\
-            "0147200001."
-        end
-
-        before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
-        end
-
-        it "calls the send transactional service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: invitation, content: content)
-          subject
+          it "calls the send transactional service with the right content" do
+            expect(Messengers::SendSms).to receive(:call)
+              .with(sendable: invitation, content: content)
+            subject
+          end
         end
       end
     end
@@ -249,7 +172,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration, motif_category: "rsa_cer_signature") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque." \
+          "un rendez-vous de signature de CER afin de construire et signer votre Contrat d'Engagement Réciproque." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
@@ -268,8 +191,95 @@ describe Invitations::SendSms, type: :service do
       context "when it is a reminder" do
         let!(:content) do
           "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
-            "vous invitant à prendre RDV au créneau de votre choix afin de signer votre Contrat d'Engagement " \
-            "Réciproque. Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "vous invitant à prendre RDV au créneau de votre choix afin de construire et signer " \
+            "votre Contrat d'Engagement Réciproque. " \
+            "Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
+            "0147200001."
+        end
+
+        before do
+          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        end
+
+        it "calls the send transactional service with the right content" do
+          expect(Messengers::SendSms).to receive(:call)
+            .with(sendable: invitation, content: content)
+          subject
+        end
+      end
+    end
+
+    context "for rsa_main_tendue" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_main_tendue") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_main_tendue") }
+      let!(:content) do
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
+          "un entretien de main tendue afin de faire le point sur votre situation." \
+          " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
+          "9 jours: " \
+          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
+          "Ce rendez-vous est obligatoire. "\
+          "En cas de problème technique, contactez le 0147200001."
+      end
+
+      it("is a success") { is_a_success }
+
+      it "calls the send transactional service with the right content" do
+        expect(Messengers::SendSms).to receive(:call)
+          .with(sendable: invitation, content: content)
+        subject
+      end
+
+      context "when it is a reminder" do
+        let!(:content) do
+          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
+            "vous invitant à prendre RDV au créneau de votre choix afin de faire le point sur votre situation." \
+            " Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
+            "0147200001."
+        end
+
+        before do
+          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        end
+
+        it "calls the send transactional service with the right content" do
+          expect(Messengers::SendSms).to receive(:call)
+            .with(sendable: invitation, content: content)
+          subject
+        end
+      end
+    end
+
+    context "for rsa_atelier_collectif_mandatory" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_atelier_collectif_mandatory") }
+      let!(:configuration) { create(:configuration, motif_category: "rsa_atelier_collectif_mandatory") }
+      let!(:content) do
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
+          "un atelier collectif afin de vous aider dans votre parcours d'insertion." \
+          " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
+          "9 jours: " \
+          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
+          "Ce rendez-vous est obligatoire. "\
+          "En cas de problème technique, contactez le 0147200001."
+      end
+
+      it("is a success") { is_a_success }
+
+      it "calls the send transactional service with the right content" do
+        expect(Messengers::SendSms).to receive(:call)
+          .with(sendable: invitation, content: content)
+        subject
+      end
+
+      context "when it is a reminder" do
+        let!(:content) do
+          "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
+            "vous invitant à prendre RDV au créneau de votre choix afin de vous aider dans votre parcours d'insertion" \
+            ". Le lien de prise de RDV suivant expire dans 5 jours: " \
             "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
             "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le "\
             "0147200001."
@@ -313,7 +323,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration, motif_category: "rsa_follow_up") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un rendez-vous de suivi avec votre référent de parcours. " \
+          "un rendez-vous de suivi afin de faire un point avec votre référent de parcours. " \
           "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\

--- a/spec/services/notifications/send_sms_spec.rb
+++ b/spec/services/notifications/send_sms_spec.rb
@@ -59,8 +59,8 @@ describe Notifications::SendSms, type: :service do
     describe "RSA orientation" do
       let!(:content) do
         "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-          "rendez-vous d'orientation. Vous êtes attendu(e) le 20/12/2021 à " \
-          "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
+          "rendez-vous d'orientation. Vous êtes attendu(e) le 20/12/2021" \
+          " à 10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
           "Ce RDV est obligatoire. "\
           "En cas d’empêchement, appelez rapidement le 0101010101."
       end
@@ -113,7 +113,8 @@ describe Notifications::SendSms, type: :service do
 
         let!(:content) do
           "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-            "rendez-vous d'orientation. Un travailleur social vous appellera le 20/12/2021 à " \
+            "rendez-vous d'orientation." \
+            " Un travailleur social vous appellera le 20/12/2021 à " \
             "partir de 10:00 sur ce numéro. " \
             "Ce RDV est obligatoire. "\
             "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -148,88 +149,71 @@ describe Notifications::SendSms, type: :service do
     end
 
     describe "RSA accompagnement" do
-      let!(:rdv_context) { create(:rdv_context, motif_category: "rsa_accompagnement") }
+      let!(:rdv_context) { create(:rdv_context) }
 
-      let!(:content) do
-        "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-          "rendez-vous d'accompagnement. Vous êtes attendu(e) le 20/12/2021 à " \
-          "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-          "Ce RDV est obligatoire. "\
-          "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-          "En cas d’empêchement, appelez rapidement le 0101010101."
-      end
-
-      it "calls the messenger service with the right content" do
-        expect(Messengers::SendSms).to receive(:call)
-          .with(sendable: notification, content: content)
-        subject
-      end
-
-      context "when is an update notification" do
-        let!(:notification) do
-          create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
-        end
-
-        let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
-            "Vous êtes attendu(e) le 20/12/2021 à " \
-            "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. "\
-            "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-            "En cas d’empêchement, appelez rapidement le 0101010101."
-        end
-
-        it "calls the messenger service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-      end
-
-      context "when it is a cancelled notification" do
-        let!(:notification) do
-          create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_cancelled")
-        end
-
-        let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé. " \
-            "Pour plus d'informations, contactez le 0101010101."
-        end
-
-        it "calls the messenger service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-      end
-
-      context "when it is a phone rdv" do
-        let!(:motif) { create(:motif, location_type: "phone") }
+      %w[rsa_accompagnement rsa_accompagnement_social rsa_accompagnement_sociopro].each do |motif_category|
+        before { rdv_context.motif_category = motif_category }
 
         let!(:content) do
           "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-            "rendez-vous d'accompagnement. Un travailleur social vous appellera le 20/12/2021 à " \
-            "partir de 10:00 sur ce numéro. " \
+            "rendez-vous d'accompagnement. Vous êtes attendu(e) " \
+            "le 20/12/2021 à 10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
             "Ce RDV est obligatoire. "\
             "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
         end
 
-        it "calls the send transactional service with the right content" do
+        it "calls the messenger service with the right content" do
           expect(Messengers::SendSms).to receive(:call)
             .with(sendable: notification, content: content)
           subject
         end
 
-        context "when it is an update notification" do
+        context "when is an update notification" do
           let!(:notification) do
             create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
           end
 
           let!(:content) do
             "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
-              "partir de 10:00 sur ce numéro. " \
+              "Vous êtes attendu(e) le 20/12/2021 à " \
+              "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
+              "Ce RDV est obligatoire. "\
+              "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
+              "En cas d’empêchement, appelez rapidement le 0101010101."
+          end
+
+          it "calls the messenger service with the right content" do
+            expect(Messengers::SendSms).to receive(:call)
+              .with(sendable: notification, content: content)
+            subject
+          end
+        end
+
+        context "when it is a cancelled notification" do
+          let!(:notification) do
+            create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_cancelled")
+          end
+
+          let!(:content) do
+            "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé. " \
+              "Pour plus d'informations, contactez le 0101010101."
+          end
+
+          it "calls the messenger service with the right content" do
+            expect(Messengers::SendSms).to receive(:call)
+              .with(sendable: notification, content: content)
+            subject
+          end
+        end
+
+        context "when it is a phone rdv" do
+          let!(:motif) { create(:motif, location_type: "phone") }
+
+          let!(:content) do
+            "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
+              "rendez-vous d'accompagnement. Un travailleur social " \
+              "vous appellera le 20/12/2021 à partir de 10:00 sur ce numéro. " \
               "Ce RDV est obligatoire. "\
               "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
               "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -240,199 +224,26 @@ describe Notifications::SendSms, type: :service do
               .with(sendable: notification, content: content)
             subject
           end
-        end
-      end
-    end
 
-    describe "RSA accompagnement social" do
-      let!(:rdv_context) { create(:rdv_context, motif_category: "rsa_accompagnement_social") }
+          context "when it is an update notification" do
+            let!(:notification) do
+              create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
+            end
 
-      let!(:content) do
-        "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-          "rendez-vous d'accompagnement. Vous êtes attendu(e) le 20/12/2021 à " \
-          "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-          "Ce RDV est obligatoire. "\
-          "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-          "En cas d’empêchement, appelez rapidement le 0101010101."
-      end
+            let!(:content) do
+              "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
+                "Un travailleur social vous appellera le 20/12/2021 à " \
+                "partir de 10:00 sur ce numéro. " \
+                "Ce RDV est obligatoire. "\
+                "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
+                "En cas d’empêchement, appelez rapidement le 0101010101."
+            end
 
-      it "calls the messenger service with the right content" do
-        expect(Messengers::SendSms).to receive(:call)
-          .with(sendable: notification, content: content)
-        subject
-      end
-
-      context "when is an update notification" do
-        let!(:notification) do
-          create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
-        end
-
-        let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
-            "Vous êtes attendu(e) le 20/12/2021 à " \
-            "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. "\
-            "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-            "En cas d’empêchement, appelez rapidement le 0101010101."
-        end
-
-        it "calls the messenger service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-      end
-
-      context "when it is a cancelled notification" do
-        let!(:notification) do
-          create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_cancelled")
-        end
-
-        let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé. " \
-            "Pour plus d'informations, contactez le 0101010101."
-        end
-
-        it "calls the messenger service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-      end
-
-      context "when it is a phone rdv" do
-        let!(:motif) { create(:motif, location_type: "phone") }
-
-        let!(:content) do
-          "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-            "rendez-vous d'accompagnement. Un travailleur social vous appellera le 20/12/2021 à " \
-            "partir de 10:00 sur ce numéro. " \
-            "Ce RDV est obligatoire. "\
-            "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-            "En cas d’empêchement, appelez rapidement le 0101010101."
-        end
-
-        it "calls the send transactional service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-
-        context "when it is an update notification" do
-          let!(:notification) do
-            create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
-          end
-
-          let!(:content) do
-            "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
-              "partir de 10:00 sur ce numéro. " \
-              "Ce RDV est obligatoire. "\
-              "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-              "En cas d’empêchement, appelez rapidement le 0101010101."
-          end
-
-          it "calls the send transactional service with the right content" do
-            expect(Messengers::SendSms).to receive(:call)
-              .with(sendable: notification, content: content)
-            subject
-          end
-        end
-      end
-    end
-
-    describe "RSA accompagnement sociopro" do
-      let!(:rdv_context) { create(:rdv_context, motif_category: "rsa_accompagnement_sociopro") }
-
-      let!(:content) do
-        "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-          "rendez-vous d'accompagnement. Vous êtes attendu(e) le 20/12/2021 à " \
-          "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-          "Ce RDV est obligatoire. "\
-          "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-          "En cas d’empêchement, appelez rapidement le 0101010101."
-      end
-
-      it "calls the messenger service with the right content" do
-        expect(Messengers::SendSms).to receive(:call)
-          .with(sendable: notification, content: content)
-        subject
-      end
-
-      context "when is an update notification" do
-        let!(:notification) do
-          create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
-        end
-
-        let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
-            "Vous êtes attendu(e) le 20/12/2021 à " \
-            "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. "\
-            "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-            "En cas d’empêchement, appelez rapidement le 0101010101."
-        end
-
-        it "calls the messenger service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-      end
-
-      context "when it is a cancelled notification" do
-        let!(:notification) do
-          create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_cancelled")
-        end
-
-        let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été annulé. " \
-            "Pour plus d'informations, contactez le 0101010101."
-        end
-
-        it "calls the messenger service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-      end
-
-      context "when it is a phone rdv" do
-        let!(:motif) { create(:motif, location_type: "phone") }
-
-        let!(:content) do
-          "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-            "rendez-vous d'accompagnement. Un travailleur social vous appellera le 20/12/2021 à " \
-            "partir de 10:00 sur ce numéro. " \
-            "Ce RDV est obligatoire. "\
-            "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-            "En cas d’empêchement, appelez rapidement le 0101010101."
-        end
-
-        it "calls the send transactional service with the right content" do
-          expect(Messengers::SendSms).to receive(:call)
-            .with(sendable: notification, content: content)
-          subject
-        end
-
-        context "when it is an update notification" do
-          let!(:notification) do
-            create(:notification, applicant: applicant, rdv: rdv, format: "sms", event: "rdv_updated")
-          end
-
-          let!(:content) do
-            "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
-              "Un travailleur social vous appellera le 20/12/2021 à " \
-              "partir de 10:00 sur ce numéro. " \
-              "Ce RDV est obligatoire. "\
-              "En cas d'absence, le versement de votre RSA pourra être suspendu ou réduit. " \
-              "En cas d’empêchement, appelez rapidement le 0101010101."
-          end
-
-          it "calls the send transactional service with the right content" do
-            expect(Messengers::SendSms).to receive(:call)
-              .with(sendable: notification, content: content)
-            subject
+            it "calls the send transactional service with the right content" do
+              expect(Messengers::SendSms).to receive(:call)
+                .with(sendable: notification, content: content)
+              subject
+            end
           end
         end
       end
@@ -443,7 +254,7 @@ describe Notifications::SendSms, type: :service do
 
       let!(:content) do
         "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-          "rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque. " \
+          "rendez-vous de signature de CER. " \
           "Vous êtes attendu(e) le 20/12/2021 à " \
           "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
           "Ce RDV est obligatoire. "\
@@ -462,7 +273,7 @@ describe Notifications::SendSms, type: :service do
         end
 
         let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque" \
+          "Monsieur John DOE,\nVotre rendez-vous de signature de CER" \
             " dans le cadre de votre RSA a été modifié. " \
             "Vous êtes attendu(e) le 20/12/2021 à " \
             "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
@@ -483,7 +294,7 @@ describe Notifications::SendSms, type: :service do
         end
 
         let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque" \
+          "Monsieur John DOE,\nVotre rendez-vous de signature de CER" \
             " dans le cadre de votre RSA a été annulé. " \
             "Pour plus d'informations, contactez le 0101010101."
         end
@@ -500,7 +311,7 @@ describe Notifications::SendSms, type: :service do
 
         let!(:content) do
           "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-            "rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque. "\
+            "rendez-vous de signature de CER. "\
             "Un travailleur social vous appellera le 20/12/2021 à " \
             "partir de 10:00 sur ce numéro. " \
             "Ce RDV est obligatoire. "\
@@ -519,7 +330,7 @@ describe Notifications::SendSms, type: :service do
           end
 
           let!(:content) do
-            "Monsieur John DOE,\nVotre rendez-vous pour construire et signer votre Contrat d'Engagement Réciproque" \
+            "Monsieur John DOE,\nVotre rendez-vous de signature de CER" \
               " dans le cadre de votre RSA a été modifié. " \
               "Un travailleur social vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \
@@ -541,7 +352,8 @@ describe Notifications::SendSms, type: :service do
 
       let!(:content) do
         "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-          "rendez-vous de suivi avec votre référent de parcours. Vous êtes attendu(e) le 20/12/2021 à " \
+          "rendez-vous de suivi. "\
+          "Vous êtes attendu(e) le 20/12/2021 à " \
           "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
           "En cas d’empêchement, appelez rapidement le 0101010101."
       end
@@ -558,8 +370,7 @@ describe Notifications::SendSms, type: :service do
         end
 
         let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous de suivi avec votre référent de parcours" \
-            " dans le cadre de votre RSA a été modifié. " \
+          "Monsieur John DOE,\nVotre rendez-vous de suivi dans le cadre de votre RSA a été modifié. " \
             "Vous êtes attendu(e) le 20/12/2021 à " \
             "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -578,7 +389,7 @@ describe Notifications::SendSms, type: :service do
         end
 
         let!(:content) do
-          "Monsieur John DOE,\nVotre rendez-vous de suivi avec votre référent de parcours" \
+          "Monsieur John DOE,\nVotre rendez-vous de suivi" \
             " dans le cadre de votre RSA a été annulé. " \
             "Pour plus d'informations, contactez le 0101010101."
         end
@@ -595,7 +406,7 @@ describe Notifications::SendSms, type: :service do
 
         let!(:content) do
           "Monsieur John DOE,\nVous êtes allocataire du RSA et à ce titre vous avez été convoqué(e) à un " \
-            "rendez-vous de suivi avec votre référent de parcours. " \
+            "rendez-vous de suivi. " \
             "Un travailleur social vous appellera le 20/12/2021 à " \
             "partir de 10:00 sur ce numéro. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
@@ -613,7 +424,7 @@ describe Notifications::SendSms, type: :service do
           end
 
           let!(:content) do
-            "Monsieur John DOE,\nVotre rendez-vous de suivi avec votre référent de parcours" \
+            "Monsieur John DOE,\nVotre rendez-vous de suivi" \
               " dans le cadre de votre RSA a été modifié. " \
               "Un travailleur social vous appellera le 20/12/2021 à " \
               "partir de 10:00 sur ce numéro. " \


### PR DESCRIPTION
Je fais une PR pour ajouter les 2 nouvelles catégories "RSA main tendue" et "RSA atelier collectif obligatoire".
J'en profite pour changer un petit peu les contenus des messages et y intégrer les `rdv_purpose` (anciennement `invitation_purpose`).