### PR TITLE
feat(invitations): Remove rdv purpose from sms

### DIFF
--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -8,8 +8,8 @@ module Invitations
     private
 
     def regular_invitation_content
-      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un #{rdv_title} " \
-        "afin de #{rdv_purpose}. Pour choisir la date et l'horaire du RDV, " \
+      "#{applicant.full_name},\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un #{rdv_title}." \
+        " Pour choisir la date et l'horaire du RDV, " \
         "cliquez sur le lien suivant dans les #{number_of_days_to_accept_invitation} jours: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "#{mandatory_warning}"\

--- a/app/views/mailers/invitation_mailer/regular_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/regular_invitation.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>Vous êtes bénéficiaire du RSA et vous devez vous présenter à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
+<p>Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
 <p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>:</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'orientation" \
+          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous d'orientation" \
           " afin de démarrer un parcours d'accompagnement"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
@@ -82,7 +82,7 @@ RSpec.describe InvitationMailer, type: :mailer do
           expect(body_string).to match("Le département de la Drôme.")
           expect(body_string).to match("01 39 39 39 39")
           expect(body_string).to match(
-            "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous d'accompagnement" \
+            "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous d'accompagnement" \
             " afin de démarrer un parcours d'accompagnement"
           )
           expect(body_string).to match("Ce rendez-vous est obligatoire.")
@@ -117,7 +117,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous de signature de CER "\
+          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous de signature de CER "\
           "afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
@@ -151,7 +151,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
+          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous "\
           "de suivi afin de faire un point avec votre référent de parcours"
         )
         expect(body_string).not_to match("Ce rendez-vous est obligatoire.")
@@ -185,7 +185,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un entretien de main tendue " \
+          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un entretien de main tendue " \
           "afin de faire le point sur votre situation"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
@@ -219,7 +219,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et vous devez vous présenter à un atelier collectif " \
+          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un atelier collectif " \
           "afin de vous aider dans votre parcours d'insertion"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -38,7 +38,7 @@ describe Invitations::SendSms, type: :service do
   let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_orientation") }
   let!(:content) do
     "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-      "d'orientation afin de démarrer un parcours d'accompagnement. "\
+      "d'orientation. "\
       "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
       "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
       "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le 0147200001."
@@ -83,7 +83,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration) }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous "\
-          "d'accompagnement afin de démarrer un parcours d'accompagnement." \
+          "d'accompagnement." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant "\
           "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
           "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
@@ -172,7 +172,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration, motif_category: "rsa_cer_signature") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un rendez-vous de signature de CER afin de construire et signer votre Contrat d'Engagement Réciproque." \
+          "un rendez-vous de signature de CER." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
@@ -216,7 +216,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration, motif_category: "rsa_main_tendue") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un entretien de main tendue afin de faire le point sur votre situation." \
+          "un entretien de main tendue." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
@@ -258,8 +258,7 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: "rsa_atelier_collectif_mandatory") }
       let!(:configuration) { create(:configuration, motif_category: "rsa_atelier_collectif_mandatory") }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un atelier collectif afin de vous aider dans votre parcours d'insertion." \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un atelier collectif." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\
@@ -323,7 +322,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration, motif_category: "rsa_follow_up") }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un rendez-vous de suivi afin de faire un point avec votre référent de parcours. " \
+          "un rendez-vous de suivi. " \
           "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n"\


### PR DESCRIPTION
J'enlève finalement le `rdv_purpose` du SMS d'invitation pour ne pas trop le rallonger. Il est présent dans le sms de rappel.
