### PR TITLE
refactor(webhook): Do not compact rdv-s attribute

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_user_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_user_job.rb
@@ -5,6 +5,7 @@ module RdvSolidaritesWebhooks
       @meta = meta.deep_symbolize_keys
       return if applicant.blank?
 
+      remove_affiliation_number_from_payload if affiliation_number.blank?
       upsert_or_delete_applicant
     end
 
@@ -18,8 +19,18 @@ module RdvSolidaritesWebhooks
       @data[:id]
     end
 
+    def affiliation_number
+      @data[:affiliation_number]
+    end
+
     def applicant
       @applicant ||= Applicant.find_by(rdv_solidarites_user_id: rdv_solidarites_user_id)
+    end
+
+    # if the affiliation number is nil in RDV-S following a user fusion, we cannot update to nil
+    # in RDV-I because we need it to keep it for the uid
+    def remove_affiliation_number_from_payload
+      @data.delete(:affiliation_number)
     end
 
     def upsert_or_delete_applicant

--- a/app/models/rdv_solidarites/user.rb
+++ b/app/models/rdv_solidarites/user.rb
@@ -2,7 +2,7 @@ module RdvSolidarites
   class User < Base
     RECORD_ATTRIBUTES = [
       :id, :first_name, :last_name, :birth_date, :email, :phone_number, :phone_number_formatted,
-      :birth_name, :address, :affiliation_number, :created_at, :invited_at, :invitation_accepted_at
+      :birth_name, :address, :affiliation_number
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 

--- a/app/services/upsert_record.rb
+++ b/app/services/upsert_record.rb
@@ -14,8 +14,6 @@ class UpsertRecord < BaseService
       record.assign_attributes(
         @rdv_solidarites_attributes
           .slice(*@klass::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
-          .compact
-          .transform_values(&:presence)
           .merge(@additional_attributes)
       )
       record.save! if record.changed?

--- a/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
@@ -8,7 +8,8 @@ describe RdvSolidaritesWebhooks::ProcessUserJob, type: :job do
       "id" => rdv_solidarites_user_id,
       "first_name" => "John",
       "last_name" => "Doe",
-      "phone_number_formatted" => "+33624242424"
+      "phone_number_formatted" => "+33624242424",
+      "affiliation_number" => "CAUCSCUAHSC"
     }.deep_symbolize_keys
   end
 
@@ -35,6 +36,17 @@ describe RdvSolidaritesWebhooks::ProcessUserJob, type: :job do
       expect(UpsertRecordJob).to receive(:perform_async)
         .with("Applicant", data, { last_webhook_update_received_at: timestamp })
       subject
+    end
+
+    context "when the affiliation number received is nil" do
+      before { data.merge!(affiliation_number: nil) }
+
+      it "enqueues an upsert record job without affiliation_number" do
+        formatted_data = data.except(:affiliation_number)
+        expect(UpsertRecordJob).to receive(:perform_async)
+          .with("Applicant", formatted_data, { last_webhook_update_received_at: timestamp })
+        subject
+      end
     end
 
     context "when the applicant is not found" do


### PR DESCRIPTION
Cette PR est liée à #619 .
J'enlève le fait de compacter automatiquement ce qu'on récupère des webhooks, et je gère le cas particulier des numéros d'allocataires nullifiés.