### PR TITLE
feat(motifs): Add follow up logic

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -1,6 +1,7 @@
 class Motif < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
-    :name, :deleted_at, :location_type, :name, :reservable_online, :rdv_solidarites_service_id, :category, :collectif
+    :name, :deleted_at, :location_type, :name, :reservable_online, :rdv_solidarites_service_id, :category, :collectif,
+    :follow_up
   ].freeze
   CATEGORIES_ENUM = {
     rsa_orientation: 0,

--- a/app/models/rdv_solidarites/motif.rb
+++ b/app/models/rdv_solidarites/motif.rb
@@ -1,7 +1,7 @@
 module RdvSolidarites
   class Motif < Base
     RECORD_ATTRIBUTES = [
-      :id, :deleted_at, :location_type, :name, :reservable_online, :service_id, :category, :collectif
+      :id, :deleted_at, :location_type, :name, :reservable_online, :service_id, :category, :collectif, :follow_up
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 

--- a/db/migrate/20221205153103_add_follow_up_to_motifs.rb
+++ b/db/migrate/20221205153103_add_follow_up_to_motifs.rb
@@ -1,0 +1,5 @@
+class AddFollowUpToMotifs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :motifs, :follow_up, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_01_093927) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_05_153103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -184,6 +184,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_01_093927) do
     t.bigint "organisation_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "follow_up", default: false
     t.index ["organisation_id"], name: "index_motifs_on_organisation_id"
     t.index ["rdv_solidarites_motif_id"], name: "index_motifs_on_rdv_solidarites_motif_id", unique: true
   end


### PR DESCRIPTION
Dans cette PR j'ajoute l'attribut `follow_up` aux motifs comme sur RDV-S et je vérifie au moment de l'invitation qu'un motif de suivi est définie pour la catégorie invitée.