### PR TITLE
fix(stat): uncache active record whe upserting stat

### DIFF
--- a/app/services/stats/upsert_stat.rb
+++ b/app/services/stats/upsert_stat.rb
@@ -16,7 +16,7 @@ module Stats
     end
 
     def assign_attributes_to_stat_record
-      stat.assign_attributes(compute_stats.data)
+      ActiveRecord::Base.uncached { stat.assign_attributes(compute_stats.data) }
     end
 
     def compute_stats


### PR DESCRIPTION
Le job d'upsert sur tous les départements ne s'exécute plus jusqu'au bout. On utilise probablement trop de ressources en gardant en mémoire des grosses collections active record.
J'essaie ici de désactiver le cache ActiveRecord au sein de la transaction pour consommer un peu moins de mémoire et voir si ça a un effet.