### PR TITLE
Fix(import) Bug d'import quand il n'y a pas de colonne role

### DIFF
--- a/app/services/applicants/save.rb
+++ b/app/services/applicants/save.rb
@@ -52,10 +52,10 @@ module Applicants
                                   .slice(*Applicant::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
                                   .transform_values(&:presence)
                                   .compact
-      return user_attributes if @applicant.demandeur?
+      return user_attributes if @applicant.demandeur? || @applicant.role.nil?
 
       # we do not send the email to rdv-s for the conjoint
-      user_attributes.except(:email)
+      user_attributes.except(:email) if @applicant.conjoint?
     end
   end
 end

--- a/spec/services/applicants/save_spec.rb
+++ b/spec/services/applicants/save_spec.rb
@@ -92,6 +92,21 @@ describe Applicants::Save, type: :service do
       end
     end
 
+    context "when the applicant has a department_internal_id but no role" do
+      before { applicant.update!(role: nil, department_internal_id: 666) }
+
+      it "creates the user normally, with the email" do
+        expect(UpsertRdvSolidaritesUser).to receive(:call)
+          .with(
+            rdv_solidarites_user_attributes: rdv_solidarites_user_attributes.except(:birth_name),
+            rdv_solidarites_session: rdv_solidarites_session,
+            rdv_solidarites_organisation_id: rdv_solidarites_organisation_id,
+            rdv_solidarites_user_id: nil
+          )
+        subject
+      end
+    end
+
     context "when the applicant is a conjoint" do
       before { applicant.update!(role: "conjoint") }
 


### PR DESCRIPTION
Suite au problème de doublon de la Manche #712  (qui était causé par l'absence de la colonne rôle). Les utilisateurs nous ont remonté un nouveau problème.
Il y a un bug lors du chargement d'un fichier d'allocataire sans colonne rôle.
Dans ce cas le service ne renvoi pas l'email à rdv-solidarites considérant l'absence de rôle comme un rôle conjoint.
Le retour du webhook created de l'usager dans rdv-solidarites efface l'email de l'applicant en DB côté rdv-insertion.

J'ai ajouté la bonne condition et un test.
Pour info, on a plus de 4000 allocataires sans rôles en DB de prod. C'est étonnant que ce bug n'est pas été remonté avant.