### PR TITLE
fix(webhooks): Do not update empty email from user webhook

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_user_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_user_job.rb
@@ -5,7 +5,7 @@ module RdvSolidaritesWebhooks
       @meta = meta.deep_symbolize_keys
       return if applicant.blank?
 
-      remove_affiliation_number_from_payload if affiliation_number.blank?
+      remove_attributes_from_payload
       upsert_or_delete_applicant
     end
 
@@ -23,14 +23,22 @@ module RdvSolidaritesWebhooks
       @data[:affiliation_number]
     end
 
+    def email
+      @data[:email]
+    end
+
     def applicant
       @applicant ||= Applicant.find_by(rdv_solidarites_user_id: rdv_solidarites_user_id)
     end
 
-    # if the affiliation number is nil in RDV-S following a user fusion, we cannot update to nil
-    # in RDV-I because we need it to keep it for the uid
-    def remove_affiliation_number_from_payload
-      @data.delete(:affiliation_number)
+    def remove_attributes_from_payload
+      # if the affiliation number is nil in RDV-S following a user fusion, we cannot update to nil
+      # in RDV-I because we need it to keep it for the uid.
+      @data.delete(:affiliation_number) if affiliation_number.blank?
+
+      # If a user is created without email in RDV-S, for the conjoint for example, we do not
+      # want the email to be nil in RDV-I or we cannot invite by email
+      @data.delete(:email) if email.blank?
     end
 
     def upsert_or_delete_applicant

--- a/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
@@ -9,7 +9,8 @@ describe RdvSolidaritesWebhooks::ProcessUserJob, type: :job do
       "first_name" => "John",
       "last_name" => "Doe",
       "phone_number_formatted" => "+33624242424",
-      "affiliation_number" => "CAUCSCUAHSC"
+      "affiliation_number" => "CAUCSCUAHSC",
+      "email" => "user@something.com"
     }.deep_symbolize_keys
   end
 
@@ -42,9 +43,20 @@ describe RdvSolidaritesWebhooks::ProcessUserJob, type: :job do
       before { data.merge!(affiliation_number: nil) }
 
       it "enqueues an upsert record job without affiliation_number" do
-        formatted_data = data.except(:affiliation_number)
+        filtered_data = data.except(:affiliation_number)
         expect(UpsertRecordJob).to receive(:perform_async)
-          .with("Applicant", formatted_data, { last_webhook_update_received_at: timestamp })
+          .with("Applicant", filtered_data, { last_webhook_update_received_at: timestamp })
+        subject
+      end
+    end
+
+    context "when the email received is nil" do
+      before { data.merge!(email: nil) }
+
+      it "enqueues an upsert record job without the email" do
+        filtered_data = data.except(:email)
+        expect(UpsertRecordJob).to receive(:perform_async)
+          .with("Applicant", filtered_data, { last_webhook_update_received_at: timestamp })
         subject
       end
     end


### PR DESCRIPTION
Lié à #727 .

Suite aux changements effectués dans #682 , les conjoints nouvellement créés n'ayant pas de mail sur RDV-S, le webhook reçu effaçait le mail présent sur RDV-I.
Je fais en sorte de ne pas mettre à jour l'email lorsque celui-ci n'est pas présent dans le payload.