### PR TITLE
feat(jsapp): Adapt upload logic to participations

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -272,7 +272,12 @@ class ApplicantsController < ApplicationController
   end
 
   def retrieve_applicants
-    @applicants = policy_scope(Applicant).preload(:organisations, :rdvs, :agents, invitations: [:rdv_context]).distinct
+    @applicants = policy_scope(Applicant).preload(
+      :rdvs, :agents,
+      rdv_contexts: [:participations],
+      invitations: :rdv_context,
+      organisations: [:department, :configurations]
+    ).distinct
     @applicants = @applicants
                   .where(department_internal_id: params.require(:applicants)[:department_internal_ids])
                   .or(@applicants.where(uid: params.require(:applicants)[:uids]))

--- a/app/javascript/react/components/applicant/InvitationCell.jsx
+++ b/app/javascript/react/components/applicant/InvitationCell.jsx
@@ -69,7 +69,7 @@ export default function InvitationCell({
             >
               {isTriggered[`${format}Invitation`]
                 ? "Invitation..."
-                : applicant.hasRdvs()
+                : applicant.hasParticipations()
                 ? CTA_BY_FORMAT[format].secondTime
                 : CTA_BY_FORMAT[format].firstTime}
             </button>

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -125,7 +125,7 @@ export default class Applicant {
       (rc) => rc.motif_category === this.currentMotifCategory
     );
     this.currentContextStatus = this.currentRdvContext && this.currentRdvContext.status;
-    this.rdvs = this.currentRdvContext?.rdvs || [];
+    this.participations = this.currentRdvContext?.participations || [];
     this.lastSmsInvitationSentAt = retrieveLastInvitationDate(
       upToDateApplicant.invitations,
       "sms",
@@ -212,17 +212,19 @@ export default class Applicant {
     );
   }
 
-  hasRdvs() {
-    return this.rdvs && this.rdvs.length > 0;
+  hasParticipations() {
+    return this.participations && this.participations.length > 0;
   }
 
-  sortedRdvsByCreationDate() {
-    return this.rdvs.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  sortedParticipationsByCreationDate() {
+    return this.participations.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
   }
 
-  lastRdvCreatedAt() {
-    return this.hasRdvs()
-      ? this.sortedRdvsByCreationDate()[this.sortedRdvsByCreationDate().length - 1].created_at
+  lastParticipationCreatedAt() {
+    return this.hasParticipations()
+      ? this.sortedParticipationsByCreationDate()[
+          this.sortedParticipationsByCreationDate().length - 1
+        ].created_at
       : null;
   }
 
@@ -274,7 +276,8 @@ export default class Applicant {
     const lastInvitationDate = this.lastInvitationDate(format);
     return (
       lastInvitationDate &&
-      (!this.hasRdvs() || new Date(lastInvitationDate) > new Date(this.lastRdvCreatedAt()))
+      (!this.hasParticipations() ||
+        new Date(lastInvitationDate) > new Date(this.lastParticipationCreatedAt()))
     );
   }
 

--- a/app/models/rdv_context.rb
+++ b/app/models/rdv_context.rb
@@ -47,7 +47,7 @@ class RdvContext < ApplicationRecord
   def as_json(_opts = {})
     super.merge(
       human_status: I18n.t("activerecord.attributes.rdv_context.statuses.#{status}"),
-      rdvs: rdvs
+      participations: participations
     )
   end
 end


### PR DESCRIPTION
Dans cette PR je prends en compte les participations liées aux `rdv_contexts` plutôt que les rdvs suite à #713  dans la partie `react` liée à l'upload de fichier de nouveaux entrants.