### PR TITLE
feat(invitations): add variable for external organisations

### DIFF
--- a/db/migrate/20230117094244_add_external_to_organisations.rb
+++ b/db/migrate/20230117094244_add_external_to_organisations.rb
@@ -1,5 +1,0 @@
-class AddExternalToOrganisations < ActiveRecord::Migration[7.0]
-  def change
-    add_column :organisations, :external, :boolean, default: false
-  end
-end

--- a/db/migrate/20230117094244_add_external_to_organisations.rb
+++ b/db/migrate/20230117094244_add_external_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddExternalToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :external, :boolean, default: false
+  end
+end

--- a/db/migrate/20230117094244_add_independent_from_cd_to_organisations.rb
+++ b/db/migrate/20230117094244_add_independent_from_cd_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddIndependentFromCdToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organisations, :independent_from_cd, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_094244) do
     t.bigint "messages_configuration_id"
     t.datetime "last_webhook_update_received_at"
     t.string "slug"
-    t.boolean "external", default: false
+    t.boolean "independent_from_cd", default: false
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["messages_configuration_id"], name: "index_organisations_on_messages_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_14_091609) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_17_094244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -202,6 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_14_091609) do
     t.bigint "messages_configuration_id"
     t.datetime "last_webhook_update_received_at"
     t.string "slug"
+    t.boolean "external", default: false
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["messages_configuration_id"], name: "index_organisations_on_messages_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true


### PR DESCRIPTION
close issue #741 
permet la réalisation de #751 
- ajout d'une nouvelle colonne `external` sur la table `organisations`, sous forme de booléen, afin de déterminer si une organisation est externe au département ou non. Par défault, la valeur est fixée à `false`