### PR TITLE
feat(invitations): change logos display for letters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,6 +387,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-17
   x86_64-linux
 

--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -1,3 +1,5 @@
+// note: flexbox is not working with wkhtmltopdf/wicked-pdf ; hence, the dirty css to keep everything centered/aligned
+
 @font-face {
   font-family: 'Marianne';
   src: url('../fonts/Marianne/Marianne-Regular.woff');
@@ -12,60 +14,27 @@ u {
   white-space: nowrap;
 }
 
-.left-col {
+.header-left-col {
   display: inline-block;
   width: 40%;
   margin-right: 140px;
 }
 
-.right-col {
+.header-right-col {
   display: inline-block;
   width: 40%;
 }
 
-.letter-first-col {
-  display: inline-block;
-  width: 15%;
-  margin-right: 0px;
-  padding-right: 0px;
-}
-
-.letter-second-col {
-  display: inline-block;
-  width: 15%;
-  margin-left: 0px;
-  padding-left: 0px;
-  margin-right: 80px;
-}
-
-.letter-third-col {
-  display: inline-block;
-  width: 20%;
-  margin-right: 80px;
-}
-
-.letter-fourth-col {
-  display: inline-block;
-  width: 30%;
-}
-
-.letter-logo {
-  &.header-logo {
-    position: absolute;
-    top: 0;
-    width: 40%;
-  }
+.header-logo {
+  position: absolute;
+  top: 0;
+  width: 40%;
   img {
     height: 80px;
     border: none;
     display: block;
     margin: 0 auto;
   }
-}
-
-
-.rdvi-logo {
-  height: 80px;
 }
 
 .mail-object {
@@ -111,4 +80,50 @@ u {
   position: absolute;
   top: 1230px;
   width: 100%;
+
+  // the "first-child:nth-last-child" tricks are used to have logos grossly centered
+  div {
+    display: inline-block;
+    // no europe logos & no organisation logo
+    &:first-child:nth-last-child(2),
+    &:first-child:nth-last-child(2) ~ div {
+      margin: 0 110px;
+    }
+    // no europe logos ; organisation & department logos displayed
+    &:first-child:nth-last-child(3),
+    &:first-child:nth-last-child(3) ~ div {
+      margin: 0 40px;
+    }
+    // europe logos displayed ; no organisation logo
+    &:first-child:nth-last-child(4) ~ div {
+      margin-right: 120px;
+    // europe, organisation & department logos displayed
+    }
+    &:first-child:nth-last-child(5) ~ div {
+      margin-right: 20px;
+      img {
+        height: 60px;
+      }
+    }
+
+    // keep both europe logos glued together
+    &.europe-logos:first-child {
+      margin-right: 0px;
+      padding-right: 0px;
+    }
+    &.europe-logos:last-child {
+      margin-left: 0px;
+      padding-left: 0px;
+    }
+
+    &:last-child {
+      height: 65px;
+      width: 25%;
+      margin-right: 0px !important;
+    }
+  }
+
+  img {
+    height: 65px;
+  }
 }

--- a/app/models/concerns/sendable.rb
+++ b/app/models/concerns/sendable.rb
@@ -4,7 +4,8 @@ module Sendable
   delegate :email, :phone_number, :phone_number_formatted, :phone_number_is_mobile?,
            :address, :street_address, :zipcode_and_city,
            to: :applicant
-  delegate :signature_lines, :sender_city, :help_address, :display_europe_logos, :direction_names,
+  delegate :signature_lines, :sender_city, :help_address, :display_europe_logos, :display_department_logo,
+           :direction_names,
            to: :messages_configuration, allow_nil: true
 
   def sms_sender_name

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -7,7 +7,7 @@ module Invitations
     delegate :applicant, :department, :motif_category, :messages_configuration,
              :letter_sender_name, :address, :street_address, :zipcode_and_city,
              :signature_lines, :display_europe_logos, :direction_names, :help_address,
-             :sender_city,
+             :sender_city, :display_department_logo,
              to: :invitation
 
     def initialize(invitation:)
@@ -59,6 +59,7 @@ module Invitations
         signature_lines: signature_lines,
         help_address: help_address,
         display_europe_logos: display_europe_logos,
+        display_department_logo: display_department_logo,
         sender_city: sender_city
       }
       return locals if template_exists_for_motif_category?
@@ -72,7 +73,7 @@ module Invitations
     end
 
     def template_exists_for_motif_category?
-      ApplicationController.new.template_exists?("invitation_for_#{@invitation.motif_category}", ["letters"], false)
+      ApplicationController.new.template_exists?("invitation_for_#{@invitation.motif_category}", ["letters"])
     end
 
     def check_messages_configuration!

--- a/app/views/letters/_footer.html.erb
+++ b/app/views/letters/_footer.html.erb
@@ -1,23 +1,23 @@
 <div class="letter-footer">
   <% if display_europe_logos == true %>
-    <div class="letter-first-col letter-logo">
+    <div class="europe-logos">
       <%= pdf_image_tag(logo_path("europe-s-engage")) %>
     </div>
-    <div class="letter-second-col letter-logo">
+    <div class="europe-logos">
       <%= pdf_image_tag(logo_path("drapeau-europe")) %>
     </div>
-    <div class="letter-third-col letter-logo">
-      <%= pdf_image_tag(organisation.logo_path || department.logo_path) %>
-    </div>
-    <div class="letter-fourth-col rdvi-logo">
-      <%= pdf_image_tag(logo_path("rdv-insertion")) %>
-    </div>
-  <% else %>
-    <div class="left-col letter-logo">
-      <%= pdf_image_tag(organisation.logo_path || department.logo_path) %>
-    </div>
-    <div class="right-col rdvi-logo">
-      <%= pdf_image_tag(logo_path("rdv-insertion")) %>
+  <% end %>
+  <% if display_department_logo == true || organisation.logo_path.nil? %>
+    <div>
+      <%= pdf_image_tag(department.logo_path) %>
     </div>
   <% end %>
+  <% if organisation.logo_path.present? %>
+    <div>
+      <%= pdf_image_tag(organisation.logo_path) %>
+    </div>
+  <% end %>
+  <div>
+    <%= pdf_image_tag(logo_path("rdv-insertion")) %>
+  </div>
 </div>

--- a/app/views/letters/_footer.html.erb
+++ b/app/views/letters/_footer.html.erb
@@ -1,5 +1,5 @@
 <div class="letter-footer">
-  <% if display_europe_logos == true %>
+  <% if display_europe_logos %>
     <div class="europe-logos">
       <%= pdf_image_tag(logo_path("europe-s-engage")) %>
     </div>
@@ -7,7 +7,7 @@
       <%= pdf_image_tag(logo_path("drapeau-europe")) %>
     </div>
   <% end %>
-  <% if display_department_logo == true || organisation.logo_path.nil? %>
+  <% if display_department_logo || organisation.logo_path.nil? %>
     <div>
       <%= pdf_image_tag(department.logo_path) %>
     </div>

--- a/app/views/letters/_header.html.erb
+++ b/app/views/letters/_header.html.erb
@@ -1,7 +1,7 @@
 <div>
-  <div class="left-col">
+  <div class="header-left-col">
     <div>
-      <div class="letter-logo header-logo">
+      <div class="header-logo">
         <%= pdf_image_tag(organisation.logo_path || department.logo_path) %>
       </div>
     </div>
@@ -9,7 +9,7 @@
       <p><%= direction_name.upcase %></p>
     <% end %>
   </div>
-  <div class="right-col">
+  <div class="header-right-col">Ò
     <p><%= sender_city || department.capital %>, le <%= Date.today.strftime('%d/%m/%Y') %></p>
     <br/>
     <p>À l'attention de</p>

--- a/app/views/letters/_header.html.erb
+++ b/app/views/letters/_header.html.erb
@@ -9,7 +9,7 @@
       <p><%= direction_name.upcase %></p>
     <% end %>
   </div>
-  <div class="header-right-col">Ò
+  <div class="header-right-col">
     <p><%= sender_city || department.capital %>, le <%= Date.today.strftime('%d/%m/%Y') %></p>
     <br/>
     <p>À l'attention de</p>

--- a/app/views/letters/invitation_for_rsa_insertion_offer.html.erb
+++ b/app/views/letters/invitation_for_rsa_insertion_offer.html.erb
@@ -17,4 +17,4 @@
     <%= render 'common/organisation_signature', signature_lines: signature_lines, department: department %>
   </div>
 </div>
-<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: display_europe_logos %>
+<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: display_europe_logos, display_department_logo: display_department_logo %>

--- a/app/views/letters/invitation_for_rsa_orientation_on_phone_platform.html.erb
+++ b/app/views/letters/invitation_for_rsa_orientation_on_phone_platform.html.erb
@@ -18,5 +18,5 @@
     <%= render 'common/organisation_signature', signature_lines: signature_lines, department: department %>
   </div>
 </div>
-<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: display_europe_logos %>
+<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: display_europe_logos, display_department_logo: display_department_logo %>
 

--- a/app/views/letters/regular_invitation.html.erb
+++ b/app/views/letters/regular_invitation.html.erb
@@ -25,4 +25,4 @@
     <%= render 'common/organisation_signature', signature_lines: signature_lines, department: department %>
   </div>
 </div>
-<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: display_europe_logos %>
+<%= render 'letters/footer', department: department, organisation: organisation, display_europe_logos: display_europe_logos, display_department_logo: display_department_logo %>

--- a/db/migrate/20230117114011_add_display_department_logo_to_messages_configurations.rb
+++ b/db/migrate/20230117114011_add_display_department_logo_to_messages_configurations.rb
@@ -1,0 +1,5 @@
+class AddDisplayDepartmentLogoToMessagesConfigurations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :messages_configurations, :display_department_logo, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -203,7 +203,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_114011) do
     t.bigint "messages_configuration_id"
     t.datetime "last_webhook_update_received_at"
     t.string "slug"
-    t.boolean "independent_from_cd", default: false
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["messages_configuration_id"], name: "index_organisations_on_messages_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -203,6 +203,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_114011) do
     t.bigint "messages_configuration_id"
     t.datetime "last_webhook_update_received_at"
     t.string "slug"
+    t.boolean "independent_from_cd", default: false
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["messages_configuration_id"], name: "index_organisations_on_messages_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_17_114011) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_17_094244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -158,7 +158,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_114011) do
     t.string "help_address"
     t.boolean "display_europe_logos", default: false
     t.string "sms_sender_name"
-    t.boolean "display_department_logo", default: true
   end
 
   create_table "motifs", force: :cascade do |t|
@@ -203,7 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_114011) do
     t.bigint "messages_configuration_id"
     t.datetime "last_webhook_update_received_at"
     t.string "slug"
-    t.boolean "external", default: false
+    t.boolean "independent_from_cd", default: false
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["messages_configuration_id"], name: "index_organisations_on_messages_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_14_091609) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_17_114011) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -158,6 +158,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_14_091609) do
     t.string "help_address"
     t.boolean "display_europe_logos", default: false
     t.string "sms_sender_name"
+    t.boolean "display_department_logo", default: true
   end
 
   create_table "motifs", force: :cascade do |t|
@@ -202,6 +203,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_14_091609) do
     t.bigint "messages_configuration_id"
     t.datetime "last_webhook_update_received_at"
     t.string "slug"
+    t.boolean "external", default: false
     t.index ["department_id"], name: "index_organisations_on_department_id"
     t.index ["messages_configuration_id"], name: "index_organisations_on_messages_configuration_id"
     t.index ["rdv_solidarites_organisation_id"], name: "index_organisations_on_rdv_solidarites_organisation_id", unique: true

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -30,8 +30,8 @@ describe Invitations::GenerateLetter, type: :service do
       expect(content).to include(invitation.uuid)
       expect(content).to include(department.name)
       expect(content).to include("Vous êtes allocataire du Revenu de Solidarité Active (RSA)")
-      # letter-first-col is only used when display_europe_logos is true (false by default)
-      expect(content).not_to include("letter-first-col")
+      # europe-logos is only used when display_europe_logos is true (false by default)
+      expect(content).not_to include("europe-logos")
     end
 
     context "when the signature is configured" do
@@ -48,8 +48,8 @@ describe Invitations::GenerateLetter, type: :service do
 
       it "generates the pdf string with the europe logos" do
         subject
-        # letter-first-col is only used when display_europe_logos is true
-        expect(invitation.content).to include("letter-first-col")
+        # europe-logos is only used when display_europe_logos is true
+        expect(invitation.content).to include("europe-logos")
       end
     end
 


### PR DESCRIPTION
close issue #752 
Dans cette PR, je change les règles d'affichage des logos dans le footer des lettres : 
- ajout d'une colonne `display_department_logo` sur la table `messages_configuration` ; valeur par défaut `true`
- le logo du département est affiché dans tous les cas si le logo de l'organisation n'est pas en base
- le logo de l'organisation est affiché dans tous les cas s'il est en base
- simplification du html + ajout de commentaires pour rendre le css plus lisible