### PR TITLE
feat(invitations): change letters texts

### DIFF
--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -54,6 +54,7 @@ module Invitations
         department: department,
         applicant: applicant,
         organisation: organisation,
+        organisation_independent_from_cd: organisation_independent_from_cd,
         sender_name: letter_sender_name,
         direction_names: direction_names,
         signature_lines: signature_lines,
@@ -84,6 +85,10 @@ module Invitations
 
     def organisation
       (applicant.organisations & @invitation.organisations).last
+    end
+
+    def organisation_independent_from_cd
+      @invitation.organisations.any?(&:independent_from_cd)
     end
   end
 end

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -88,7 +88,7 @@ module Invitations
     end
 
     def organisation_independent_from_cd
-      @invitation.organisations.any?(&:independent_from_cd)
+      @invitation.organisations.all?(&:independent_from_cd)
     end
   end
 end

--- a/app/views/letters/_help_message.html.erb
+++ b/app/views/letters/_help_message.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Si vous rencontrez une difficulté pour accéder à internet, veuillez téléphoner dès réception de ce courrier au <%= invitation.help_phone_number_formatted %>
+  Si vous rencontrez une difficulté pour accéder à internet, veuillez téléphoner dès réception de ce courrier au <%= invitation.help_phone_number_formatted %>.
   <% if help_address.present? %>
     ou vous rendre <%= help_address %>.
   <% end %>

--- a/app/views/letters/_punishable_warning.html.erb
+++ b/app/views/letters/_punishable_warning.html.erb
@@ -1,0 +1,9 @@
+<span class="bold-blue">
+  En l’absence d’action de votre part,
+  <% if organisation_independent_from_cd %>
+      nous serons dans l’obligation d’en informer le Conseil Départemental <%= t("with_prefix.#{department.pronoun}", name: department.name) %> qui
+  <% else %>
+      le département
+  <% end %>
+  jugera des suites à réserver à votre dossier ; la sanction peut aller jusqu’à une suspension ou une réduction du versement de votre RSA.
+</span>

--- a/app/views/letters/regular_invitation.html.erb
+++ b/app/views/letters/regular_invitation.html.erb
@@ -13,10 +13,10 @@
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
   <p>
     <% if display_mandatory_warning %>
-      Vous devez obligatoirement prendre ce rendez-vous <span class="bold-blue">dans un délai de <%= invitation.number_of_days_to_accept_invitation %> jours</span> à réception de ce courrier.
+      Nous vous remercions de prendre ce rendez-vous dans un délai de <%= invitation.number_of_days_to_accept_invitation %> jours à réception de ce courrier.
     <% end %>
     <% if display_punishable_warning %>
-      <span class="bold-blue">En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA.</span>
+      <%= render 'letters/punishable_warning', department: department, organisation_independent_from_cd: organisation_independent_from_cd %>
     <% end %>
   </p>
   <%= render 'letters/help_message', invitation: invitation, help_address: help_address %>

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -72,9 +72,9 @@ describe Invitations::GenerateLetter, type: :service do
         content = unescape_html(invitation.content)
         expect(content).to include("Objet : Rendez-vous d'orientation dans le cadre de votre RSA")
         expect(content).to include("vous devez prendre un rendez-vous afin de démarrer un parcours d'accompagnement")
-        expect(content).to include("Vous devez obligatoirement prendre ce rendez-vous")
+        expect(content).to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).not_to include(
-          "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
+          "la sanction peut aller jusqu’à une suspension ou une réduction du versement de votre RSA."
         )
       end
     end
@@ -87,10 +87,23 @@ describe Invitations::GenerateLetter, type: :service do
         content = unescape_html(invitation.content)
         expect(content).to include("Objet : Rendez-vous d'accompagnement dans le cadre de votre RSA")
         expect(content).to include("vous devez prendre un rendez-vous afin de démarrer un parcours d'accompagnement")
-        expect(content).to include("Vous devez obligatoirement prendre ce rendez-vous")
+        expect(content).to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).to include(
-          "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
+          "la sanction peut aller jusqu’à une suspension ou une réduction du versement de votre RSA."
         )
+      end
+
+      context "when the organisation is independent from the cd" do
+        let!(:organisation) do
+          create(:organisation, messages_configuration: messages_configuration,
+                                department: department, independent_from_cd: true)
+        end
+
+        it "generates the pdf with the right content" do
+          subject
+          content = unescape_html(invitation.content)
+          expect(content).to include("nous serons dans l’obligation d’en informer le Conseil Départemental")
+        end
       end
     end
 
@@ -106,9 +119,9 @@ describe Invitations::GenerateLetter, type: :service do
         expect(content).to include(
           "vous devez prendre un rendez-vous afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
-        expect(content).to include("Vous devez obligatoirement prendre ce rendez-vous")
+        expect(content).to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).not_to include(
-          "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
+          "la sanction peut aller jusqu’à une suspension ou une réduction du versement de votre RSA."
         )
       end
     end
@@ -125,9 +138,9 @@ describe Invitations::GenerateLetter, type: :service do
         expect(content).to include(
           "vous devez prendre un rendez-vous afin de faire un point avec votre référent de parcours"
         )
-        expect(content).not_to include("Vous devez obligatoirement prendre ce rendez-vous")
+        expect(content).not_to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).not_to include(
-          "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
+          "la sanction peut aller jusqu’à une suspension ou une réduction du versement de votre RSA."
         )
       end
     end
@@ -145,9 +158,9 @@ describe Invitations::GenerateLetter, type: :service do
           "Pour profiter au mieux de cet accompagnement, nous vous invitons à vous inscrire directement" \
           " et librement aux ateliers et formations de votre choix"
         )
-        expect(content).not_to include("Vous devez obligatoirement prendre ce rendez-vous")
+        expect(content).not_to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).not_to include(
-          "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
+          "la sanction peut aller jusqu’à une suspension ou une réduction du versement de votre RSA."
         )
       end
     end


### PR DESCRIPTION
close issue #751 
Dans cette PR : 
- on remplace (dans tous les cas) : "Vous êtes allocataire du RSA" par "Vous êtes [type de public]" : déjà fait dans la PR #747 
- on remplace (dans tous les cas) "Vous devez obligatoirement prendre rendez-vous dans un délai de 3 jours à réception de ce courrier" par "Nous vous remercions de prendre rendez-vous dans un délai de 3 jours à réception de ce courrier" ✅
- le texte menaçant d'une sanction (extrait dans une partial `punishable_warning`) change si l'organisation émetrice est `external_from_cd` ✅
- en cas d'invitation liée à plusieurs organisations (si l'invitation est envoyée depuis "toutes les organisations"), pour déterminer quel `punishable_warning` afficher : si elle est liée à au moins une organisation interne au département, alors on utilise le texte interne au departement ; sinon, on utilise l'autre. ✅
