### PR TITLE
fix(status): set rdv_seen status when last created participation is seen

### DIFF
--- a/app/models/concerns/rdv_context_status.rb
+++ b/app/models/concerns/rdv_context_status.rb
@@ -52,7 +52,7 @@ module RdvContextStatus
   def status_from_participations
     if participations.any?(&:pending?)
       :rdv_pending
-    elsif seen_rdv_after_last_created_participation?
+    elsif last_created_participation.seen? || seen_rdv_after_last_created_participation?
       :rdv_seen
     elsif multiple_cancelled_participations?
       :multiple_rdvs_cancelled

--- a/spec/models/rdv_context_spec.rb
+++ b/spec/models/rdv_context_spec.rb
@@ -103,6 +103,23 @@ describe RdvContext do
             end
           end
 
+          context "when the last created participation is seen" do
+            let!(:rdv) { create(:rdv, starts_at: 4.days.ago) }
+            let!(:participation) do
+              create(
+                :participation,
+                created_at: 1.day.ago, rdv: rdv, applicant: applicant, rdv_context: rdv_context, status: "seen"
+              )
+            end
+            let!(:other_participation) do
+              create(:participation, created_at: 2.days.ago, rdv_context: rdv_context, status: "revoked")
+            end
+
+            it "is the status of the participation" do
+              expect(subject).to eq(:rdv_seen)
+            end
+          end
+
           context "cancelled participation created after the seen participation but before the start of the seen rdv" do
             let!(:rdv) { create(:rdv, starts_at: 1.day.ago) }
             let!(:participation) do


### PR DESCRIPTION
Suite au changement sur la façon de mettre à jour le statut dans #774 , je n'ai pas pris en compte les cas où un rdv était créé dans le passé puis honoré.
Cette PR remédie à cela.