### PR TITLE
feat(app): Enable agent to add and remove applicants from orgs

### DIFF
--- a/app/clients/rdv_solidarites_client.rb
+++ b/app/clients/rdv_solidarites_client.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class RdvSolidaritesClient
   def initialize(rdv_solidarites_session:)
     @rdv_solidarites_session = rdv_solidarites_session
@@ -48,6 +49,14 @@ class RdvSolidaritesClient
     Faraday.post(
       "#{@url}/api/v1/user_profiles",
       { user_id: user_id, organisation_id: organisation_id }.to_json,
+      request_headers
+    )
+  end
+
+  def delete_user_profile(user_id, organisation_id)
+    Faraday.delete(
+      "#{@url}/api/v1/user_profiles",
+      { user_id: user_id, organisation_id: organisation_id },
       request_headers
     )
   end
@@ -137,3 +146,4 @@ class RdvSolidaritesClient
     }
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -16,7 +16,7 @@ class ApplicantsController < ApplicationController
                 :set_current_motif_category, :set_applicants, :set_rdv_contexts,
                 :filter_applicants, :order_applicants, only: [:index]
   before_action :set_organisations, only: [:new, :create]
-  before_action :set_applicant_rdv_contexts, :set_can_be_added_to_other_org, :set_back_to_list_url, only: [:show]
+  before_action :set_applicant_rdv_contexts, :set_back_to_list_url, only: [:show]
   before_action :retrieve_applicants, only: [:search]
   after_action :store_back_to_list_url, only: [:index]
 
@@ -201,10 +201,6 @@ class ApplicantsController < ApplicationController
       ).where(
         applicant: @applicant, motif_category: @all_configurations.map(&:motif_category)
       ).in_order_of(:motif_category, Motif::CHRONOLOGICALLY_SORTED_CATEGORIES)
-  end
-
-  def set_can_be_added_to_other_org
-    @can_be_added_to_other_org = (@department.organisation_ids - @applicant.organisation_ids).any?
   end
 
   def set_applicants

--- a/app/controllers/applicants_organisations_controller.rb
+++ b/app/controllers/applicants_organisations_controller.rb
@@ -9,6 +9,9 @@ class ApplicantsOrganisationsController < ApplicationController
   def create
     @success = save_applicant.success?
     @errors = save_applicant.errors
+
+    # in this case we need to refresh the page in case there are new rdv contexts
+    redirect_to_department_applicant_path if @success && !@current_organisation
   end
 
   def destroy
@@ -60,6 +63,13 @@ class ApplicantsOrganisationsController < ApplicationController
 
   def redirect_to_applicants_list
     redirect_to session[:back_to_list_url] || department_applicants_path(@department)
+  end
+
+  def redirect_to_department_applicant_path
+    redirect_to(
+      department_applicant_path(@department, @applicant),
+      flash: { success: "L'organisation a bien été ajoutée" }
+    )
   end
 
   def applicant_deleted_or_removed_from_current_org?

--- a/app/controllers/applicants_organisations_controller.rb
+++ b/app/controllers/applicants_organisations_controller.rb
@@ -1,51 +1,83 @@
 class ApplicantsOrganisationsController < ApplicationController
-  before_action :set_applicant, :set_department, :set_organisations, only: [:new, :create]
-  before_action :set_organisation, only: [:create]
+  before_action :set_applicant, :set_department, :set_organisations, :set_current_organisation,
+                only: [:index, :create, :destroy]
+  before_action :set_organisation_to_add, only: [:create]
+  before_action :set_organisation_to_remove, only: [:destroy]
 
-  def new; end
+  def index; end
 
   def create
-    if save_applicant.success?
-      respond_to do |format|
-        format.turbo_stream
-      end
-    else
-      flash[:error] = save_applicant.errors&.join(", ")
-      redirect_to department_applicant_path(@department, @applicant)
-    end
+    @success = save_applicant.success?
+    @errors = save_applicant.errors
+  end
+
+  def destroy
+    @success = remove_applicant_from_org.success?
+    @errors = remove_applicant_from_org.errors
+    redirect_to_applicants_list if applicant_deleted_or_removed_from_current_org?
   end
 
   private
 
-  def applicants_organisations
-    (@applicant.organisations.to_a + [@organisation]).uniq
+  def applicants_organisation_params
+    params.require(:applicants_organisation).permit(:organisation_id, :applicant_id)
   end
 
-  def applicants_organisation_params
-    params.require(:applicants_organisation).permit(:organisation_id)
+  def applicant_id
+    params[:applicant_id] || applicants_organisation_params[:applicant_id]
   end
 
   def set_applicant
-    @applicant = policy_scope(Applicant).find(params[:applicant_id])
-    authorize @applicant
+    @applicant = policy_scope(Applicant).find(applicant_id)
   end
 
   def set_department
     @department = policy_scope(Department).find(params[:department_id])
   end
 
-  def set_organisation
-    @organisation = Organisation.find(applicants_organisation_params[:organisation_id])
+  def set_organisation_to_add
+    @organisation_to_add = @department.organisations.find(applicants_organisation_params[:organisation_id])
+  end
+
+  def set_organisation_to_remove
+    @organisation_to_remove = @department.organisations.find(applicants_organisation_params[:organisation_id])
+  end
+
+  # this lets us know from which organisation we are seeing the applicant if we are at the org level
+  def set_current_organisation
+    return unless params[:current_organisation_id]
+
+    @current_organisation = policy_scope(Organisation).find(params[:current_organisation_id])
   end
 
   def set_organisations
-    @organisations = @department.organisations - @applicant.organisations
+    @organisations = @department.organisations
+  end
+
+  def set_applicant_organisations
+    @applicant_organisations = @applicant.reload.organisations
+  end
+
+  def redirect_to_applicants_list
+    redirect_to session[:back_to_list_url] || department_applicants_path(@department)
+  end
+
+  def applicant_deleted_or_removed_from_current_org?
+    @applicant.deleted? || @organisation_to_remove == @current_organisation
   end
 
   def save_applicant
     @save_applicant ||= Applicants::Save.call(
       applicant: @applicant,
-      organisation: @organisation,
+      organisation: @organisation_to_add,
+      rdv_solidarites_session: rdv_solidarites_session
+    )
+  end
+
+  def remove_applicant_from_org
+    @remove_applicant_from_org ||= Applicants::RemoveFromOrganisation.call(
+      applicant: @applicant,
+      organisation: @organisation_to_remove,
       rdv_solidarites_session: rdv_solidarites_session
     )
   end

--- a/app/jobs/rdv_solidarites_webhooks/process_agent_role_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_agent_role_job.rb
@@ -40,7 +40,7 @@ module RdvSolidaritesWebhooks
     end
 
     def remove_from_org
-      agent.delete_organisation(organisation)
+      agent.delete_organisation(organisation) if agent.organisation_ids.include?(organisation.id)
     end
   end
 end

--- a/app/jobs/rdv_solidarites_webhooks/process_user_profile_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_user_profile_job.rb
@@ -6,7 +6,7 @@ module RdvSolidaritesWebhooks
       return if applicant.blank? || organisation.blank?
 
       attach_applicant_to_org if event == "created"
-      mark_applicant_as_deleted if event == "destroyed"
+      remove_applicant_from_organisation if event == "destroyed"
     end
 
     private
@@ -35,12 +35,9 @@ module RdvSolidaritesWebhooks
       applicant.organisations << organisation unless applicant.organisation_ids.include?(organisation.id)
     end
 
-    def mark_applicant_as_deleted
-      if applicant.organisations.length > 1
-        applicant.delete_organisation(organisation)
-      else
-        SoftDeleteApplicantJob.perform_async(rdv_solidarites_user_id)
-      end
+    def remove_applicant_from_organisation
+      applicant.delete_organisation(organisation) if applicant.organisation_ids.include?(organisation.id)
+      SoftDeleteApplicantJob.perform_async(rdv_solidarites_user_id) if applicant.organisations.empty?
     end
   end
 end

--- a/app/jobs/soft_delete_applicant_job.rb
+++ b/app/jobs/soft_delete_applicant_job.rb
@@ -1,15 +1,9 @@
 class SoftDeleteApplicantJob < ApplicationJob
   def perform(rdv_solidarites_user_id)
     applicant = Applicant.find_by(rdv_solidarites_user_id: rdv_solidarites_user_id)
-    return if applicant.blank?
+    return if applicant.blank? || applicant.deleted?
 
-    applicant.update_columns(
-      deleted_at: Time.zone.now,
-      affiliation_number: nil,
-      role: nil,
-      uid: nil,
-      department_internal_id: nil
-    )
+    applicant.soft_delete
     MattermostClient.send_to_notif_channel(
       "RDV Solidarites user #{rdv_solidarites_user_id} deleted"
     )

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class Applicant < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
     :first_name, :last_name, :birth_date, :email, :phone_number, :address, :affiliation_number, :birth_name
@@ -113,6 +114,16 @@ class Applicant < ApplicationRecord
     archived_at.present?
   end
 
+  def soft_delete
+    update_columns(
+      deleted_at: Time.zone.now,
+      affiliation_number: nil,
+      role: nil,
+      uid: nil,
+      department_internal_id: nil
+    )
+  end
+
   def as_json(_opts = {})
     super.merge(
       created_at: created_at,
@@ -150,3 +161,4 @@ class Applicant < ApplicationRecord
     address&.match(/^(.+) (\d{5}.*)$/m)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/policies/organisation_assignation_policy.rb
+++ b/app/policies/organisation_assignation_policy.rb
@@ -1,0 +1,1 @@
+organisation_assignation_policy.rb

--- a/app/policies/organisation_assignation_policy.rb
+++ b/app/policies/organisation_assignation_policy.rb
@@ -1,1 +1,0 @@
-organisation_assignation_policy.rb

--- a/app/services/applicants/remove_from_organisation.rb
+++ b/app/services/applicants/remove_from_organisation.rb
@@ -1,0 +1,28 @@
+module Applicants
+  class RemoveFromOrganisation < BaseService
+    def initialize(applicant:, organisation:, rdv_solidarites_session:)
+      @applicant = applicant
+      @organisation = organisation
+      @rdv_solidarites_session = rdv_solidarites_session
+    end
+
+    def call
+      Applicant.transaction do
+        @applicant.organisations.delete(@organisation)
+        delete_rdv_solidarites_user_profile
+        @applicant.soft_delete if @applicant.organisations.empty?
+      end
+    end
+
+    private
+
+    def delete_rdv_solidarites_user_profile
+      @delete_rdv_solidarites_user_profile ||= call_service!(
+        RdvSolidaritesApi::DeleteUserProfile,
+        user_id: @applicant.rdv_solidarites_user_id,
+        organisation_id: @organisation.rdv_solidarites_organisation_id,
+        rdv_solidarites_session: @rdv_solidarites_session
+      )
+    end
+  end
+end

--- a/app/services/rdv_solidarites_api/delete_user_profile.rb
+++ b/app/services/rdv_solidarites_api/delete_user_profile.rb
@@ -1,0 +1,19 @@
+module RdvSolidaritesApi
+  class DeleteUserProfile < Base
+    def initialize(user_id:, organisation_id:, rdv_solidarites_session:)
+      @user_id = user_id
+      @organisation_id = organisation_id
+      @rdv_solidarites_session = rdv_solidarites_session
+    end
+
+    def call
+      request!
+    end
+
+    private
+
+    def rdv_solidarites_response
+      @rdv_solidarites_response ||= rdv_solidarites_client.delete_user_profile(@user_id, @organisation_id)
+    end
+  end
+end

--- a/app/views/applicants/_add_to_org_button.html.erb
+++ b/app/views/applicants/_add_to_org_button.html.erb
@@ -1,9 +1,0 @@
-<% if can_be_added_to_other_org %>
-  <div id="add_to_org_button" class="col-12 col-md-6 px-5">
-    <%= link_to(new_department_applicant_applicants_organisation_path(department, applicant), data: { turbo_frame: 'remote_modal' }) do %>
-      <button class="btn btn-blue"><i class="fas fa-plus"></i>Ajouter à une organisation</button>
-    <% end %>
-  </div>
-<% else %>
-  <div class="col-12 col-md-6 px-5"></div>
-<% end %>

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -83,7 +83,11 @@
     </div>
 
     <div class="row d-flex justify-content-start flex-wrap">
-       <%= render "add_to_org_button", can_be_added_to_other_org: @can_be_added_to_other_org, department: @department, applicant: @applicant %>
+       <div class="col-12 col-md-6 px-5">
+        <%= link_to(department_applicant_applicants_organisations_path(@department, @applicant, current_organisation_id: department_level? ? nil : @organisation.id), data: { turbo_frame: 'remote_modal' }) do %>
+          <button class="btn btn-blue"><i class="fas fa-pen"></i> Ajouter ou retirer une organisation </button>
+        <% end %>
+      </div>
       <div class="col-12 col-md-6 px-5">
         <%= link_to(department_applicant_referent_assignations_path(@department, @applicant), data: { turbo_frame: 'remote_modal' }) do %>
           <button class="btn btn-blue"><i class="fas fa-user-plus"></i> Assigner le.s référent.s</button>

--- a/app/views/applicants_organisations/_applicants_organisation.html.erb
+++ b/app/views/applicants_organisations/_applicants_organisation.html.erb
@@ -1,0 +1,27 @@
+<div id="<%= dom_id(organisation, :applicants_organisation) %>" class="d-flex justify-content-between my-4">
+  <div><p><%= organisation.name %> <%= organisations_count %></p></div>
+  <div>
+    <%= simple_form_for(:applicants_organisation, url: department_applicants_organisations_path(department, current_organisation_id: @current_organisation&.id), html: { method: belongs_to_org ? :delete : :post }) do |f| %>
+      <%= f.input :applicant_id,
+                  as: :hidden,
+                  input_html: { class: "form-control", value: applicant.id }
+      %>
+      <%= f.input :organisation_id,
+                  as: :hidden,
+                  input_html: { class: "form-control", value: organisation.id }
+      %>
+      <% if belongs_to_org %>
+        <%= f.button(
+              :submit,
+              "- Retirer",
+              class: "btn btn-danger text-white",
+              data: organisations_count == 1 ? { confirm: "Cette action va supprimer défintivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?" } : {},
+              disabled: !removable
+            )
+        %>
+      <% else %>
+        <%= f.button :submit, "+ Ajouter", class: "btn btn-blue text-white" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/applicants_organisations/_applicants_organisation.html.erb
+++ b/app/views/applicants_organisations/_applicants_organisation.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(organisation, :applicants_organisation) %>" class="d-flex justify-content-between my-4">
-  <div><p><%= organisation.name %> <%= organisations_count %></p></div>
+  <div><p><%= organisation.name %></p></div>
   <div>
     <%= simple_form_for(:applicants_organisation, url: department_applicants_organisations_path(department, current_organisation_id: @current_organisation&.id), html: { method: belongs_to_org ? :delete : :post }) do |f| %>
       <%= f.input :applicant_id,

--- a/app/views/applicants_organisations/create.turbo_stream.erb
+++ b/app/views/applicants_organisations/create.turbo_stream.erb
@@ -1,14 +1,11 @@
 <%= turbo_stream.replace "organisations_list" do %>
-  <%= render partial: "applicants/organisations_list", locals: { organisations: @applicant.organisations } %>
-<% end %>
-<%= turbo_stream.replace "add_to_org_button" do %>
-  <%= render partial: "applicants/add_to_org_button", locals: { applicant: @applicant, department: @department, can_be_added_to_other_org: (@department.organisations - @applicant.organisations).any? } %>
+  <%= render partial: "applicants/organisations_list", locals: { organisations: @applicant.reload.organisations } %>
 <% end %>
 <%= turbo_stream.prepend "flashes" do %>
-  <%= render partial: "common/flash", locals: { flash: { success: "L'allocataire a bien été ajouté à l'organisation" } } %>
+  <%= render partial: "common/flash", locals: { flash: @success ? { success: "L'organisation a bien été ajoutée" } : { error: "Une erreur s'est produite lors de l'ajout de l'organisation: #{@errors}" } } %>
 <% end %>
-<% if @organisation.email? %>
+<% if @organisation_to_add.email? %>
   <%= turbo_stream.replace "remote_modal" do %>
-    <%= render partial: "organisations/applicant_added_notifications/form", locals: { emails: [@organisation.email], applicant: @applicant, organisation: @organisation } %>
+    <%= render partial: "organisations/applicant_added_notifications/form", locals: { emails: [@organisation_to_add.email], applicant: @applicant, organisation: @organisation_to_add } %>
   <% end %>
 <% end %>

--- a/app/views/applicants_organisations/destroy.turbo_stream.erb
+++ b/app/views/applicants_organisations/destroy.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.replace "organisations_list" do %>
+  <%= render partial: "applicants/organisations_list", locals: { organisations: @applicant.reload.organisations } %>
+<% end %>
+<%= turbo_stream.prepend "flashes" do %>
+  <%= render partial: "common/flash", locals: { flash: @success ? { success: "L'organisation a bien été retirée" } : { error: "Une erreur s'est produite lors du retrait de l'organisation: #{@errors}" } } %>
+<% end %>

--- a/app/views/applicants_organisations/index.html.erb
+++ b/app/views/applicants_organisations/index.html.erb
@@ -1,0 +1,6 @@
+<%= render "common/remote_modal", title: "Choisissez l'organisation à ajouter" do %>
+  <% @organisations.each do |organisation| %>
+    <%= render "applicants_organisation", department: @department, organisation: organisation, applicant: @applicant, belongs_to_org: @applicant.organisation_ids.include?(organisation.id), removable: current_agent.organisation_ids.include?(organisation.id), organisations_count: @applicant.organisation_ids.length %>
+  <% end %>
+<% end %>
+

--- a/app/views/applicants_organisations/index.html.erb
+++ b/app/views/applicants_organisations/index.html.erb
@@ -1,4 +1,4 @@
-<%= render "common/remote_modal", title: "Choisissez l'organisation à ajouter" do %>
+<%= render "common/remote_modal", title: "Choisissez les organisations à assigner" do %>
   <% @organisations.each do |organisation| %>
     <%= render "applicants_organisation", department: @department, organisation: organisation, applicant: @applicant, belongs_to_org: @applicant.organisation_ids.include?(organisation.id), removable: current_agent.organisation_ids.include?(organisation.id), organisations_count: @applicant.organisation_ids.length %>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,9 +57,10 @@ Rails.application.routes.draw do
     resources :applicants, only: [:index, :new, :create, :show, :edit, :update] do
       collection { resources :uploads, only: [:new] }
       resources :invitations, only: [:create]
-      resources :applicants_organisations, only: [:new, :create]
+      resources :applicants_organisations, only: [:index]
       resources :referent_assignations, only: [:index]
     end
+    resource :applicants_organisations, only: [:create, :destroy]
     resource :referent_assignations, only: [:create, :destroy]
   end
   resources :invitation_dates_filterings, only: [:new]

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -278,26 +278,6 @@ describe ApplicantsController do
       end
     end
 
-    context "when it belongs to all department organisations" do
-      it "does not show the add to organisation button" do
-        get :show, params: show_params
-
-        expect(response).to be_successful
-        expect(response.body).not_to match(/Ajouter à une organisation/)
-      end
-    end
-
-    context "when it does not belong to all department organisations" do
-      let!(:other_org) { create(:organisation, department: department) }
-
-      it "shows the add to organisation button" do
-        get :show, params: show_params
-
-        expect(response).to be_successful
-        expect(response.body).to match(/Ajouter à une organisation/)
-      end
-    end
-
     context "it shows the different contexts" do
       let!(:configuration) do
         create(:configuration, motif_category: "rsa_orientation", invitation_formats: %w[sms email])

--- a/spec/controllers/applicants_organisations_controller_spec.rb
+++ b/spec/controllers/applicants_organisations_controller_spec.rb
@@ -30,9 +30,8 @@ describe ApplicantsOrganisationsController do
     it "redirects with a success message" do
       subject
 
-      expect(response).to be_successful
-      expect(response.body).to match(/flashes/)
-      expect(unescaped_response_body).to match(/L'organisation a bien été ajoutée/)
+      expect(response).to redirect_to(department_applicant_path(department, applicant))
+      expect(flash[:success]).to include("L'organisation a bien été ajoutée")
     end
 
     it "saves the applicant with the organisation" do

--- a/spec/features/agent_can_add_or_remove_applicant_from_organisations_spec.rb
+++ b/spec/features/agent_can_add_or_remove_applicant_from_organisations_spec.rb
@@ -1,0 +1,152 @@
+describe "Agents can add or remove applicant from organisations", js: true do
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:department) { create(:department) }
+  let!(:organisation) do
+    create(
+      :organisation,
+      department: department,
+      # needed for the organisation applicants page
+      configurations: [create(:configuration)]
+    )
+  end
+  let!(:rdv_solidarites_user_id) { 243 }
+  let!(:applicant) do
+    create(
+      :applicant,
+      organisations: [organisation],
+      rdv_solidarites_user_id: rdv_solidarites_user_id, department: department
+    )
+  end
+  let!(:other_org) { create(:organisation, department: department) }
+
+  before do
+    setup_agent_session(agent)
+  end
+
+  context "from department applicant page" do
+    it "can add to an organisation" do
+      stub_other_org_user = stub_request(
+        :get,
+        "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/organisations/#{other_org.rdv_solidarites_organisation_id}/" \
+        "users/#{rdv_solidarites_user_id}"
+      ).with(
+        headers: { "Content-Type" => "application/json" }.merge(session_hash(agent.email))
+      ).to_return(status: 404)
+
+      stub_create_user_profile = stub_request(
+        :post, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/user_profiles"
+      ).with(
+        headers: { "Content-Type" => "application/json" }.merge(session_hash(agent.email)),
+        body: { user_id: rdv_solidarites_user_id, organisation_id: other_org.rdv_solidarites_organisation_id }.to_json
+      ).to_return(
+        status: 200,
+        body: {
+          user_profile: { user_id: rdv_solidarites_user_id, organisation_id: other_org.rdv_solidarites_organisation_id }
+        }.to_json
+      )
+
+      stub_update_user = stub_request(
+        :patch, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/users/#{rdv_solidarites_user_id}"
+      ).to_return(
+        status: 200,
+        body: {
+          user: { id: rdv_solidarites_user_id }
+        }.to_json
+      )
+
+      visit department_applicant_path(department, applicant)
+      expect(page).to have_content(organisation.name)
+      expect(page).not_to have_content(other_org.name)
+
+      click_link("Ajouter ou retirer une organisation")
+
+      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(other_org.name)
+      click_button("+ Ajouter")
+
+      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(other_org.name)
+      expect(page).to have_content(applicant.last_name)
+
+      expect(stub_other_org_user).to have_been_requested
+      expect(stub_create_user_profile).to have_been_requested
+      expect(stub_update_user).to have_been_requested
+      expect(applicant.reload.organisation_ids).to match_array([organisation.id, other_org.id])
+    end
+
+    it "can remove from org" do
+      stub_delete_user_profile = stub_request(
+        :delete, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/user_profiles"
+      ).with(
+        headers: { "Content-Type" => "application/json" }.merge(session_hash(agent.email)),
+        query: {
+          "user_id" => rdv_solidarites_user_id, "organisation_id" => organisation.rdv_solidarites_organisation_id
+        }
+      ).to_return(status: 204)
+
+      visit department_applicant_path(department, applicant)
+      expect(page).to have_content(organisation.name)
+      expect(page).not_to have_content(other_org.name)
+
+      click_link("Ajouter ou retirer une organisation")
+
+      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(other_org.name)
+      expect(page).to have_button("- Retirer", disabled: false)
+
+      accept_confirm(
+        "Cette action va supprimer défintivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?"
+      ) do
+        click_button("- Retirer")
+      end
+
+      expect(page).to have_content("Filtrer")
+      expect(page).to have_content("Créer allocataire(s)")
+
+      expect(stub_delete_user_profile).to have_been_requested
+      expect(applicant.reload.organisation_ids).to eq([])
+      expect(applicant.deleted?).to eq(true)
+    end
+  end
+
+  context "from organisation page" do
+    let!(:applicant) do
+      create(
+        :applicant,
+        organisations: [organisation, other_org],
+        rdv_solidarites_user_id: rdv_solidarites_user_id, department: department
+      )
+    end
+
+    it "returns to the department list if the applicant is removed from the org" do
+      stub_delete_user_profile = stub_request(
+        :delete, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/user_profiles"
+      ).with(
+        headers: { "Content-Type" => "application/json" }.merge(session_hash(agent.email)),
+        query: {
+          "user_id" => rdv_solidarites_user_id, "organisation_id" => organisation.rdv_solidarites_organisation_id
+        }
+      ).to_return(status: 204)
+
+      visit organisation_applicant_path(organisation, applicant)
+      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(other_org.name)
+
+      click_link("Ajouter ou retirer une organisation")
+
+      expect(page).to have_content(organisation.name)
+      expect(page).to have_content(other_org.name)
+
+      expect(page).to have_button("- Retirer", disabled: false)
+      expect(page).to have_button("- Retirer", disabled: true)
+      click_button("- Retirer")
+
+      expect(page).to have_content("Filtrer")
+      expect(page).to have_content("Créer allocataire(s)")
+
+      expect(stub_delete_user_profile).to have_been_requested
+      expect(applicant.reload.organisation_ids).to eq([other_org.id])
+      expect(applicant.deleted?).to eq(false)
+    end
+  end
+end

--- a/spec/features/agent_can_invite_applicants_from_index_page_spec.rb
+++ b/spec/features/agent_can_invite_applicants_from_index_page_spec.rb
@@ -19,7 +19,7 @@ describe "Agents can invite from index page", js: true do
   let!(:motif) { create(:motif, category: motif_category, organisation: organisation) }
 
   before do
-    setup_capybara_session(agent)
+    setup_agent_session(agent)
     stub_rdv_solidarites_invitation_requests
     stub_geo_api_request
   end

--- a/spec/services/applicants/remove_from_organisation_spec.rb
+++ b/spec/services/applicants/remove_from_organisation_spec.rb
@@ -1,0 +1,72 @@
+describe Applicants::RemoveFromOrganisation, type: :service do
+  subject do
+    described_class.call(
+      organisation: organisation,
+      applicant: applicant,
+      rdv_solidarites_session: rdv_solidarites_session
+    )
+  end
+
+  let!(:organisation) { create(:organisation) }
+  let!(:applicant) { create(:applicant, organisations: [organisation]) }
+  let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession) }
+
+  describe "#call" do
+    before do
+      allow(RdvSolidaritesApi::DeleteUserProfile).to receive(:call)
+        .with(
+          user_id: applicant.rdv_solidarites_user_id,
+          organisation_id: organisation.rdv_solidarites_organisation_id,
+          rdv_solidarites_session: rdv_solidarites_session
+        ).and_return(OpenStruct.new(success?: true))
+    end
+
+    it "is a success" do
+      is_a_success
+    end
+
+    it "removes the organisation from the applicant" do
+      subject
+      expect(applicant.reload.organisations).not_to include(organisation)
+    end
+
+    it "deletes the applicant when there is no org attached" do
+      subject
+      expect(applicant.deleted?).to eq(true)
+    end
+
+    context "when the applicant is attached to more than one org" do
+      let!(:other_organisation) { create(:organisation) }
+      let!(:applicant) { create(:applicant, organisations: [organisation, other_organisation]) }
+
+      it "does not delete the applicant" do
+        subject
+        expect(applicant.deleted?).to eq(false)
+      end
+    end
+
+    context "when it fails to remove the org from the API through API" do
+      before do
+        allow(RdvSolidaritesApi::DeleteUserProfile).to receive(:call)
+          .with(
+            user_id: applicant.rdv_solidarites_user_id,
+            organisation_id: organisation.rdv_solidarites_organisation_id,
+            rdv_solidarites_session: rdv_solidarites_session
+          ).and_return(OpenStruct.new(success?: false, errors: ["impossible to remove"]))
+      end
+
+      it "is a failure" do
+        is_a_failure
+      end
+
+      it "does not remove the organisation from the applicant" do
+        subject
+        expect(applicant.reload.organisations).to include(organisation)
+      end
+
+      it "outputs an error" do
+        expect(subject.errors).to eq(["impossible to remove"])
+      end
+    end
+  end
+end

--- a/spec/services/applicants/remove_from_organisation_spec.rb
+++ b/spec/services/applicants/remove_from_organisation_spec.rb
@@ -25,7 +25,7 @@ describe Applicants::RemoveFromOrganisation, type: :service do
       is_a_success
     end
 
-    it "removes the organisation from the applicant" do
+    it "removes the applicant from the organisation" do
       subject
       expect(applicant.reload.organisations).not_to include(organisation)
     end
@@ -45,7 +45,7 @@ describe Applicants::RemoveFromOrganisation, type: :service do
       end
     end
 
-    context "when it fails to remove the org from the API through API" do
+    context "when it fails to remove the org through API" do
       before do
         allow(RdvSolidaritesApi::DeleteUserProfile).to receive(:call)
           .with(
@@ -59,7 +59,7 @@ describe Applicants::RemoveFromOrganisation, type: :service do
         is_a_failure
       end
 
-      it "does not remove the organisation from the applicant" do
+      it "does not remove the applicant from the organisation" do
         subject
         expect(applicant.reload.organisations).to include(organisation)
       end

--- a/spec/services/applicants/remove_referent_spec.rb
+++ b/spec/services/applicants/remove_referent_spec.rb
@@ -25,12 +25,12 @@ describe Applicants::RemoveReferent, type: :service do
       is_a_success
     end
 
-    it "assigns the agent to the applicant" do
+    it "removes the agent from the applicant" do
       subject
       expect(applicant.reload.agents).not_to include(agent)
     end
 
-    context "when it fails to assign referent through API" do
+    context "when it fails to remove referent through API" do
       before do
         allow(RdvSolidaritesApi::DeleteReferentAssignation).to receive(:call)
           .with(
@@ -44,7 +44,7 @@ describe Applicants::RemoveReferent, type: :service do
         is_a_failure
       end
 
-      it "does not assign the agent to the applicant" do
+      it "does not remove the agent to the applicant" do
         subject
         expect(applicant.reload.agents).to include(agent)
       end

--- a/spec/support/authentication_spec_helper.rb
+++ b/spec/support/authentication_spec_helper.rb
@@ -1,6 +1,6 @@
 module AuthenticationSpecHelper
   def sign_in(agent, for_api: false)
-    setup_agent_session(agent) unless for_api
+    setup_request_session(agent) unless for_api
     mock_rdv_solidarites_session(agent.email)
   end
 
@@ -8,12 +8,12 @@ module AuthenticationSpecHelper
     { "client" => "someclient", "uid" => agent_email, "access_token" => "sometoken" }
   end
 
-  def setup_agent_session(agent)
+  def setup_request_session(agent)
     request.session["agent_id"] = agent.id
     request.session["rdv_solidarites"] = session_hash(agent.email)
   end
 
-  def setup_capybara_session(agent)
+  def setup_agent_session(agent)
     page.set_rack_session(agent_id: agent.id, rdv_solidarites: session_hash(agent.email))
 
     ENV["RDV_SOLIDARITES_URL"] = "http://www.rdv-solidarites-test.localhost"


### PR DESCRIPTION
Dans cette PR je permets à un agent d'ajouter et de retirer le bénéficiaire des différentes organisations du département. 
Pour ça j'ajoute une action pour pouvoir retirer une organisation au bénéficiaire (lié à cette PR côté RDV-Solidarités: https://github.com/betagouv/rdv-solidarites.fr/pull/3289).
Bien sûr, un agent ne peut retirer un bénéficiaire d'une organisation que s'il appartient à cette organisation. 
Si le bénéficiaire n'appartient qu'à une seule organisation et qu'on le retire, ça a pour effet de supprimer le bénéficiaire (même comportement que sur RDV-Solidarités). On affiche un message de confirmation dans ces cas-là.

J'ai également ajouté des tests d'intégration sur cette partie là.

## Previews 📷 

<img width="594" alt="image" src="https://user-images.githubusercontent.com/7602809/214930931-441fbf25-164d-4339-bcc7-419170b0af00.png">
<img width="535" alt="image" src="https://user-images.githubusercontent.com/7602809/214930981-0dc792b2-af3f-4106-ba17-87fa2371eb48.png">
