### PR TITLE
fix(webhook): Synchronize when receiving webhooks for all ressources

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_agent_role_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_agent_role_job.rb
@@ -5,12 +5,12 @@ module RdvSolidaritesWebhooks
       @meta = meta.deep_symbolize_keys
       return if organisation.blank?
 
-      # let's make sure the agent is created before we continue
-      sleep 2
-      raise "Could not find agent: #{@data[:agent]}" unless agent
+      if event == "created"
+        upsert_agent_and_raise if agent.nil?
+        attach_agent_to_org
+      end
 
-      attach_agent_to_org if event == "created"
-      remove_from_org if event == "destroyed"
+      remove_from_org if agent && event == "destroyed"
     end
 
     private
@@ -25,6 +25,20 @@ module RdvSolidaritesWebhooks
 
     def rdv_solidarites_organisation_id
       @data[:organisation][:id]
+    end
+
+    def upsert_agent_and_raise
+      UpsertRecordJob.perform_async(
+        "Agent",
+        @data[:agent],
+        { last_webhook_update_received_at: @meta[:timestamp] }
+      )
+      sleep 2
+
+      raise(
+        "Could not find agent #{rdv_solidarites_agent_id}. " \
+        "Launched upsert agent job and will retry"
+      )
     end
 
     def organisation

--- a/app/jobs/rdv_solidarites_webhooks/process_organisation_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_organisation_job.rb
@@ -4,7 +4,7 @@ module RdvSolidaritesWebhooks
       @data = data.deep_symbolize_keys
       @meta = meta.deep_symbolize_keys
       return if organisation.blank?
-      return unless event == "updated"
+      return if event == "destroyed"
 
       update_organisation
     end

--- a/spec/jobs/rdv_solidarites_webhooks/process_agent_role_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_agent_role_job_spec.rb
@@ -63,12 +63,20 @@ describe RdvSolidaritesWebhooks::ProcessAgentRoleJob do
       let!(:meta) do
         {
           "model" => "AgentRole",
-          "event" => "created"
+          "event" => "created",
+          "timestamp" => "2022-05-30 14:44:22 +0200"
         }.deep_symbolize_keys
       end
 
       it "raises an error" do
-        expect { subject }.to raise_error(StandardError, "Could not find agent: #{data[:agent]}")
+        expect(UpsertRecordJob).to receive(:perform_async)
+          .with(
+            "Agent", data[:agent], { last_webhook_update_received_at: "2022-05-30 14:44:22 +0200" }
+          )
+        expect { subject }.to raise_error(
+          StandardError,
+          "Could not find agent 455. Launched upsert agent job and will retry"
+        )
       end
     end
   end


### PR DESCRIPTION
Dans cette PR je fais un fix pour que l'orga se synchronise avec RDV-Solidarités lorsqu'on appelle la méthode `WebhookEndpoint#trigger_for_all_resources`.
Je fais également en sorte d'upserter l'agent avant de raiser lorsque l'on process un webhook d'`AgentRole` et que l'agent n'est pas sur RDV-I.