### PR TITLE
refactor(app): Separate file configurations and configurations in separate tables

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -267,8 +267,8 @@ class ApplicantsController < ApplicationController
     @applicants = policy_scope(Applicant).preload(
       :rdvs, :agents,
       invitations: :rdv_context,
-      rdv_contexts: [:participations],
-      organisations: [:department, :configurations]
+      rdv_contexts: [:participations, :motif_category],
+      organisations: [:motif_categories, :department, :configurations]
     ).distinct
     @applicants = @applicants
                   .where(department_internal_id: params.require(:applicants)[:department_internal_ids])

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -72,11 +72,9 @@ class InvitationsController < ApplicationController
 
   def set_organisations
     @organisations = \
-      if department_level?
-        policy_scope(Organisation).where(department_id: params[:department_id])
-      else
-        policy_scope(Organisation).where(id: params[:organisation_id])
-      end
+      policy_scope(Organisation)
+      .includes(:motif_categories, :department, :messages_configuration)
+      .where(department_level? ? { department_id: params[:department_id] } : { id: params[:organisation_id] })
   end
 
   def set_rdv_context

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -13,9 +13,12 @@ class UploadsController < ApplicationController
     @department = Department.find(params[:department_id])
     authorize @department, :upload?
     @organisation = nil
-    @all_configurations = (policy_scope(::Configuration).includes(:motif_category) & @department.configurations)
-                          .uniq(&:motif_category_id)
-                          .sort_by(&:motif_category_position)
+
+    @all_configurations = (
+      policy_scope(::Configuration).includes(:motif_category, :file_configuration) &
+      @department.configurations
+    ).uniq(&:motif_category_id).sort_by(&:motif_category_position)
+
     set_current_configuration
   end
 

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,7 +1,16 @@
 class Configuration < ApplicationRecord
   belongs_to :motif_category
+  belongs_to :file_configuration
   has_many :configurations_organisations, dependent: :delete_all
   has_many :organisations, through: :configurations_organisations
 
   delegate :position, :name, to: :motif_category, prefix: true
+
+  def as_json(opts = {})
+    super.merge(
+      # TODO: delegate these methods to file_configuration
+      sheet_name: file_configuration.sheet_name,
+      column_names: file_configuration.column_names
+    )
+  end
 end

--- a/app/models/file_configuration.rb
+++ b/app/models/file_configuration.rb
@@ -1,0 +1,5 @@
+class FileConfiguration < ApplicationRecord
+  has_many :organisations, dependent: :restrict_with_error
+
+  validates :column_names, uniqueness: { scope: :sheet_name }
+end

--- a/app/models/file_configuration.rb
+++ b/app/models/file_configuration.rb
@@ -1,5 +1,5 @@
 class FileConfiguration < ApplicationRecord
-  has_many :organisations, dependent: :restrict_with_error
+  has_many :configurations, dependent: :restrict_with_error
 
   validates :column_names, uniqueness: { scope: :sheet_name }
 end

--- a/db/migrate/20230207094221_create_file_configurations.rb
+++ b/db/migrate/20230207094221_create_file_configurations.rb
@@ -1,0 +1,40 @@
+class CreateFileConfigurations < ActiveRecord::Migration[7.0]
+  def up
+    create_table :file_configurations do |t|
+      t.string :sheet_name
+      t.jsonb :column_names
+
+      t.timestamps
+    end
+
+    add_reference :configurations, :file_configuration, foreign_key: true
+
+    ::Configuration.find_each do |configuration|
+      file_configuration = FileConfiguration.find_or_create_by!(
+        sheet_name: configuration.sheet_name,
+        column_names: configuration.column_names
+      )
+      configuration.update! file_configuration_id: file_configuration.id
+    end
+
+    remove_column :configurations, :sheet_name
+    remove_column :configurations, :column_names
+  end
+
+  def down
+    add_column :configurations, :sheet_name, :string
+    add_column :configurations, :column_names, :json
+
+    ::Configuration.find_each do |configuration|
+      file_configuration = FileConfiguration.find(configuration.file_configuration_id)
+      configuration.update!(
+        sheet_name: file_configuration.sheet_name,
+        column_names: file_configuration.column_names
+      )
+    end
+
+    remove_reference :configurations, :file_configuration, foreign_key: true
+
+    drop_table :file_configurations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,10 +74,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_134639) do
   end
 
   create_table "configurations", force: :cascade do |t|
-    t.string "sheet_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "column_names"
     t.string "invitation_formats", default: ["sms", "email", "postal"], null: false, array: true
     t.boolean "convene_applicant", default: false
     t.integer "number_of_days_to_accept_invitation", default: 3
@@ -85,6 +83,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_134639) do
     t.boolean "invitation_fallbacks_set_to_applicants_organisations", default: false
     t.boolean "rdv_with_referents", default: false
     t.bigint "motif_category_id"
+    t.bigint "file_configuration_id"
+    t.index ["file_configuration_id"], name: "index_configurations_on_file_configuration_id"
     t.index ["motif_category_id"], name: "index_configurations_on_motif_category_id"
   end
 
@@ -105,6 +105,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_134639) do
     t.string "email"
     t.string "phone_number"
     t.boolean "display_in_stats", default: true
+  end
+
+  create_table "file_configurations", force: :cascade do |t|
+    t.string "sheet_name"
+    t.jsonb "column_names"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "invitations", force: :cascade do |t|
@@ -333,6 +340,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_134639) do
   end
 
   add_foreign_key "applicants", "departments"
+  add_foreign_key "configurations", "file_configurations"
   add_foreign_key "configurations", "motif_categories"
   add_foreign_key "invitations", "applicants"
   add_foreign_key "invitations", "departments"

--- a/spec/factories/configuration.rb
+++ b/spec/factories/configuration.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :configuration do
     association :motif_category
-    sheet_name { "LISTE DEMANDEURS" }
+    association :file_configuration
     invitation_formats { %w[sms] }
   end
 end

--- a/spec/factories/file_configuration.rb
+++ b/spec/factories/file_configuration.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :file_configuration do
+    sequence(:sheet_name) { |n| "LISTE DEMANDEURS_#{n}" }
+  end
+end


### PR DESCRIPTION
Cette PR vient après #815 .
Dans cette PR j'extrais les colonnes `sheet_name`  et `column_names` de la table `configurations` dans une table séparée `file_configurations`. 
J'en profite pour optimiser certaines queries en preloadant les records nécessaires.

Remarque: 
* la table configuration devra probablement être renommé (`CategoryConfiguration` ?) dans une autre PR