### PR TITLE
fix(webhooks): Do not process unhandled category webhook

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
@@ -54,11 +54,8 @@ module RdvSolidaritesWebhooks
       @motif_category ||= MotifCategory.find_by(short_name: rdv_solidarites_motif_category&.short_name)
     end
 
-    # Category is checked through the webhook directly and not through the motif we have in DB since it's always
-    # more reliable than our cache
     def unhandled_category?
-      MotifCategory.pluck(:short_name).exclude?(rdv_solidarites_motif_category&.short_name) ||
-        motif_category.nil?
+      rdv_solidarites_motif_category.nil? || motif_category.nil? || matching_configuration.nil?
     end
 
     def event

--- a/app/views/applicants/_applicants_list_header.html.erb
+++ b/app/views/applicants/_applicants_list_header.html.erb
@@ -32,7 +32,7 @@
       </div>
       <% if display_back_to_list_button? %>
         <div>
-          <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category.id, applicants_scope: @applicants_scope), class: "btn btn-blue-out" do %>
+          <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, applicants_scope: @applicants_scope), class: "btn btn-blue-out" do %>
             Retour à la liste
           <% end %>
         </div>


### PR DESCRIPTION
On avait une erreur si un webhook comprenait une catégorie de motif mais que l'organisation en question n'avait pas de configurations associée à cette catégorie : https://sentry.incubateur.net/organizations/betagouv/issues/21493/?project=16

Je corrige également une erreur que l'on avait lorsqu'on effectuait une recherche sur les bénéficaires archivés: https://sentry.incubateur.net/organizations/betagouv/issues/12768/?project=16&referrer=regression-activity-email