### PR TITLE
fix(cron): Send invitation reminders through rdv contexts

### DIFF
--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -4,14 +4,15 @@ class SendInvitationRemindersJob < ApplicationJob
 
     @sent_reminders_applicant_ids = []
 
-    applicants_to_send_reminders_to.find_each do |applicant|
+    rdv_contexts_with_reminder_needed.find_each do |rdv_context|
       # we check here that it is the **first** invitation that has been sent 3 days ago
-      next if applicant.first_invitation_relative_to_last_participation_sent_at.to_date != 3.days.ago.to_date
+      next if rdv_context.first_invitation_relative_to_last_participation_sent_at.to_date != 3.days.ago.to_date
 
-      SendInvitationReminderJob.perform_async(applicant.id, "email") if applicant.email?
-      if applicant.phone_number? && applicant.phone_number_is_mobile?
-        SendInvitationReminderJob.perform_async(applicant.id, "sms")
-      end
+      applicant = rdv_context.applicant
+
+      SendInvitationReminderJob.perform_async(rdv_context.id, "email") if applicant.email?
+      SendInvitationReminderJob.perform_async(rdv_context.id, "sms") if applicant.phone_number_is_mobile?
+
       @sent_reminders_applicant_ids << applicant.id
     end
 
@@ -20,12 +21,14 @@ class SendInvitationRemindersJob < ApplicationJob
 
   private
 
-  def applicants_to_send_reminders_to
-    @applicants_to_send_reminders_to ||= \
-      Applicant.active
-               .archived(false)
-               .where(id: valid_invitations_sent_3_days_ago.pluck(:applicant_id))
-               .distinct
+  def rdv_contexts_with_reminder_needed
+    @rdv_contexts_with_reminder_needed ||= \
+      RdvContext.invitation_pending
+                .joins(:motif_category)
+                .where(motif_category: MotifCategory.not_atelier)
+                .where(id: valid_invitations_sent_3_days_ago.pluck(:rdv_context_id))
+                .where(applicant_id: Applicant.active.archived(false).ids)
+                .distinct
   end
 
   def staging_env?
@@ -37,13 +40,6 @@ class SendInvitationRemindersJob < ApplicationJob
       # we want the token to be valid for at least two days to be sure the invitation will be valid
       Invitation.where("valid_until > ?", 2.days.from_now)
                 .where(format: %w[email sms], sent_at: 3.days.ago.all_day, reminder: false)
-                .joins(:rdv_context)
-                .where(
-                  rdv_contexts: RdvContext.invitation_pending.joins(:motif_category).where(
-                    # ateliers are open invitations so we don't send reminders
-                    motif_category: MotifCategory.not_atelier
-                  )
-                )
   end
 
   def notify_on_mattermost


### PR DESCRIPTION
Dans cette PR je change la façon de lancer les rappels, suite aux nombreuses erreurs lors du lancement de ces derniers jours : https://sentry.incubateur.net/organizations/betagouv/issues/20419/?project=16&query=&statsPeriod=14d

En effet dans certains cas l'allocataire a pu avoir reçu une invitation il y a 3 jours sur un contexte mais a eu un rdv sur un autre entre temps, et donc l'expression `applicant.first_invitation_relative_to_last_participation_sent_at` pouvait renvoyer `nil`.


Remarque: On risque d'avoir quelques retours au cas où ces rdvs dans différents contextes ne sont pas voulus, auquel cas on devra en parler aux départements concernés et voir comment on peut éviter ça.

