### PR TITLE
fix(preview): Use new scope in notification mailer preview

### DIFF
--- a/spec/mailers/previews/notification_preview.rb
+++ b/spec/mailers/previews/notification_preview.rb
@@ -1,6 +1,6 @@
 # Preview all emails at http://localhost:8000/rails/mailers/notification
 class NotificationPreview < ActionMailer::Preview
-  MotifCategory.rdvs_mandatory.find_each do |motif_category|
+  MotifCategory.participation_optional(false).find_each do |motif_category|
     notification = \
       Notification
       .joins(:participation)


### PR DESCRIPTION
J'ai oublié de mettre à jour le scope pour récupérer les catégories où la présence n'est pas optionnelle dans la preview des mails de notifications danss  #815 