### PR TITLE
fix(status): Refresh rdv_context status on participations create/update

### DIFF
--- a/app/models/concerns/rdv_context_status.rb
+++ b/app/models/concerns/rdv_context_status.rb
@@ -11,7 +11,7 @@ module RdvContextStatus
   end
 
   def set_status
-    rdvs.reload
+    participations.reload
     invitations.reload
     self.status = compute_status
   end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -10,7 +10,7 @@ class Participation < ApplicationRecord
   validates :status, presence: true
   validates :rdv_solidarites_participation_id, uniqueness: true, allow_nil: true
 
-  after_commit :refresh_applicant_context_statuses, on: [:destroy]
+  after_commit :refresh_applicant_context_statuses
   after_commit :notify_applicant, if: :rdv_notify_applicants?, on: [:create, :update]
 
   delegate :starts_at, :convocable?, :motif_name, :rdv_solidarites_url, :rdv_solidarites_rdv_id, to: :rdv


### PR DESCRIPTION
On a plusieurs instances de `rdv_context` qui ne se sont pas mis à jour ces derniers jours. 
Je tente ici de rafraichir le statut à chaque modification de participation, voir déjà si ça change quelque chose.