### PR TITLE
refactor(invitation): Rename configuration attribute 

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 class InvitationsController < ApplicationController
   before_action :set_organisations, :set_department, :set_applicant,
                 :set_motif_category, :set_rdv_context, :set_current_configuration,
-                :set_invitation_format, :set_fallback_organisations, :set_new_invitation, :save_and_send_invitation,
+                :set_invitation_format, :set_preselected_organisations, :set_new_invitation, :save_and_send_invitation,
                 only: [:create]
   before_action :set_invitation, :verify_invitation_validity, only: [:redirect]
   skip_before_action :authenticate_agent!, only: [:invitation_code, :redirect]
@@ -37,7 +37,7 @@ class InvitationsController < ApplicationController
     @invitation = Invitation.new(
       applicant: @applicant,
       department: @department,
-      organisations: @fallback_organisations,
+      organisations: @preselected_organisations,
       rdv_context: @rdv_context,
       format: @invitation_format,
       number_of_days_to_accept_invitation: @current_configuration.number_of_days_to_accept_invitation,
@@ -85,9 +85,9 @@ class InvitationsController < ApplicationController
     end
   end
 
-  def set_fallback_organisations
-    @fallback_organisations = \
-      if @current_configuration.invitation_fallbacks_set_to_applicants_organisations?
+  def set_preselected_organisations
+    @preselected_organisations = \
+      if @current_configuration.invite_to_applicant_organisations_only?
         @organisations & @applicant.organisations
       else
         @organisations

--- a/db/migrate/20230213152346_rename_invitation_fallbacks_set_to_applicants_organisation_to_invite_to_applicant_organisations_only.rb
+++ b/db/migrate/20230213152346_rename_invitation_fallbacks_set_to_applicants_organisation_to_invite_to_applicant_organisations_only.rb
@@ -1,0 +1,8 @@
+class RenameInvitationFallbacksSetToApplicantsOrganisationToInviteToApplicantOrganisationsOnly <
+    ActiveRecord::Migration[7.0]
+  def change
+    rename_column :configurations,
+                  :invitation_fallbacks_set_to_applicants_organisations,
+                  :invite_to_applicant_organisations_only
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_08_154729) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_13_152346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,7 +88,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_154729) do
     t.boolean "convene_applicant", default: false
     t.integer "number_of_days_to_accept_invitation", default: 3
     t.integer "number_of_days_before_action_required", default: 10
-    t.boolean "invitation_fallbacks_set_to_applicants_organisations", default: false
+    t.boolean "invite_to_applicant_organisations_only", default: false
     t.boolean "rdv_with_referents", default: false
     t.bigint "motif_category_id"
     t.bigint "file_configuration_id"

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -142,9 +142,9 @@ describe InvitationsController do
         post :create, params: create_params
       end
 
-      context "when the invitation fallbacks is set to applicants organisations" do
+      context "when the config invites to applicants organisations only" do
         before do
-          configuration.update!(invitation_fallbacks_set_to_applicants_organisations: true)
+          configuration.update!(invite_to_applicant_organisations_only: true)
           allow(Invitation).to receive(:new)
             .with(
               department: department, applicant: applicant, organisations: [organisation], rdv_context: rdv_context,
@@ -154,7 +154,7 @@ describe InvitationsController do
             ).and_return(invitation)
         end
 
-        it "instantiates the invitation with the applicant org only" do
+        it "instantiates the invitation with the applicant orgs only" do
           expect(Invitation).to receive(:new)
             .with(
               department: department, applicant: applicant, organisations: [organisation], rdv_context: rdv_context,


### PR DESCRIPTION
Dans cette PR je renomme la colonne `invitation_fallbacks_set_to_applicants_organisations` de la table `configurations` en 
`invite_to_applicant_organisations_only` qui est plus parlante.
Je mettrai à jour le wiki une fois la PR mergée.