### PR TITLE
feat(view): Hide invites when rdv pending on index

### DIFF
--- a/app/views/applicants/_applicants_table_for_motif_category.html.erb
+++ b/app/views/applicants/_applicants_table_for_motif_category.html.erb
@@ -23,8 +23,10 @@
         <td><%= display_attribute applicant.first_name %></td>
         <% @current_configuration.invitation_formats.each do |invitation_format| %>
           <td class="d-none d-lg-table-cell">
-            <% if applicant.can_be_invited_through?(invitation_format) %>
-              <%= render "invitations/checkbox_form", applicant: applicant, invitation_format: invitation_format, motif_category: @current_motif_category, rdv_context: rdv_context, checked: checked = rdv_context.first_invitation_relative_to_last_participation_by(invitation_format).present?, disabled: checked || applicant.inactive? || rdv_context.status == "rdv_pending" %>
+            <% if rdv_context.rdv_pending? %>
+              <!-- show nothing -->
+            <% elsif applicant.can_be_invited_through?(invitation_format) %>
+              <%= render "invitations/checkbox_form", applicant: applicant, invitation_format: invitation_format, motif_category: @current_motif_category, rdv_context: rdv_context, checked: checked = rdv_context.first_invitation_relative_to_last_participation_by(invitation_format).present?, disabled: checked || applicant.inactive? %>
             <% else %>
               -
             <% end %>

--- a/spec/features/agent_can_invite_applicants_from_index_page_spec.rb
+++ b/spec/features/agent_can_invite_applicants_from_index_page_spec.rb
@@ -146,13 +146,13 @@ describe "Agents can invite from index page", js: true do
         )
       end
 
-      it "cannot invite in any format" do
+      it "cannot invite in any format and do not show the invitation fields" do
         rdv_context.set_status
         rdv_context.save!
 
         visit organisation_applicants_path(organisation, motif_category_id: motif_category.id)
-        expect(page).to have_field("sms_invite", checked: true, disabled: true)
-        expect(page).to have_field("email_invite", checked: false, disabled: true)
+        expect(page).not_to have_field("sms_invite")
+        expect(page).not_to have_field("email_invite")
         expect(page).to have_content("RDV pris")
       end
     end


### PR DESCRIPTION
## Contexte 

Dans cette PR je fais une proposition de changement d'affichage des invitations sur la page index lorsqu'un "RDV est pris".
Aujourd'hui, on affiche les checkbox d'invitations qui sont décochées et incochables: 

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/7602809/218749632-7b27b220-493d-44d6-8b0d-df539b8ab462.png">

C'est censé vouloir dire qu'il est impossible d'inviter la personne car il y a un RDV en attente, mais qu'il sera possible de le faire dès que le RDV sera passé (et son statut déterminé).

Cependant, vu que cette affichage arrive juste après la période "d'invitation en attente de réponse", on pourrait penser que l'affichage ci-dessus veuille dire que le RDV a été pris sans que la personne ait été invitée. 
Nous avions eu un retour du Var nous faisant part de leur étonnement sur cette interface.

## Proposition

Je propose donc de changer pour juste enlever les checkbox lorsqu'un RDV est pris et est en attente pour éviter toute confusion:

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/7602809/218750542-1fbca87d-9a07-48ba-a219-7ebacf0a2332.png">


Dites-moi ce que vous en pensez.