### PR TITLE
fix(app): underscore rdv solidarites klass names in upsert record

### DIFF
--- a/app/services/upsert_record.rb
+++ b/app/services/upsert_record.rb
@@ -36,7 +36,7 @@ class UpsertRecord < BaseService
   end
 
   def rdv_solidarites_id_attribute_name
-    "rdv_solidarites_#{rdv_solidarites_class_name.downcase}_id"
+    "rdv_solidarites_#{rdv_solidarites_class_name.underscore}_id"
   end
 
   def rdv_solidarites_class_name


### PR DESCRIPTION
Hotfix pour [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/22538/?environment=staging&project=16&referrer=alert_email)

Lors de la construction du `rdv_solidarites_agent_role_id` dans `UpsertRecord`, le nom de la classe était downcasé plutôt que underscoré, ce qui créait une erreur.