### PR TITLE
fix(stats): change global stats computing frequency

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,5 +1,5 @@
 upsert_global_stats_job:
-  cron: "0 22 * * *" # we compute global stats once a day, at 22:00
+  cron: "0 22 * * sat" # we compute global stats once a week, the saturday at 22:00
   class: "Stats::GlobalStats::UpsertStatsJob"
 upsert_monthly_stats_job:
   cron: "0 23 last * *" # we compute monthly stats the last day of the month, at 23:00


### PR DESCRIPTION
Temporairement en attendant d'avoir optimisé le service (ou définitivement si on pense que ce n'est pas nécessaire de le faire quotidiennement), je baisse la fréquence du calcul des stats globals à une fois par semaine, le week-end, pour éviter d'encombrer les workers.