### PR TITLE
refactor(controllers): Group before_action filters by action 

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -7,16 +7,20 @@ class ApplicantsController < ApplicationController
     :status, :rights_opening_date, :archiving_reason
   ].freeze
 
-  include FilterableApplicantsConcern
+  include Applicants::Filters
 
-  before_action :set_applicant, only: [:show, :update, :edit]
-  before_action :set_organisation, :set_department, only: [:index, :new, :create, :show, :update, :edit]
-  before_action :set_all_configurations, only: [:index, :show]
-  before_action :set_applicants_scope, :set_current_configuration,
-                :set_current_motif_category, :set_applicants, :set_rdv_contexts,
-                :filter_applicants, :order_applicants, only: [:index]
-  before_action :set_organisations, only: [:index, :new, :create]
-  before_action :set_applicant_rdv_contexts, :set_back_to_list_url, only: [:show]
+  before_action :set_organisation, :set_department, :set_organisations, :set_all_configurations,
+                :set_applicants_scope,
+                :set_current_configuration, :set_current_motif_category, :set_applicants, :set_rdv_contexts,
+                :filter_applicants, :order_applicants,
+                for: :index
+  before_action :set_applicant, :set_organisation, :set_department, :set_all_configurations,
+                :set_applicant_rdv_contexts, :set_back_to_list_url,
+                for: :show
+  before_action :set_organisation, :set_department, :set_organisations,
+                for: [:new, :create]
+  before_action :set_applicant, :set_organisation, :set_department,
+                for: [:edit, :update]
   before_action :retrieve_applicants, only: [:search]
   after_action :store_back_to_list_url, only: [:index]
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
 
   include AuthorizationConcern
   include AuthenticatedControllerConcern
+  include BeforeActionOverride
 
   private
 

--- a/app/controllers/concerns/applicants/filters.rb
+++ b/app/controllers/concerns/applicants/filters.rb
@@ -1,4 +1,4 @@
-module FilterableApplicantsConcern
+module Applicants::Filters
   private
 
   def filter_applicants

--- a/app/controllers/concerns/before_action_override.rb
+++ b/app/controllers/concerns/before_action_override.rb
@@ -1,0 +1,49 @@
+module BeforeActionOverride
+  extend ActiveSupport::Concern
+
+  # This override enables before_action to take a `for` option that enables a filter
+  # to be run for the controller actions passed as arguments but NOT EXCLUSIVELY
+  # (which is not the case for `if` or `only` filters).
+  # To do so it appends the name of the action on the filters. For example,
+  # `set_organisations, for: :index` would produce `set_organisations_for_index, only: :index`.
+  # Since the new filters (set_organisations_index in the example) are not instance methods on the controller,
+  # we have to use method_missing hook to call the matching method.
+
+  class_methods do
+    def before_action(*names, &)
+      names_dup = names.dup
+      opts = names_dup.extract_options!
+      if opts[:for].present?
+        actions = Array(opts.delete(:for))
+        new_names_by_action = actions.index_with do |action|
+          action_opts = opts.dup
+          action_opts[:only] ||= []
+          action_opts[:only] << action
+          names_dup.map do |name|
+            :"#{name}_for_#{action}"
+          end.push(action_opts)
+        end
+        new_names_by_action.each_value do |new_names|
+          super(*new_names, &)
+        end
+      else
+        super
+      end
+    end
+  end
+
+  def method_missing(method_name, *args)
+    return super unless method_name.to_s.end_with?("for_#{action_name}")
+
+    matching_method = method_name.to_s.split("_")[0..-3].join("_")
+    if respond_to?(matching_method, true)
+      send(matching_method)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.end_with?("for_#{action_name}") || super
+  end
+end


### PR DESCRIPTION
## Contexte 

Cette PR a pour but de regrouper les `before_action` du `ApplicantsController` par action.
En effet, il devenait de plus en plus difficile d'avoir en tête quelle filtre ajouter pour quelle action, sans compter le fait que ces filtres peuvent être appelés dans un ordre différent selon l'action.
Cependant, la méthode `before_action` ne permet pas de scoper les filtres par action. Si on appelle un filtre sur une action et qu'on met une condition (à l'aide des options `only`, `if`, `except`, `unless`), alors ce filtre ne pourra pas être appelé pour une autre action.

## Différentes solutions

### Ajouter un filtre globale

Une méthode simple consisterait à appeler une définir un nouveau filtre pour chaque action et appeler passer ce filtre à `before_action`.
Par exemple on peut avoir: 
```ruby 
before_action :prepare_index, only: :index
...
def prepare_index
  set_organisation
  set_department
  ...
end
```

Cette solution est sans doute acceptable et possiblement la solution recommandée. Cependant je trouvais personnellement qu'on perdait en lisibilité en faisant ainsi.

### Ajouter une option à `before_action` 

La deuxième solution, celle sur laquelle je suis parti, consiste à overrider la méthode `before_action` pour qu'elle accepte une option `for`. Cette option permet d'appliquer un filtre pour une action sans qu'il soit exclusif à cette action.
Pour se faire, je suffixe le nom de l'action en question au nom du filtre pour avoir un filtre spécifique. Par exemple:
```ruby
before_action :set_organisations, for: :index 
```
équivaut à  
```ruby 
before_action :set_organisations_for_index, only: :index 
```
Comme cette dernière méthode n'existe pas, j'utilise la méthode `method_missing` de ruby pour appler l'action correspondante.
Je trouve la lisibilité du controller meilleure avec cette solution, mais elle a quelques inconvénients: 
* C'est toujours un peu dangereux de patcher de rails, surtout une qu'on utilise autant. On est jamais à l'abri d'un changement de fonctionnement d'une version à l'autre. 
* Le fait de faire du metaprogramming peut produire des erreurs moins compréhensible et potentiellement introduire un peu d'overhead (même si je pense qu'il est négligeable ici, bien que je n'ai pas réalisé de benchmark) 

## Remarques 

* J'en profite pour renommer le module `FilterableApplicantsConcern` en `Applicants::Filters`
* Je l'ai fait que pour le `before_action` callback parce qu'on en a besoin que pour celui-là mais le principe pourrait bien sûr être généralisé aux autres