### PR TITLE
fix(agent_roles): add last webhook update received at to agent_roles

### DIFF
--- a/db/migrate/20230216152810_add_last_webhook_update_received_at_for_agent_roles.rb
+++ b/db/migrate/20230216152810_add_last_webhook_update_received_at_for_agent_roles.rb
@@ -1,0 +1,5 @@
+class AddLastWebhookUpdateReceivedAtForAgentRoles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :agent_roles, :last_webhook_update_received_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_13_152346) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_152810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_13_152346) do
     t.bigint "rdv_solidarites_agent_role_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_webhook_update_received_at"
     t.index ["agent_id", "organisation_id"], name: "index_agent_roles_on_agent_id_and_organisation_id", unique: true
     t.index ["agent_id"], name: "index_agent_roles_on_agent_id"
     t.index ["level"], name: "index_agent_roles_on_level"


### PR DESCRIPTION
Pour résoudre [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/22612/), j'ajoute une colonne `last_webhook_update_received_at` à la table `agent_roles`