### PR TITLE
fix(convocation): Select active motifs only for convocation

### DIFF
--- a/app/controllers/concerns/applicants/convocable.rb
+++ b/app/controllers/concerns/applicants/convocable.rb
@@ -6,7 +6,7 @@ module Applicants::Convocable
     return if archived_scope?
     return unless @current_configuration.convene_applicant?
 
-    convocation_motifs = Motif.includes(:organisation).where(
+    convocation_motifs = Motif.includes(:organisation).active.where(
       organisation_id: department_level? ? @organisations.ids : @organisation.id,
       motif_category: @current_motif_category
     ).select(&:convocation?)
@@ -25,7 +25,7 @@ module Applicants::Convocable
     return if archived_scope?
     return if @all_configurations.none?(&:convene_applicant?)
 
-    convocation_motifs = Motif.includes(:organisation).where(
+    convocation_motifs = Motif.includes(:organisation).active.where(
       organisation_id: @applicant_organisations.ids, motif_category: @all_configurations.map(&:motif_category)
     ).select(&:convocation?)
 

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -145,7 +145,8 @@ module ApplicantsHelper
     params = {
       user_ids: [rdv_solidarites_user_id],
       motif_id: rdv_solidarites_motif_id,
-      service_id: rdv_solidarites_service_id
+      service_id: rdv_solidarites_service_id,
+      commit: "Afficher les créneaux"
     }
     "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/#{rdv_solidarites_organisation_id}/" \
       "agent_searches?#{params.to_query}"

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -15,6 +15,7 @@ class Motif < ApplicationRecord
 
   delegate :rdv_solidarites_organisation_id, to: :organisation
 
+  scope :active, ->(active = true) { active ? where(deleted_at: nil) : where.not(deleted_at: nil) }
   scope :collectif, ->(collectif = true) { collectif ? where(collectif: true) : where(collectif: false) }
 
   def presential?

--- a/spec/features/agent_can_convene_applicant_spec.rb
+++ b/spec/features/agent_can_convene_applicant_spec.rb
@@ -51,7 +51,8 @@ describe "Agents can convene applicant to rdv", js: true do
     params = {
       user_ids: [rdv_solidarites_user_id],
       motif_id: rdv_solidarites_motif_id,
-      service_id: rdv_solidarites_service_id
+      service_id: rdv_solidarites_service_id,
+      commit: "Afficher les créneaux"
     }
     "http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv_solidarites_organisation_id}/" \
       "agent_searches?#{params.to_query}"
@@ -111,6 +112,17 @@ describe "Agents can convene applicant to rdv", js: true do
       it "does not show a convocation button" do
         visit organisation_applicants_path(organisation)
         expect(page).not_to have_content("📅 Convoquer")
+      end
+    end
+
+    context "when the motif is deleted" do
+      before { motif.update! deleted_at: 2.days.ago }
+
+      it "shows a disabled button to convene the applicant" do
+        visit organisation_applicants_path(organisation)
+        expect(page).to have_content("📅 Convoquer")
+        expect(page).not_to have_link("📅 Convoquer")
+        expect(page).to have_css("div#js-disabled-convocation-button")
       end
     end
 
@@ -179,7 +191,8 @@ describe "Agents can convene applicant to rdv", js: true do
       params = {
         user_ids: [rdv_solidarites_user_id],
         motif_id: other_rdv_solidarites_motif_id,
-        service_id: other_rdv_solidarites_service_id
+        service_id: other_rdv_solidarites_service_id,
+        commit: "Afficher les créneaux"
       }
       "http://www.rdv-solidarites-test.localhost/admin/organisations/#{rdv_solidarites_organisation_id}/" \
         "agent_searches?#{params.to_query}"
@@ -260,7 +273,8 @@ describe "Agents can convene applicant to rdv", js: true do
         params = {
           user_ids: [rdv_solidarites_user_id],
           motif_id: other_rdv_solidarites_motif_id,
-          service_id: other_rdv_solidarites_service_id
+          service_id: other_rdv_solidarites_service_id,
+          commit: "Afficher les créneaux"
         }
         "http://www.rdv-solidarites-test.localhost/admin/organisations/393/" \
           "agent_searches?#{params.to_query}"


### PR DESCRIPTION
Dans cette PR je filtre les motifs supprimés pour la convocation.
J'ajoute également un paramètre de commit pour afficher directement les créneaux disponibles.