### PR TITLE
feat(app): Do not set expiration for session duration

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,4 @@
 Rails.application.config.session_store(
   :cookie_store,
-  key: "_rdv_insertion_session",
-  expire_after: 2.hours
+  key: "_rdv_insertion_session"
 )


### PR DESCRIPTION
Lorsque l'application a été créé on ne vérifiait pas si le token de session de RDV-S était valide à chaque requête. 
Par conséquent si on invalidait le token RDV-Solidarités en se connectant à RDVI sur un autre navigateur (ou par API) des sessions RDVI pouvaient rester ouverte sans qu'aucune requête n'aboutisse (puisque les actions ne pouvaient pas se faire sur RDV-S). L'idée était donc de faire des sessions courtes sur RDVI pour éviter ce problème.
Seulement depuis #662 on vérifie que le token est valide à chaque requête, donc on devra automatiquement se logger si le token RDVS devenait invalide. Ainsi j'enlève l'expiration sur la durée de session.