### PR TITLE
feat(app): refresh out of date rdv context statuses

### DIFF
--- a/app/jobs/refresh_out_of_date_rdv_context_statuses_job.rb
+++ b/app/jobs/refresh_out_of_date_rdv_context_statuses_job.rb
@@ -1,0 +1,19 @@
+class RefreshOutOfDateRdvContextStatusesJob < ApplicationJob
+  def perform
+    @rdv_context_ids = []
+    RdvContext.find_each do |rdv_context|
+      @rdv_context_ids << rdv_context.id if rdv_context.status != rdv_context.set_status.to_s
+    end
+
+    notify_on_mattermost
+    RefreshRdvContextStatusesJob.perform_async(@rdv_context_ids)
+  end
+
+  private
+
+  def notify_on_mattermost
+    MattermostClient.send_to_notif_channel(
+      "✨ Rafraîchit les statuts pour: #{@rdv_context_ids}"
+    )
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,3 +7,6 @@ upsert_monthly_stats_job:
 send_invitation_reminders_job:
   cron: "0 11 * * *" # we send reminders once a day, at 11:00
   class: "SendInvitationRemindersJob"
+refresh_out_of_date_rdv_context_statuses_job:
+  cron: "0 21 * * *" # we refresh out of date statuses once a day, at 21:00
+  class: "RefreshOutOfDateRdvContextStatusesJob"

--- a/spec/jobs/refresh_out_of_date_rdv_context_statuses_job_spec.rb
+++ b/spec/jobs/refresh_out_of_date_rdv_context_statuses_job_spec.rb
@@ -1,0 +1,54 @@
+describe RefreshOutOfDateRdvContextStatusesJob do
+  subject do
+    described_class.new.perform
+  end
+
+  # status out of date
+  let!(:participation1) { create(:participation, status: "unknown", rdv_context: rdv_context1) }
+  let!(:rdv1) { create(:rdv, starts_at: 1.day.ago, participations: [participation1]) }
+  let!(:rdv_context1) { create(:rdv_context, status: "rdv_pending", id: 1) }
+
+  # ok
+  let!(:rdv_context2) { create(:rdv_context, status: "not_invited", id: 2) }
+
+  # status out of date
+  let!(:rdv_context3) { create(:rdv_context, status: "invitation_pending", id: 3) }
+  let!(:invitation) { create(:invitation, sent_at: 3.days.ago) }
+  let!(:rdv3) { create(:rdv, participations: [participation3]) }
+  let!(:participation3) { create(:participation, created_at: 2.days.ago, status: "unknown", rdv_context: rdv_context3) }
+
+  # ok
+  let!(:rdv_context4) { create(:rdv_context, status: "rdv_seen", id: 4) }
+  let!(:rdv4) do
+    create(:rdv, starts_at: 1.day.ago, participations: [participation4])
+  end
+  let!(:participation4) { create(:participation, rdv_context: rdv_context4, status: "seen") }
+
+  # status out of date
+  let!(:rdv_context5) { create(:rdv_context, status: "rdv_pending", id: 5) }
+  let!(:rdv5) { create(:rdv, starts_at: 1.day.ago, participations: [participation5]) }
+  let!(:participation5) { create(:participation, status: "seen", rdv_context: rdv_context5) }
+
+  describe "#perform" do
+    before do
+      # remove rdv contexts created in callbacks
+      RdvContext.where.not(id: [1, 2, 3, 4, 5]).each(&:destroy!)
+      allow(RefreshRdvContextStatusesJob).to receive(:perform_async)
+      allow(MattermostClient).to receive(:send_to_notif_channel)
+    end
+
+    it "enqueues a refresh job for out of date rdv contexts" do
+      expect(RefreshRdvContextStatusesJob).to receive(:perform_async)
+        .with([1, 3, 5])
+      subject
+    end
+
+    it "sends a notification on mattermost" do
+      expect(MattermostClient).to receive(:send_to_notif_channel)
+        .with(
+          "✨ Rafraîchit les statuts pour: [1, 3, 5]"
+        )
+      subject
+    end
+  end
+end


### PR DESCRIPTION
Cette PR est lié à #85 .
Je fais en sorte qu'on lance une tâche tous les jours à 21h qui met à jours les statuts des `rdv_contexts` qui ne sont pas à jour.