### PR TITLE
feat(api): Add 'users' route

### DIFF
--- a/app/controllers/api/v1/applicants_controller.rb
+++ b/app/controllers/api/v1/applicants_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class ApplicantsController < ApplicationController
-      before_action :set_organisation
+      before_action :set_applicants_params, :set_organisation
       include ParamsValidationConcern
 
       def create_and_invite_many
@@ -44,6 +44,12 @@ module Api
             }
           ]
         )
+      end
+
+      def set_applicants_params
+        # we want POST users/create_and_invite_many to behave like applicants/create_and_invite_many,
+        # so we're changing the payload to have applicants instead of users
+        params[:applicants] ||= params[:users]
       end
     end
   end

--- a/app/jobs/invite_applicant_job.rb
+++ b/app/jobs/invite_applicant_job.rb
@@ -1,5 +1,5 @@
 class InviteApplicantJob < ApplicationJob
-  sidekiq_options retry: 2
+  sidekiq_options retry: 10
 
   def perform(
     applicant_id, organisation_id, invitation_attributes, motif_category_id, rdv_solidarites_session_credentials

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
           resources :applicants, only: [] do
             post :create_and_invite_many, on: :collection
           end
+          post "users/create_and_invite_many", to: "applicants#create_and_invite_many"
         end
       end
     end


### PR DESCRIPTION
Dans cette PR je fais en sorte qu'on ait une route `POST /api/v1/organisations/:rdv_solidarites_organisation_id/users/create_and_invite_many` qui prend des `users` dans le payload, et qui route vers l'action `applicants#create_and_invite_many`. 
L'idée est que l'API soit moins confusante pour les utilisateurs: on garde le terme `users` qui est utilisé dans les webhooks, et on "cache" le terme `applicants` qui est utilisé que dans notre appli. 

J'en profite pour ajouter 2 retry au job `InviteApplicantJob` (pour les cas où SIB est down par exemple)