### PR TITLE
fix(tests): fix the ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays test

### DIFF
--- a/spec/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days_spec.rb
+++ b/spec/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days_spec.rb
@@ -48,6 +48,7 @@ describe Stats::ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays, type: :s
   let!(:rdv_context3) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant3) }
 
   before do
+    # this little time travel avoids bugs in the first days of march (because february is less than 30 days)
     travel_to(Time.zone.today + 3.days)
   end
 

--- a/spec/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days_spec.rb
+++ b/spec/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days_spec.rb
@@ -47,6 +47,10 @@ describe Stats::ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays, type: :s
 
   let!(:rdv_context3) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant3) }
 
+  before do
+    travel_to(Time.zone.today + 3.days)
+  end
+
   describe "#call" do
     let!(:result) { subject }
 


### PR DESCRIPTION
Dans cette PR, je fix le test de `ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays`, qui pouvait bugger les premiers jours de mars, lorsque le premier jour du mois précédent était distant de moins de 30 jours.