### PR TITLE
fix(cron): Send mattermost notifications on prod only

### DIFF
--- a/app/helpers/environments_helper.rb
+++ b/app/helpers/environments_helper.rb
@@ -1,0 +1,9 @@
+module EnvironmentsHelper
+  def production_env?
+    ENV["SENTRY_ENVIRONMENT"] == "production"
+  end
+
+  def staging_env?
+    ENV["SENTRY_ENVIRONMENT"] == "staging"
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,13 +1,4 @@
 class ApplicationJob
   include Sidekiq::Worker
-
-  private
-
-  def production_env?
-    ENV["SENTRY_ENVIRONMENT"] == "production"
-  end
-
-  def staging_env?
-    ENV["SENTRY_ENVIRONMENT"] == "staging"
-  end
+  include EnvironmentsHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,13 @@
 class ApplicationJob
   include Sidekiq::Worker
+
+  private
+
+  def production_env?
+    ENV["SENTRY_ENVIRONMENT"] == "production"
+  end
+
+  def staging_env?
+    ENV["SENTRY_ENVIRONMENT"] == "staging"
+  end
 end

--- a/app/jobs/refresh_out_of_date_rdv_context_statuses_job.rb
+++ b/app/jobs/refresh_out_of_date_rdv_context_statuses_job.rb
@@ -5,7 +5,7 @@ class RefreshOutOfDateRdvContextStatusesJob < ApplicationJob
       @rdv_context_ids << rdv_context.id if rdv_context.status != rdv_context.set_status.to_s
     end
 
-    notify_on_mattermost
+    notify_on_mattermost if production_env?
     RefreshRdvContextStatusesJob.perform_async(@rdv_context_ids)
   end
 

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -31,10 +31,6 @@ class SendInvitationRemindersJob < ApplicationJob
                 .distinct
   end
 
-  def staging_env?
-    ENV["SENTRY_ENVIRONMENT"] == "staging"
-  end
-
   def valid_invitations_sent_3_days_ago
     @valid_invitations_sent_3_days_ago ||= \
       # we want the token to be valid for at least two days to be sure the invitation will be valid

--- a/spec/jobs/refresh_out_of_date_rdv_context_statuses_job_spec.rb
+++ b/spec/jobs/refresh_out_of_date_rdv_context_statuses_job_spec.rb
@@ -35,6 +35,7 @@ describe RefreshOutOfDateRdvContextStatusesJob do
       RdvContext.where.not(id: [1, 2, 3, 4, 5]).each(&:destroy!)
       allow(RefreshRdvContextStatusesJob).to receive(:perform_async)
       allow(MattermostClient).to receive(:send_to_notif_channel)
+      allow(ENV).to receive(:[]).with("SENTRY_ENVIRONMENT").and_return("production")
     end
 
     it "enqueues a refresh job for out of date rdv contexts" do


### PR DESCRIPTION
Je fais en sorte que les notifications mattermost ne soient envoyées qu'en production lorsque la tâche de mise à jour des statuts se lance.