### PR TITLE
fix(job): Do not process empty user profiles webhooks

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_user_profile_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_user_profile_job.rb
@@ -3,10 +3,15 @@ module RdvSolidaritesWebhooks
     def perform(data, meta)
       @data = data.deep_symbolize_keys
       @meta = meta.deep_symbolize_keys
+
+      return if @data[:user].blank?
       return if applicant.blank? || organisation.blank?
 
-      attach_applicant_to_org if event == "created"
-      remove_applicant_from_organisation if event == "destroyed"
+      if event == "destroyed"
+        remove_applicant_from_organisation
+      else
+        attach_applicant_to_org
+      end
     end
 
     private


### PR DESCRIPTION
On reçoit beaucoup de webhooks de user profiles sans user dans le payload (parce qu'ils ont été supprimés).
Je fais en sorte ici de ne pas traiter ces webhooks. J'en profite pour traiter les events `updated` de la même manière que `created` (au cas où ces jobs sont lancés manuellement depuis RDV-S)