### PR TITLE
feat(ops): Designate on watch developer each week

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ SENTRY_ENVIRONMENT=change_me
 
 # Secret used to verify webhooks coming from rdv solidarites
 RDV_SOLIDARITES_SECRET=rdv-solidarites
+
+MATTERMOST_NOTIFICATIONS_WEBHOOKS_URL=mattermost_notif_channel_url
+MATTERMOST_BUG_WEBHOOKS_URL=mattermost_bug_channel_url

--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,5 @@ SENTRY_ENVIRONMENT=change_me
 # Secret used to verify webhooks coming from rdv solidarites
 RDV_SOLIDARITES_SECRET=rdv-solidarites
 
-MATTERMOST_NOTIFICATIONS_WEBHOOKS_URL=mattermost_notif_channel_url
-MATTERMOST_BUG_WEBHOOKS_URL=mattermost_bug_channel_url
+MATTERMOST_NOTIFICATIONS_CHANNEL_URL=mattermost_notif_channel_url
+MATTERMOST_MAIN_CHANNEL_URL=mattermost_main_channel_url

--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -1,10 +1,20 @@
 class MattermostClient
   class << self
     def send_to_notif_channel(text)
+      send_message(ENV["MATTERMOST_NOTIFICATIONS_WEBHOOKS_URL"], text)
+    end
+
+    def send_to_bug_channel(text)
+      send_message(ENV["MATTERMOST_BUG_WEBHOOKS_URL"], text)
+    end
+
+    private
+
+    def send_message(url, text)
       return unless Rails.env.production?
 
       Faraday.post(
-        ENV["MATTERMOST_WEBHOOKS_URL"],
+        url,
         { text: text }.to_json,
         { "Content-Type" => "application/json" }
       )

--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -1,11 +1,11 @@
 class MattermostClient
   class << self
     def send_to_notif_channel(text)
-      send_message(ENV["MATTERMOST_NOTIFICATIONS_WEBHOOKS_URL"], text)
+      send_message(ENV["MATTERMOST_NOTIFICATIONS_CHANNEL_URL"], text)
     end
 
-    def send_to_bug_channel(text)
-      send_message(ENV["MATTERMOST_BUG_WEBHOOKS_URL"], text)
+    def send_to_main_channel(text)
+      send_message(ENV["MATTERMOST_MAIN_CHANNEL_URL"], text)
     end
 
     private

--- a/app/jobs/designate_on_watch_developer_job.rb
+++ b/app/jobs/designate_on_watch_developer_job.rb
@@ -9,8 +9,9 @@ class DesignateOnWatchDeveloperJob < ApplicationJob
       (DEVELOPERS_HANDLE.index(current_on_watch_developer_handle) + 1) % DEVELOPERS_HANDLE.length
     ]
     redis_client.set("current_on_watch_developer_handle", new_on_watch_developer_handle)
-    MattermostClient.send_to_bug_channel(
-      "@#{new_on_watch_developer_handle} est de vigie cette semaine et saura s'occuper de vous 💂!"
+    MattermostClient.send_to_main_channel(
+      "@#{new_on_watch_developer_handle} est de vigie cette semaine et saura répondre" \
+      " à vos besoins techniques (bugs, configurations, questions) 💂!"
     )
   end
 

--- a/app/jobs/designate_on_watch_developer_job.rb
+++ b/app/jobs/designate_on_watch_developer_job.rb
@@ -1,0 +1,22 @@
+class DesignateOnWatchDeveloperJob < ApplicationJob
+  DEVELOPERS_HANDLE = %w[quentin.blanc romain.neuville amine.dhobb].freeze
+
+  def perform
+    return unless production_env?
+
+    current_on_watch_developer_handle = redis_client.get("current_on_watch_developer_handle")
+    new_on_watch_developer_handle = DEVELOPERS_HANDLE[
+      (DEVELOPERS_HANDLE.index(current_on_watch_developer_handle) + 1) % DEVELOPERS_HANDLE.length
+    ]
+    redis_client.set("current_on_watch_developer_handle", new_on_watch_developer_handle)
+    MattermostClient.send_to_bug_channel(
+      "@#{new_on_watch_developer_handle} est de vigie cette semaine et saura s'occuper de vous 💂!"
+    )
+  end
+
+  private
+
+  def redis_client
+    @redis_client ||= Redis.new
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -10,3 +10,6 @@ send_invitation_reminders_job:
 refresh_out_of_date_rdv_context_statuses_job:
   cron: "0 21 * * *" # we refresh out of date statuses once a day, at 21:00
   class: "RefreshOutOfDateRdvContextStatusesJob"
+designate_on_watch_developer_job:
+  cron: "0 10 * * mon" # we designate an on watch developer once a week, monday at 10:00
+  class: "DesignateOnWatchDeveloperJob"


### PR DESCRIPTION
Dans cette PR je crée un job qui envoie tag chaque semaine le développeur de vigie dans le channel mattermost `startup-data-insertion-bug-RGPD` tous les lundi à 10h.
Pour ça je set le handle du développeur de vigie dans redis.

Remarques: 

* Il est peut-être préférable d'envoyer la notif sur `startup-data-insertion`, vous me direz ce que vous en pensez
* Je ne fais pas de tests puisque ce n'est pas une fonctionnalité directe de l'appli et ce n'est pas critique
* Il faudra ajuster les variables d'environnement et setter manuellement le développeur de garde cette semaine une fois la fonctionnalité déployée