### PR TITLE
fix(stats): optimize stats + change rythm calculation

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,7 +2,7 @@ class OrganisationsController < ApplicationController
   def index
     @organisations = policy_scope(Organisation).includes(:department, :configurations)
     @organisations_by_department = @organisations.sort_by(&:department_number).group_by(&:department)
-    redirect_to organisation_applicants_path(@organisations.first) if @organisations.count == 1
+    redirect_to organisation_applicants_path(@organisations.first) if @organisations.to_a.length == 1
   end
 
   def geolocated

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,7 +2,7 @@ class OrganisationsController < ApplicationController
   def index
     @organisations = policy_scope(Organisation).includes(:department, :configurations)
     @organisations_by_department = @organisations.sort_by(&:department_number).group_by(&:department)
-    redirect_to organisation_applicants_path(@organisations.first) if @organisations.to_a.length == 1
+    redirect_to organisation_applicants_path(@organisations.first) if @organisations.count == 1
   end
 
   def geolocated

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -18,10 +18,6 @@ class Participation < ApplicationRecord
   delegate :motif_category, to: :rdv_context
   delegate :notify_applicants?, to: :rdv, prefix: true
 
-  def delay_in_days
-    rdv.starts_at.to_datetime.mjd - created_at.to_datetime.mjd
-  end
-
   private
 
   def refresh_applicant_context_statuses

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -29,17 +29,15 @@ class Stat < ApplicationRecord
 
   # We exclude the rdvs collectifs motifs to correctly compute the rate of autonomous applicants
   def rdvs_non_collectifs_sample
-    @rdvs_non_collectifs_sample ||= Rdv.joins(:applicants)
-                                       .where(applicants: applicants_sample)
-                                       .where(motif: Motif.collectif(false))
-                                       .distinct
+    @rdvs_non_collectifs_sample ||= Rdv.where(motif: Motif.collectif(false)).distinct
   end
 
   def invited_applicants_with_rdvs_non_collectifs_sample
-    @invited_applicants_with_rdvs_non_collectifs_sample ||= Applicant.where(participations: all_participations
-                                                                     .where(rdv: rdvs_non_collectifs_sample))
-                                                                     .with_sent_invitations
-                                                                     .distinct
+    @invited_applicants_with_rdvs_non_collectifs_sample ||= \
+      applicants_sample.joins(:rdvs)
+                       .where(rdvs: rdvs_non_collectifs_sample)
+                       .with_sent_invitations
+                       .distinct
   end
 
   # We filter the rdv_contexts to keep those where the applicants were invited and created a rdv/participation

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -19,22 +19,27 @@ class Stat < ApplicationRecord
 
   # We filter the participations to only keep the rdvs/participations of the applicants in the scope
   def participations_sample
-    @participations_sample ||= all_participations.preload(:rdv).where(applicant_id: applicants_sample).distinct
-  end
-
-  # We filter the rdvs to keep the rdvs of the applicants in the scope
-  def rdvs_sample
-    @rdvs_sample ||= Rdv.joins(:applicants).where(applicants: applicants_sample).distinct
+    @participations_sample ||= all_participations.where(applicant_id: applicants_sample)
+                                                 .distinct
+                                                 .joins(:rdv)
+                                                 .select("participations.id, participations.created_at,
+                                                          participations.status, participations.rdv_id,
+                                                          rdvs.starts_at AS rdv_starts_at")
   end
 
   # We exclude the rdvs collectifs motifs to correctly compute the rate of autonomous applicants
   def rdvs_non_collectifs_sample
-    @rdvs_non_collectifs_sample ||= rdvs_sample.where(motif: Motif.collectif(false)).distinct
+    @rdvs_non_collectifs_sample ||= Rdv.joins(:applicants)
+                                       .where(applicants: applicants_sample)
+                                       .where(motif: Motif.collectif(false))
+                                       .distinct
   end
 
-  def applicants_with_rdvs_non_collectifs_sample
-    @applicants_with_rdvs_non_collectifs_sample ||= \
-      Applicant.where(participations: participations_sample.where(rdv: rdvs_non_collectifs_sample)).distinct
+  def invited_applicants_with_rdvs_non_collectifs_sample
+    @invited_applicants_with_rdvs_non_collectifs_sample ||= Applicant.where(participations: all_participations
+                                                                     .where(rdv: rdvs_non_collectifs_sample))
+                                                                     .with_sent_invitations
+                                                                     .distinct
   end
 
   # We filter the rdv_contexts to keep those where the applicants were invited and created a rdv/participation
@@ -48,8 +53,7 @@ class Stat < ApplicationRecord
 
   # We filter the applicants by organisations and retrieve deleted or archived applicants
   def applicants_sample
-    @applicants_sample ||= Applicant.includes(:participations)
-                                    .preload(rdv_contexts: :participations)
+    @applicants_sample ||= Applicant.preload(:participations)
                                     .joins(:organisations)
                                     .where(organisations: organisations_sample)
                                     .active

--- a/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
+++ b/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
@@ -13,10 +13,10 @@ module Stats
     # Delays between the first invitation and the first rdv
     def compute_average_time_between_invitation_and_rdv_in_days
       cumulated_invitation_delays = 0
-      @rdv_contexts.to_a.each do |rdv_context|
+      @rdv_contexts.find_each do |rdv_context|
         cumulated_invitation_delays += rdv_context.time_between_invitation_and_rdv_in_days
       end
-      cumulated_invitation_delays / (@rdv_contexts.to_a.length.nonzero? || 1).to_f
+      cumulated_invitation_delays / (@rdv_contexts.count.nonzero? || 1).to_f
     end
   end
 end

--- a/app/services/stats/compute_average_time_between_participation_creation_and_rdv_start_in_days.rb
+++ b/app/services/stats/compute_average_time_between_participation_creation_and_rdv_start_in_days.rb
@@ -13,10 +13,15 @@ module Stats
     # Delays between the creation of the rdvs and the rdvs date
     def compute_average_time_between_participation_creation_and_rdv_start_in_days
       cumulated_time_between_rdv_creation_and_starts = 0
-      @participations.to_a.each do |participation|
-        cumulated_time_between_rdv_creation_and_starts += participation.delay_in_days
+      @participations.find_each do |participation|
+        cumulated_time_between_rdv_creation_and_starts += delay_in_days(participation)
       end
-      cumulated_time_between_rdv_creation_and_starts / (@participations.to_a.length.nonzero? || 1).to_f
+      cumulated_time_between_rdv_creation_and_starts / (@participations.size.nonzero? || 1).to_f
+    end
+
+    def delay_in_days(participation)
+      participation.created_at.to_datetime.mjd
+      participation.rdv_starts_at.to_datetime.mjd - participation.created_at.to_datetime.mjd
     end
   end
 end

--- a/app/services/stats/compute_percentage_of_no_show.rb
+++ b/app/services/stats/compute_percentage_of_no_show.rb
@@ -11,7 +11,7 @@ module Stats
     private
 
     def compute_percentage_of_no_show
-      (@participations.count(&:noshow?) / (@participations.count(&:resolved?).nonzero? || 1).to_f) * 100
+      (@participations.noshow.count / (@participations.resolved.count.nonzero? || 1).to_f) * 100
     end
   end
 end

--- a/app/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days.rb
+++ b/app/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days.rb
@@ -12,15 +12,16 @@ module Stats
 
     # Rate of applicants with rdv seen in less than 30 days
     def compute_rate_of_applicants_with_rdv_seen_in_less_than_30_days
-      (applicants_oriented_in_less_than_30_days.to_a.length / (
-        applicants_created_more_than_30_days_ago.to_a.length.nonzero? || 1
+      (applicants_oriented_in_less_than_30_days.count / (
+        applicants_created_more_than_30_days_ago.count.nonzero? || 1
       ).to_f) * 100
     end
 
     def applicants_oriented_in_less_than_30_days
       @applicants_oriented_in_less_than_30_days ||=
-        applicants_created_more_than_30_days_ago.to_a.select do |applicant|
-          applicant.rdv_seen_delay_in_days.present? && applicant.rdv_seen_delay_in_days < 30
+        applicants_created_more_than_30_days_ago.select do |applicant|
+          applicant_rdv_seen_delay_in_days = applicant.rdv_seen_delay_in_days
+          applicant_rdv_seen_delay_in_days.present? && applicant_rdv_seen_delay_in_days < 30
         end
     end
 

--- a/app/services/stats/compute_rate_of_autonomous_applicants.rb
+++ b/app/services/stats/compute_rate_of_autonomous_applicants.rb
@@ -1,8 +1,7 @@
 module Stats
   class ComputeRateOfAutonomousApplicants < BaseService
-    def initialize(applicants:, rdvs:)
+    def initialize(applicants:)
       @applicants = applicants
-      @rdvs = rdvs
     end
 
     def call
@@ -19,14 +18,7 @@ module Stats
     end
 
     def autonomous_applicants
-      @autonomous_applicants ||= @applicants.select do |applicant|
-        applicant.id.in?(ids_of_applicants_who_created_rdvs_themselves)
-      end
-    end
-
-    def ids_of_applicants_who_created_rdvs_themselves
-      @ids_of_applicants_who_created_rdvs_themselves ||= \
-        @rdvs.joins(:applicants).select(&:created_by_user?).flat_map(&:applicant_ids)
+      @autonomous_applicants ||= @applicants.joins(:rdvs).where(rdvs: { created_by: "user" })
     end
   end
 end

--- a/app/services/stats/compute_rate_of_autonomous_applicants.rb
+++ b/app/services/stats/compute_rate_of_autonomous_applicants.rb
@@ -14,18 +14,19 @@ module Stats
     # Rate of rdvs taken in autonomy
     def compute_rate_of_autonomous_applicants
       (autonomous_applicants.count / (
-        invited_applicants.count.nonzero? || 1
+        @applicants.count.nonzero? || 1
       ).to_f) * 100
     end
 
     def autonomous_applicants
-      @autonomous_applicants ||= invited_applicants.select do |applicant|
-        applicant.id.in?(@rdvs.preload(:applicants).select(&:created_by_user?).flat_map(&:applicant_ids))
+      @autonomous_applicants ||= @applicants.select do |applicant|
+        applicant.id.in?(ids_of_applicants_who_created_rdvs_themselves)
       end
     end
 
-    def invited_applicants
-      @invited_applicants ||= @applicants.with_sent_invitations
+    def ids_of_applicants_who_created_rdvs_themselves
+      @ids_of_applicants_who_created_rdvs_themselves ||= \
+        @rdvs.joins(:applicants).select(&:created_by_user?).flat_map(&:applicant_ids)
     end
   end
 end

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -64,8 +64,7 @@ module Stats
       # the rdvs that belong to a collectif motif and the applicants that do not have at least one non collectif rdv
       def rate_of_autonomous_applicants
         ComputeRateOfAutonomousApplicants.call(
-          applicants: @stat.invited_applicants_with_rdvs_non_collectifs_sample,
-          rdvs: @stat.rdvs_non_collectifs_sample
+          applicants: @stat.invited_applicants_with_rdvs_non_collectifs_sample
         ).value
       end
 

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -27,15 +27,15 @@ module Stats
       end
 
       def applicants_count
-        @stat.all_applicants.to_a.length
+        @stat.all_applicants.count
       end
 
       def rdvs_count
-        @stat.all_participations.to_a.length
+        @stat.all_participations.count
       end
 
       def sent_invitations_count
-        @stat.invitations_sample.to_a.length
+        @stat.invitations_sample.count
       end
 
       def percentage_of_no_show
@@ -64,13 +64,13 @@ module Stats
       # the rdvs that belong to a collectif motif and the applicants that do not have at least one non collectif rdv
       def rate_of_autonomous_applicants
         ComputeRateOfAutonomousApplicants.call(
-          applicants: @stat.applicants_with_rdvs_non_collectifs_sample,
+          applicants: @stat.invited_applicants_with_rdvs_non_collectifs_sample,
           rdvs: @stat.rdvs_non_collectifs_sample
         ).value
       end
 
       def agents_count
-        @stat.agents_sample.to_a.length
+        @stat.agents_sample.count
       end
     end
   end

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -61,7 +61,8 @@ module Stats
 
       def rate_of_applicants_with_rdv_seen_in_less_than_30_days_for_focused_month
         ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays.call(
-          applicants: created_during_focused_month(@stat.applicants_for_30_days_rdvs_seen_sample)
+          # we compute the applicants of the previous month because we want at least 30 days old applicants
+          applicants: @stat.applicants_for_30_days_rdvs_seen_sample.where(created_at: (@date - 1.month).all_month)
         ).value.round
       end
 
@@ -69,7 +70,7 @@ module Stats
       # the rdvs that belong to a collectif motif and the applicants that do not have at least one non collectif rdv
       def rate_of_autonomous_applicants_for_focused_month
         ComputeRateOfAutonomousApplicants.call(
-          applicants: created_during_focused_month(@stat.applicants_with_rdvs_non_collectifs_sample),
+          applicants: created_during_focused_month(@stat.invited_applicants_with_rdvs_non_collectifs_sample),
           rdvs: created_during_focused_month(@stat.rdvs_non_collectifs_sample)
         ).value.round
       end

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -70,8 +70,7 @@ module Stats
       # the rdvs that belong to a collectif motif and the applicants that do not have at least one non collectif rdv
       def rate_of_autonomous_applicants_for_focused_month
         ComputeRateOfAutonomousApplicants.call(
-          applicants: created_during_focused_month(@stat.invited_applicants_with_rdvs_non_collectifs_sample),
-          rdvs: created_during_focused_month(@stat.rdvs_non_collectifs_sample)
+          applicants: created_during_focused_month(@stat.invited_applicants_with_rdvs_non_collectifs_sample)
         ).value.round
       end
 

--- a/app/services/stats/monthly_stats/upsert_stat.rb
+++ b/app/services/stats/monthly_stats/upsert_stat.rb
@@ -20,7 +20,12 @@ module Stats
       def merge_monthly_stats_attributes_for_focused_month_to_stat_record
         compute_monthly_stats_for_focused_month.stats_values.each do |stat_name, stat_value|
           stat_attribute = stat[stat_name] || {}
-          stat_attribute.merge!({ date.strftime("%m/%Y") => stat_value })
+          if stat_name == :rate_of_applicants_with_rdv_seen_in_less_than_30_days_by_month
+            # cette stat est calculée avec 1 mois de décalage par rapport aux autres
+            stat_attribute.merge!({ (date - 1.month).strftime("%m/%Y") => stat_value })
+          else
+            stat_attribute.merge!({ date.strftime("%m/%Y") => stat_value })
+          end
           stat[stat_name] = stat_attribute
         end
       end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,8 +1,8 @@
 upsert_global_stats_job:
-  cron: "0 22 * * sat" # we compute global stats once a week, the saturday at 22:00
+  cron: "0 22 * * 6" # we compute global stats once a week, the saturday at 22:00
   class: "Stats::GlobalStats::UpsertStatsJob"
 upsert_monthly_stats_job:
-  cron: "0 23 last * *" # we compute monthly stats the last day of the month, at 23:00
+  cron: "0 22 * * 7" # we compute monthly stats once a week, the sunday at 22:00
   class: "Stats::MonthlyStats::UpsertStatsJob"
 send_invitation_reminders_job:
   cron: "0 11 * * *" # we send reminders once a day, at 11:00

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -223,27 +223,13 @@ describe Stat do
 
       describe "#rdvs_non_collectifs_sample" do
         let!(:applicant3) do
-          create(:applicant, department: department, organisations: [organisation_with_no_configuration])
-        end
-        let!(:rdv3) { create(:rdv, organisation: organisation_with_no_configuration, motif: motif) }
-        let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
-        let!(:applicant4) do
           create(:applicant, department: department, organisations: [organisation])
         end
-        let!(:rdv4) { create(:rdv, organisation: organisation, motif: motif_collectif) }
-        let!(:participation4) { create(:participation, rdv: rdv4, applicant: applicant4) }
-
-        it "scopes the collection to the department" do
-          expect(stat.rdvs_non_collectifs_sample).to include(rdv1)
-          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv2)
-        end
-
-        it "does not include rdvs of irrelevant applicants" do
-          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv3)
-        end
+        let!(:rdv3) { create(:rdv, organisation: organisation, motif: motif_collectif) }
+        let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
 
         it "does not include collectifs rdvs" do
-          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv4)
+          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv3)
         end
       end
 
@@ -370,12 +356,6 @@ describe Stat do
       describe "#rdv_contexts_sample" do
         it "does not scope the collection to the department" do
           expect(stat.rdv_contexts_sample).to include(rdv_context2)
-        end
-      end
-
-      describe "#rdvs_non_collectifs_sample" do
-        it "does not scope the collection to the department" do
-          expect(stat.rdvs_non_collectifs_sample).to include(rdv2)
         end
       end
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -29,11 +29,11 @@ describe Stat do
     let!(:other_department) { create(:department) }
     let!(:applicant1) do
       create(:applicant, department: department, organisations: [organisation],
-                         created_at: 1.month.ago.beginning_of_month)
+                         created_at: date)
     end
     let!(:applicant2) do
       create(:applicant, department: other_department, organisations: [other_organisation],
-                         created_at: 1.month.ago.beginning_of_month)
+                         created_at: date)
     end
     let!(:configuration) { create(:configuration) }
     let!(:organisation) { create(:organisation, department: department, configurations: [configuration]) }
@@ -216,7 +216,7 @@ describe Stat do
           expect(stat.rdv_contexts_sample).not_to include(rdv_context5)
         end
 
-        it "does not include rdv_contexts of irrelevant applicants" do
+        it "does not include the rdv_contexts of applicants from irrelevant organisations" do
           expect(stat.rdv_contexts_sample).not_to include(rdv_context6)
         end
       end
@@ -235,7 +235,7 @@ describe Stat do
 
       describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
         let!(:applicant3) do
-          create(:applicant, department: department, organisations: [other_organisation])
+          create(:applicant, department: department, organisations: [organisation_with_no_configuration])
         end
         let!(:applicant4) { create(:applicant, department: department, organisations: [organisation]) }
         let!(:applicant5) { create(:applicant, department: department, organisations: [organisation]) }
@@ -259,7 +259,7 @@ describe Stat do
           expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant2)
         end
 
-        it "does not include the irrelevant applicants" do
+        it "does not include the applicant from irrelevant organisations" do
           expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant3)
         end
 
@@ -283,7 +283,7 @@ describe Stat do
       describe "#applicants_for_30_days_rdvs_seen_sample" do
         let!(:applicant3) do
           create(:applicant, department: department, organisations: [organisation],
-                             created_at: 1.month.ago.beginning_of_month)
+                             created_at: date)
         end
         let!(:rdv_context3) do
           create(:rdv_context, applicant: applicant3, motif_category: category_rsa_cer_signature)

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -1,4 +1,6 @@
 describe Stat do
+  include_context "with all existing categories"
+
   describe "department_number validation" do
     context "when the department_number is present" do
       let!(:stat) { build(:stat, department_number: "1") }
@@ -23,6 +25,7 @@ describe Stat do
   describe "instance_methods" do
     let!(:department) { create(:department) }
     let!(:stat) { build(:stat, department_number: department.number) }
+    let(:date) { Time.zone.parse("17/03/2022 12:00") }
     let!(:other_department) { create(:department) }
     let!(:applicant1) do
       create(:applicant, department: department, organisations: [organisation],
@@ -36,15 +39,16 @@ describe Stat do
     let!(:organisation) { create(:organisation, department: department, configurations: [configuration]) }
     let!(:organisation_with_no_configuration) { create(:organisation, department: department) }
     let!(:other_organisation) { create(:organisation, department: other_department, configurations: [configuration]) }
-    let!(:rdv1) { create(:rdv, organisation: organisation, created_by: "user") }
-    let!(:rdv2) { create(:rdv, organisation: other_organisation, created_by: "user") }
+    let!(:motif) { create(:motif, collectif: false) }
+    let!(:motif_collectif) { create(:motif, collectif: true) }
+    let!(:rdv1) { create(:rdv, organisation: organisation, created_by: "user", motif: motif, starts_at: date) }
+    let!(:rdv2) { create(:rdv, organisation: other_organisation, created_by: "user", motif: motif) }
     let!(:invitation1) do
-      create(:invitation, applicant: applicant1, department: department, sent_at: Time.zone.today)
+      create(:invitation, applicant: applicant1, department: department, sent_at: date)
     end
     let!(:invitation2) do
-      create(:invitation, applicant: applicant2, department: other_department, sent_at: Time.zone.today)
+      create(:invitation, applicant: applicant2, department: other_department, sent_at: date)
     end
-    let!(:invitation3) { create(:invitation, department: department, sent_at: nil) }
     let!(:agent1) { create(:agent, organisations: [organisation], has_logged_in: true) }
     let!(:agent2) { create(:agent, organisations: [other_organisation], has_logged_in: true) }
     let!(:participation1) { create(:participation, rdv: rdv1, applicant: applicant1) }
@@ -57,8 +61,6 @@ describe Stat do
       create(:rdv_context, applicant: applicant2, invitations: [invitation2],
                            participations: [participation2], motif_category: category_rsa_orientation)
     end
-    let!(:category_rsa_orientation) { create(:motif_category, short_name: "rsa_orientation") }
-    let!(:category_rsa_cer_signature) { create(:motif_category, short_name: "rsa_cer_signature") }
 
     context "when department_number is not 'all'" do
       describe "#all_applicants" do
@@ -83,6 +85,8 @@ describe Stat do
       end
 
       describe "#invitations_sample" do
+        let!(:invitation3) { create(:invitation, department: department, sent_at: nil) }
+
         it "scopes the collection to the department" do
           expect(stat.invitations_sample).to include(invitation1)
           expect(stat.invitations_sample).not_to include(invitation2)
@@ -90,6 +94,17 @@ describe Stat do
 
         it "scopes the collection to sent invitations" do
           expect(stat.invitations_sample).not_to include(invitation3)
+        end
+      end
+
+      describe "#participations_sample" do
+        it "scopes the collection to the department" do
+          expect(stat.participations_sample).to include(participation1)
+          expect(stat.participations_sample).not_to include(participation2)
+        end
+
+        it "returns a rdv_starts_at" do
+          expect(stat.participations_sample.first.rdv_starts_at).to eq(date)
         end
       end
 
@@ -112,10 +127,10 @@ describe Stat do
 
       describe "#applicants_sample" do
         let!(:applicant3) do
-          create(:applicant, department: department, organisations: [organisation], deleted_at: Time.zone.today)
+          create(:applicant, department: department, organisations: [organisation], deleted_at: date)
         end
         let!(:applicant4) do
-          create(:applicant, department: department, organisations: [organisation], archived_at: Time.zone.today)
+          create(:applicant, department: department, organisations: [organisation], archived_at: date)
         end
         let!(:applicant5) do
           create(:applicant, department: department, organisations: [organisation_with_no_configuration])
@@ -177,7 +192,7 @@ describe Stat do
         let!(:applicant6) do
           create(:applicant, department: department, organisations: [organisation_with_no_configuration])
         end
-        let!(:invitation6) { create(:invitation, sent_at: Time.zone.today) }
+        let!(:invitation6) { create(:invitation, sent_at: date) }
         let!(:rdv6) { create(:rdv, organisation: organisation) }
         let!(:participation6) { create(:participation, rdv: rdv6) }
         let!(:rdv_context6) do
@@ -206,20 +221,76 @@ describe Stat do
         end
       end
 
-      describe "#rdvs_sample" do
+      describe "#rdvs_non_collectifs_sample" do
         let!(:applicant3) do
           create(:applicant, department: department, organisations: [organisation_with_no_configuration])
         end
-        let!(:rdv3) { create(:rdv, organisation: organisation_with_no_configuration) }
+        let!(:rdv3) { create(:rdv, organisation: organisation_with_no_configuration, motif: motif) }
         let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
+        let!(:applicant4) do
+          create(:applicant, department: department, organisations: [organisation])
+        end
+        let!(:rdv4) { create(:rdv, organisation: organisation, motif: motif_collectif) }
+        let!(:participation4) { create(:participation, rdv: rdv4, applicant: applicant4) }
 
         it "scopes the collection to the department" do
-          expect(stat.rdvs_sample).to include(rdv1)
-          expect(stat.rdvs_sample).not_to include(rdv2)
+          expect(stat.rdvs_non_collectifs_sample).to include(rdv1)
+          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv2)
         end
 
         it "does not include rdvs of irrelevant applicants" do
-          expect(stat.rdvs_sample).not_to include(rdv3)
+          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv3)
+        end
+
+        it "does not include collectifs rdvs" do
+          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv4)
+        end
+      end
+
+      describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
+        let!(:applicant3) do
+          create(:applicant, department: department, organisations: [other_organisation])
+        end
+        let!(:applicant4) { create(:applicant, department: department, organisations: [organisation]) }
+        let!(:applicant5) { create(:applicant, department: department, organisations: [organisation]) }
+        let!(:applicant6) { create(:applicant, department: department, organisations: [organisation]) }
+        let!(:applicant7) { create(:applicant, department: department, organisations: [organisation]) }
+        let!(:invitation3) { create(:invitation, applicant: applicant3, department: department, sent_at: date) }
+        let!(:invitation5) { create(:invitation, applicant: applicant5, department: department) }
+        let!(:invitation6) { create(:invitation, applicant: applicant6, department: department, sent_at: date) }
+        let!(:invitation7) { create(:invitation, applicant: applicant7, department: department, sent_at: date) }
+        let!(:rdv3) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
+        let!(:rdv4) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
+        let!(:rdv5) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
+        let!(:rdv7) { create(:rdv, organisation: organisation, created_by: "user", motif: motif_collectif) }
+        let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
+        let!(:participation4) { create(:participation, rdv: rdv4, applicant: applicant4) }
+        let!(:participation5) { create(:participation, rdv: rdv5, applicant: applicant5) }
+        let!(:participation7) { create(:participation, rdv: rdv7, applicant: applicant7) }
+
+        it "scopes the collection to the department" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).to include(applicant1)
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant2)
+        end
+
+        it "does not include the irrelevant applicants" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant3)
+        end
+
+        it "does not include the applicants whith no invitations" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant4)
+        end
+
+        it "does not include the applicants whith no sent invitation" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant5)
+        end
+
+        it "does not include the applicants whith no rdvs" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant6)
+        end
+
+        it "does not include the applicants whith collectifs rdvs" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant7)
         end
       end
 
@@ -271,6 +342,12 @@ describe Stat do
         end
       end
 
+      describe "#participations_sample" do
+        it "does not scope the collection to the department" do
+          expect(stat.participations_sample).to include(participation2)
+        end
+      end
+
       describe "#organisations_sample" do
         it "does not scope the collection to the department" do
           expect(stat.organisations_sample).to include(other_organisation)
@@ -296,9 +373,15 @@ describe Stat do
         end
       end
 
-      describe "#rdvs_sample" do
+      describe "#rdvs_non_collectifs_sample" do
         it "does not scope the collection to the department" do
-          expect(stat.rdvs_sample).to include(rdv2)
+          expect(stat.rdvs_non_collectifs_sample).to include(rdv2)
+        end
+      end
+
+      describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
+        it "does not scope the collection to the department" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).to include(applicant2)
         end
       end
 

--- a/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
+++ b/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
@@ -1,31 +1,25 @@
 describe Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays, type: :service do
   subject { described_class.call(rdv_contexts: rdv_contexts) }
 
-  let!(:first_day_of_last_month) { 1.month.ago.beginning_of_month }
+  let(:date) { Time.zone.parse("17/03/2022 12:00") }
 
   let!(:rdv_contexts) { RdvContext.where(id: [rdv_context1, rdv_context2]) }
 
   # First rdv_context : 2 days delay between first invitation sent_at and first participation creation
-  let!(:rdv_context1) { create(:rdv_context, created_at: first_day_of_last_month) }
-  let!(:invitation1) do
-    create(:invitation, created_at: first_day_of_last_month, sent_at: first_day_of_last_month,
-                        rdv_context: rdv_context1)
-  end
+  let!(:rdv_context1) { create(:rdv_context, created_at: date) }
+  let!(:invitation1) { create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context1) }
   let!(:participation1) do
-    create(:participation, rdv_context: rdv_context1, created_at: (first_day_of_last_month + 2.days), status: "seen")
+    create(:participation, rdv_context: rdv_context1, created_at: (date + 2.days), status: "seen")
   end
-  let!(:rdv1) { create(:rdv, created_at: (first_day_of_last_month + 2.days), participations: [participation1]) }
+  let!(:rdv1) { create(:rdv, created_at: (date + 2.days), participations: [participation1]) }
 
   # Second rdv_context : 4 days delay between first invitation sent_at and first participation creation
-  let!(:rdv_context2) { create(:rdv_context, created_at: first_day_of_last_month) }
-  let!(:invitation2) do
-    create(:invitation, created_at: first_day_of_last_month, sent_at: first_day_of_last_month,
-                        rdv_context: rdv_context2)
-  end
+  let!(:rdv_context2) { create(:rdv_context, created_at: date) }
+  let!(:invitation2) { create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context2) }
   let!(:participation2) do
-    create(:participation, rdv_context: rdv_context2, created_at: (first_day_of_last_month + 4.days), status: "seen")
+    create(:participation, rdv_context: rdv_context2, created_at: (date + 4.days), status: "seen")
   end
-  let!(:rdv2) { create(:rdv, created_at: (first_day_of_last_month + 4.days), participations: [participation2]) }
+  let!(:rdv2) { create(:rdv, created_at: (date + 4.days), participations: [participation2]) }
 
   describe "#call" do
     let!(:result) { subject }

--- a/spec/services/stats/compute_average_time_between_participation_creation_and_rdv_start_in_days_spec.rb
+++ b/spec/services/stats/compute_average_time_between_participation_creation_and_rdv_start_in_days_spec.rb
@@ -1,17 +1,23 @@
 describe Stats::ComputeAverageTimeBetweenParticipationCreationAndRdvStartInDays, type: :service do
   subject { described_class.call(participations: participations) }
 
-  let!(:first_day_of_last_month) { 1.month.ago.beginning_of_month }
+  let(:date) { Time.zone.parse("17/03/2022 12:00") }
 
-  let!(:participations) { Participation.where(id: [participation1, participation2]) }
+  let!(:participations) do
+    Participation.where(id: [participation1, participation2])
+                 .joins(:rdv)
+                 .select("participations.id, participations.created_at,
+                          participations.status, participations.rdv_id,
+                          rdvs.starts_at AS rdv_starts_at")
+  end
 
   # First rdv : created 1 month ago, 2 days delay between created_at and starts_at
-  let!(:rdv1) { create(:rdv, starts_at: (first_day_of_last_month + 2.days)) }
-  let!(:participation1) { create(:participation, created_at: first_day_of_last_month, rdv: rdv1) }
+  let!(:rdv1) { create(:rdv, starts_at: (date + 2.days)) }
+  let!(:participation1) { create(:participation, created_at: date, rdv: rdv1) }
 
   # Second rdv : created 1 month ago, 4 days delay between created_at and starts_at
-  let!(:rdv2) { create(:rdv, starts_at: (first_day_of_last_month + 4.days)) }
-  let!(:participation2) { create(:participation, created_at: first_day_of_last_month, rdv: rdv2) }
+  let!(:rdv2) { create(:rdv, starts_at: (date + 4.days)) }
+  let!(:participation2) { create(:participation, created_at: date, rdv: rdv2) }
 
   describe "#call" do
     let!(:result) { subject }

--- a/spec/services/stats/compute_percentage_of_no_show_spec.rb
+++ b/spec/services/stats/compute_percentage_of_no_show_spec.rb
@@ -1,15 +1,15 @@
 describe Stats::ComputePercentageOfNoShow, type: :service do
   subject { described_class.call(participations: participations) }
 
-  let!(:first_day_of_last_month) { 1.month.ago.beginning_of_month }
+  let(:date) { Time.zone.parse("17/03/2022 12:00") }
 
   let!(:participations) { Participation.where(id: [participation1, participation2]) }
 
   # First rdv : created 1 month ago, seen status
-  let!(:participation1) { create(:participation, created_at: first_day_of_last_month, status: "seen") }
+  let!(:participation1) { create(:participation, created_at: date, status: "seen") }
 
   # Second rdv : created 1 month ago, noshow status
-  let!(:participation2) { create(:participation, created_at: first_day_of_last_month, status: "noshow") }
+  let!(:participation2) { create(:participation, created_at: date, status: "noshow") }
 
   describe "#call" do
     let!(:result) { subject }

--- a/spec/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days_spec.rb
+++ b/spec/services/stats/compute_rate_of_applicants_with_rdv_seen_in_less_than_thirty_days_spec.rb
@@ -1,51 +1,45 @@
 describe Stats::ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays, type: :service do
   subject { described_class.call(applicants: applicants) }
 
-  let!(:first_day_of_last_month) { 1.month.ago.beginning_of_month }
+  let(:date) { Time.zone.parse("17/03/2022 12:00") }
 
   let!(:applicants) { Applicant.where(id: [applicant1, applicant2, applicant3, applicant4]) }
 
   # First applicant : created 1 month ago, has a rdv_seen_delay_in_days present and the delay is less than 30 days
   # => considered as oriented in less than 30 days
-  let!(:applicant1) { create(:applicant, created_at: first_day_of_last_month) }
-  let!(:rdv_context1) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant1) }
-  let!(:rdv1) do
-    create(:rdv, created_at: first_day_of_last_month, starts_at: (first_day_of_last_month + 2.days), status: "seen")
-  end
+  let!(:applicant1) { create(:applicant, created_at: date) }
+  let!(:rdv_context1) { create(:rdv_context, created_at: date, applicant: applicant1) }
+  let!(:rdv1) { create(:rdv, created_at: date, starts_at: (date + 2.days), status: "seen") }
   let!(:participation1) do
     create(:participation, rdv_context: rdv_context1, applicant: applicant1,
-                           rdv: rdv1, created_at: first_day_of_last_month, status: "seen")
+                           rdv: rdv1, created_at: date, status: "seen")
   end
 
   # Second applicant : created 1 month ago, has a rdv_seen_delay_in_days present and the delay is more than 30 days
   # => not considered as oriented in less than 30 days
-  let!(:applicant2) { create(:applicant, created_at: first_day_of_last_month) }
-  let!(:rdv_context2) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant2) }
-  let!(:rdv2) do
-    create(:rdv, created_at: first_day_of_last_month, starts_at: (first_day_of_last_month + 33.days), status: "seen")
-  end
+  let!(:applicant2) { create(:applicant, created_at: date) }
+  let!(:rdv_context2) { create(:rdv_context, created_at: date, applicant: applicant2) }
+  let!(:rdv2) { create(:rdv, created_at: date, starts_at: (date + 33.days), status: "seen") }
   let!(:participation2) do
     create(:participation, rdv_context: rdv_context2, applicant: applicant2,
-                           rdv: rdv2, created_at: first_day_of_last_month, status: "seen")
+                           rdv: rdv2, created_at: date, status: "seen")
   end
 
   # Third applicant : created 1 month ago, has no rdv_seen_delay_in_days present
   # => not considered as oriented in less than 30 days
-  let!(:applicant3) { create(:applicant, created_at: first_day_of_last_month) }
+  let!(:applicant3) { create(:applicant, created_at: date) }
 
   # Fourth applicant : everything okay but created less than 30 days ago
   # not taken into account in the computing
   let!(:applicant4) { create(:applicant, created_at: Time.zone.today) }
   let!(:rdv_context4) { create(:rdv_context, created_at: Time.zone.today, applicant: applicant4) }
-  let!(:rdv4) do
-    create(:rdv, created_at: Time.zone.today, starts_at: (Time.zone.today + 2.days), status: "seen")
-  end
+  let!(:rdv4) { create(:rdv, created_at: Time.zone.today, starts_at: (Time.zone.today + 2.days), status: "seen") }
   let!(:participation4) do
     create(:participation, rdv_context: rdv_context4, applicant: applicant4,
                            rdv: rdv4, created_at: Time.zone.today, status: "seen")
   end
 
-  let!(:rdv_context3) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant3) }
+  let!(:rdv_context3) { create(:rdv_context, created_at: date, applicant: applicant3) }
 
   before do
     # this little time travel avoids bugs in the first days of march (because february is less than 30 days)

--- a/spec/services/stats/compute_rate_of_autonomous_applicants_spec.rb
+++ b/spec/services/stats/compute_rate_of_autonomous_applicants_spec.rb
@@ -1,5 +1,5 @@
 describe Stats::ComputeRateOfAutonomousApplicants, type: :service do
-  subject { described_class.call(applicants: applicants, rdvs: rdvs) }
+  subject { described_class.call(applicants: applicants) }
 
   let(:date) { Time.zone.parse("17/03/2022 12:00") }
 

--- a/spec/services/stats/compute_rate_of_autonomous_applicants_spec.rb
+++ b/spec/services/stats/compute_rate_of_autonomous_applicants_spec.rb
@@ -1,68 +1,50 @@
 describe Stats::ComputeRateOfAutonomousApplicants, type: :service do
   subject { described_class.call(applicants: applicants, rdvs: rdvs) }
 
-  let!(:first_day_of_last_month) { 1.month.ago.beginning_of_month }
+  let(:date) { Time.zone.parse("17/03/2022 12:00") }
 
-  let!(:applicants) { Applicant.where(id: [applicant1, applicant2, applicant3, applicant4, applicant5]) }
+  let!(:applicants) { Applicant.where(id: [applicant1, applicant2, applicant3, applicant4]) }
   let!(:rdvs) { Rdv.where(id: [rdv1, rdv2, rdv3]) }
 
   # First applicant : created 1 month ago, has a rdv taken in autonomy
-  let!(:applicant1) { create(:applicant, created_at: first_day_of_last_month) }
+  let!(:applicant1) { create(:applicant, created_at: date) }
   let!(:invitation1) do
-    create(:invitation, created_at: first_day_of_last_month, sent_at: first_day_of_last_month,
-                        rdv_context: rdv_context1, applicant: applicant1)
+    create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context1, applicant: applicant1)
   end
-  let!(:rdv_context1) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant1) }
-  let!(:rdv1) do
-    create(:rdv, created_at: first_day_of_last_month, created_by: "user")
-  end
+  let!(:rdv_context1) { create(:rdv_context, created_at: date, applicant: applicant1) }
+  let!(:rdv1) { create(:rdv, created_at: date, created_by: "user") }
   let!(:participation1) do
-    create(:participation, rdv_context: rdv_context1, applicant: applicant1,
-                           rdv: rdv1, created_at: first_day_of_last_month)
+    create(:participation, rdv_context: rdv_context1, applicant: applicant1, rdv: rdv1, created_at: date)
   end
 
   # Second applicant : created 1 month ago, has a rdv not taken in autonomy
-  let!(:applicant2) { create(:applicant, created_at: first_day_of_last_month) }
+  let!(:applicant2) { create(:applicant, created_at: date) }
   let!(:invitation2) do
-    create(:invitation, created_at: first_day_of_last_month, sent_at: first_day_of_last_month,
-                        rdv_context: rdv_context2, applicant: applicant2)
+    create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context2, applicant: applicant2)
   end
-  let!(:rdv_context2) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant2) }
-  let!(:rdv2) do
-    create(:rdv, created_at: first_day_of_last_month, created_by: "agent")
-  end
+  let!(:rdv_context2) { create(:rdv_context, created_at: date, applicant: applicant2) }
+  let!(:rdv2) { create(:rdv, created_at: date, created_by: "agent") }
   let!(:participation2) do
-    create(:participation, rdv_context: rdv_context2, applicant: applicant2,
-                           rdv: rdv2, created_at: first_day_of_last_month)
+    create(:participation, rdv_context: rdv_context2, applicant: applicant2, rdv: rdv2, created_at: date)
   end
 
   # Third applicant : created 1 month ago, has a rdv taken in autonomy
-  let!(:applicant3) { create(:applicant, created_at: first_day_of_last_month) }
+  let!(:applicant3) { create(:applicant, created_at: date) }
   let!(:invitation3) do
-    create(:invitation, created_at: first_day_of_last_month, sent_at: first_day_of_last_month,
-                        rdv_context: rdv_context3, applicant: applicant3)
+    create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context3, applicant: applicant3)
   end
-  let!(:rdv_context3) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant3) }
-  let!(:rdv3) do
-    create(:rdv, created_at: first_day_of_last_month, created_by: "user")
-  end
+  let!(:rdv_context3) { create(:rdv_context, created_at: date, applicant: applicant3) }
+  let!(:rdv3) { create(:rdv, created_at: date, created_by: "user") }
   let!(:participation3) do
-    create(:participation, rdv_context: rdv_context3, applicant: applicant3,
-                           rdv: rdv3, created_at: first_day_of_last_month)
+    create(:participation, rdv_context: rdv_context3, applicant: applicant3, rdv: rdv3, created_at: date)
   end
 
-  # Fourth applicant : created 1 month ago, has not been invited
-  # => should not be taken into account to compute the percentage
-  let!(:applicant4) { create(:applicant, created_at: first_day_of_last_month) }
-  let!(:rdv_context4) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant4) }
-
-  # Fifth applicant : created 1 month ago, has been invited but has not take any rdv
-  let!(:applicant5) { create(:applicant, created_at: first_day_of_last_month) }
-  let!(:invitation5) do
-    create(:invitation, created_at: first_day_of_last_month, sent_at: first_day_of_last_month,
-                        rdv_context: rdv_context5, applicant: applicant5)
+  # Fourth applicant : created 1 month ago, has been invited but has not take any rdv
+  let!(:applicant4) { create(:applicant, created_at: date) }
+  let!(:invitation4) do
+    create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context4, applicant: applicant4)
   end
-  let!(:rdv_context5) { create(:rdv_context, created_at: first_day_of_last_month, applicant: applicant5) }
+  let!(:rdv_context4) { create(:rdv_context, created_at: date, applicant: applicant4) }
 
   describe "#call" do
     let!(:result) { subject }

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -35,8 +35,6 @@ describe Stats::GlobalStats::Compute, type: :service do
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:rdvs_non_collectifs_sample)
-        .and_return(Rdv.where(id: [rdv1, rdv2]))
       allow(stat).to receive(:agents_sample)
         .and_return(Agent.where(id: [agent]))
       allow(Stats::ComputePercentageOfNoShow).to receive(:call)
@@ -128,9 +126,8 @@ describe Stats::GlobalStats::Compute, type: :service do
 
     it "computes the percentage of invited applicants with at least on rdv taken in autonomy" do
       expect(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
-      expect(stat).to receive(:rdvs_non_collectifs_sample)
       expect(Stats::ComputeRateOfAutonomousApplicants).to receive(:call)
-        .with(applicants: [applicant1, applicant2], rdvs: [rdv1, rdv2])
+        .with(applicants: [applicant1, applicant2])
       subject
     end
 

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -3,8 +3,6 @@ describe Stats::GlobalStats::Compute, type: :service do
 
   let!(:stat) { create(:stat, department_number: department.number) }
 
-  let!(:first_day_of_last_month) { 1.month.ago.beginning_of_month }
-
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department: department) }
   let!(:applicant1) { create(:applicant, department: department) }
@@ -29,15 +27,13 @@ describe Stats::GlobalStats::Compute, type: :service do
         .and_return(Invitation.where(id: [invitation1, invitation2]))
       allow(stat).to receive(:participations_sample)
         .and_return(Participation.where(id: [participation1, participation2]))
-      allow(stat).to receive(:rdvs_sample)
-        .and_return(Rdv.where(id: [rdv1, rdv2]))
       allow(stat).to receive(:rdv_contexts_sample)
         .and_return(RdvContext.where(id: [rdv_context1, rdv_context2]))
       allow(stat).to receive(:applicants_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:applicants_with_rdvs_non_collectifs_sample)
+      allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:rdvs_non_collectifs_sample)
         .and_return(Rdv.where(id: [rdv1, rdv2]))
@@ -131,7 +127,7 @@ describe Stats::GlobalStats::Compute, type: :service do
     end
 
     it "computes the percentage of invited applicants with at least on rdv taken in autonomy" do
-      expect(stat).to receive(:applicants_with_rdvs_non_collectifs_sample)
+      expect(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
       expect(stat).to receive(:rdvs_non_collectifs_sample)
       expect(Stats::ComputeRateOfAutonomousApplicants).to receive(:call)
         .with(applicants: [applicant1, applicant2], rdvs: [rdv1, rdv2])

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -41,8 +41,6 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:rdvs_non_collectifs_sample)
-        .and_return(Rdv.where(id: [rdv1, rdv2]))
       allow(Stats::ComputePercentageOfNoShow).to receive(:call)
         .and_return(OpenStruct.new(success?: true, value: 50.0))
       allow(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
@@ -133,10 +131,8 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
 
     it "computes the percentage of invited applicants with at least on rdv taken in autonomy" do
       expect(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
-      expect(stat).to receive(:rdvs_non_collectifs_sample)
       expect(Stats::ComputeRateOfAutonomousApplicants).to receive(:call)
-        .with(applicants: [applicant1],
-              rdvs: [rdv1])
+        .with(applicants: [applicant1])
       subject
     end
   end

--- a/spec/services/stats/monthly_stats/upsert_stat_spec.rb
+++ b/spec/services/stats/monthly_stats/upsert_stat_spec.rb
@@ -2,7 +2,7 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
   subject { described_class.call(department_number: department.number, date_string: date_string) }
 
   let!(:department) { create(:department) }
-  let!(:date_string) { 1.month.ago.to_s }
+  let!(:date_string) { "2022-03-17 12:00:00 +0100" }
   let!(:date) { date_string.to_date }
   let!(:stats_values) do
     {
@@ -55,7 +55,7 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
         { date.strftime("%m/%Y") => 6 }
       )
       expect(stat.reload[:rate_of_applicants_with_rdv_seen_in_less_than_30_days_by_month]).to eq(
-        { date.strftime("%m/%Y") => 7 }
+        { (date - 1.month).strftime("%m/%Y") => 7 }
       )
       expect(stat.reload[:rate_of_autonomous_applicants_grouped_by_month]).to eq({ date.strftime("%m/%Y") => 8 })
     end


### PR DESCRIPTION
closes #836 (inch'allah)
closes #855

📅📊
Pour la PR 855:
- la stat mensuelle sur le `rate_of_applicants_with_rdv_seen_in_less_than_30_days` est calculée avec un mois de décalage par rapport au reste (pour permettre aux bénéficiaires d'acquérir 30 jours "d'ancienneté")
- je calcule les stats mensuelles toutes les semaines : cela permet de calculer en début de mois la stat `rate_of_applicants_with_rdv_seen_in_less_than_30_days` pour m-2 ; pour les autres stats, cela permet d'avoir des stats plus rapidement pour m-1. Pour les "compteurs" de rdvs, invitations, benef, agents, c'est parfait ; pour les autres stats, qui pourraient être imcomplètes à ce moment-là, cela donne une première idée, qui sera updatée régulièrement jusqu'à la fin du mois.

🎉🛁🚧🛺 (ces emojis n'ont aucun sens mais c'est pour vous inciter à continuer à lire)
Pour la PR 836, différentes optimisations. Les principaux buts poursuivis (et normalement atteints) : 
- supprimer les requêtes n+1
- limiter ce qui est mis en mémoire (notamment en remplaçant les `to_a.length` par des `count`, et des `to_a` par des `find_each`)
- à noter : pour le `participations_sample`, j'évite de `preload`ou de `eager_load` les `rdvs` en extrayant uniquement le champ nécessaire de `rdv` avec un `joins` et un `select`. Cela veut donc dire qu'on ne pourra plus appeler le service `ComputeAverageTimeBetweenParticipationCreationAndRdvStartInDays` avec _n'importe quel_ set de `participations` (il faut qu'il soit join de la même façon), mais je pense que ça vaut le coup (et en réalité, il n'y a pas vraiment de cas où on aura besoin de faire ça, 99% si on veut déclencher à la main, on déclenchera le `Compute` ou le `ComputeForFocusedMonth`, voir les services d'upsert, qui eux vont chercher automatiquement la donnée bien structurée.

J'en profite également pour spécifier les dates dans les tests plutôt que des `Time.zone.today` (cf ta remarque de la dernière fois Amine)
