### PR TITLE
feat(webhooks): process destroyed motifs

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_motif_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_motif_job.rb
@@ -5,10 +5,18 @@ module RdvSolidaritesWebhooks
       @meta = meta.deep_symbolize_keys
       return if organisation.blank?
 
-      upsert_motif
+      if event == "destroyed"
+        delete_motif
+      else
+        upsert_motif
+      end
     end
 
     private
+
+    def event
+      @meta[:event]
+    end
 
     def rdv_solidarites_organisation_id
       @data[:organisation_id]
@@ -36,6 +44,11 @@ module RdvSolidaritesWebhooks
         }
           .merge(motif_category ? { motif_category_id: motif_category.id } : {})
       )
+    end
+
+    def delete_motif
+      motif = Motif.find_by(rdv_solidarites_motif_id: @data[:id])
+      motif.destroy!
     end
   end
 end

--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -12,6 +12,7 @@ class Motif < ApplicationRecord
 
   validates :rdv_solidarites_motif_id, uniqueness: true, presence: true
   validates :name, :location_type, presence: true
+  validates :collectif, inclusion: { in: [true, false] }
 
   delegate :rdv_solidarites_organisation_id, to: :organisation
 

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     name { "RSA orientation sur site" }
     location_type { "public_office" }
     organisation { create(:organisation) }
+    collectif { false }
   end
 end

--- a/spec/jobs/rdv_solidarites_webhooks/process_motif_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_motif_job_spec.rb
@@ -5,7 +5,7 @@ describe RdvSolidaritesWebhooks::ProcessMotifJob do
 
   let!(:data) do
     {
-      "id" => rdv_solidarites_organisation_id,
+      "id" => rdv_solidarites_motif_id,
       "name" => "RDV d'orientation sur site",
       "category" => "rsa_orientation",
       "service_id" => 444,
@@ -66,6 +66,23 @@ describe RdvSolidaritesWebhooks::ProcessMotifJob do
             }
           )
         subject
+      end
+    end
+
+    context "when it is the destroy event" do
+      let!(:motif) { create(:motif, rdv_solidarites_motif_id: rdv_solidarites_motif_id) }
+
+      let!(:meta) do
+        {
+          "model" => "Motif",
+          "event" => "destroyed",
+          "timestamp" => "2022-05-30 14:44:22 +0200"
+        }.deep_symbolize_keys
+      end
+
+      it "deletes the lieu" do
+        expect(UpsertRecordJob).not_to receive(:perform_async)
+        expect { subject }.to change(Motif, :count).by(-1)
       end
     end
 


### PR DESCRIPTION
Après que @qblanc m'ait fait remarquer que certains motifs n'avaient pas stocké de valeur dans la colonne `collectif`, j'ai fait lancé les webhooks pour ces motifs sur RDV-Solidarités. 
Ça m'a fait remarquer que certains motifs sur RDV-I n'étaient plus présents sur RDV-S, parce qu'on ne process pas les "destroyed" event. Cette PR répare ça.
J'en profite pour ajouter une validation sur les motifs pour toujours avoir un booléen dans la colonne `collectif`.

Remarque: Une fois cette PR en prod il faudra supprimer tous les motifs de RDV-I qui ont été supprimés sur RDV-S.