### PR TITLE
fix(configuration): avoid duplicate file configurations display

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -76,7 +76,7 @@ class ConfigurationsController < ApplicationController
   end
 
   def set_file_configurations
-    @file_configurations = @department.file_configurations
+    @file_configurations = @department.file_configurations.distinct
   end
 
   def set_department

--- a/app/views/configurations/_configuration_form.html.erb
+++ b/app/views/configurations/_configuration_form.html.erb
@@ -30,7 +30,7 @@
       <h4 class="px-5">Fichier d'import</h4>
       <div class="mb-4 px-5">
         <% if @file_configurations %>
-          <% @file_configurations.uniq.each do |file_configuration| %>
+          <% @file_configurations.each do |file_configuration| %>
             <div class="d-flex justify-content-between mb-2">
               <%= radio_button_tag "configuration[file_configuration_id]",
                   file_configuration.id,


### PR DESCRIPTION
Cette PR corrige un bug lié à l'ajout de la nouvelle fonction de configuration des organisations : sur la page d'ajout/modification d'une configuration, les fichiers d'imports pouvaient apparaître dupliqués. Cette PR résout ce problème.