### PR TITLE
fix(invitations): hotfix for letters without messages_configurations

### DIFF
--- a/app/models/concerns/sendable.rb
+++ b/app/models/concerns/sendable.rb
@@ -13,6 +13,6 @@ module Sendable
   end
 
   def letter_sender_name
-    messages_configuration.letter_sender_name || "le Conseil départemental"
+    messages_configuration&.letter_sender_name || "le Conseil départemental"
   end
 end


### PR DESCRIPTION
résout [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/31647/)
Lorsqu'une organisation était configurée sans `MessagesConfiguration`, la génération de lettre entraînait le bug remonté ci-dessus par Sentry. Cette PR corrige ce bug.