### PR TITLE
fix(applicants): nullify nir and pole emploi id

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -84,7 +84,7 @@ class ApplicantsController < ApplicationController
   def formatted_params
     # we nullify some blank params for unicity exceptions (ActiveRecord::RecordNotUnique) not to raise
     applicant_params.to_h do |k, v|
-      [k, k.in?([:affiliation_number, :department_internal_id, :email]) ? v.presence : v]
+      [k, k.in?([:affiliation_number, :department_internal_id, :email, :pole_emploi_id, :nir]) ? v.presence : v]
     end
   end
 


### PR DESCRIPTION
Dans cette PR, je nullify à la création d'un allocataire le `nir` et le `pole_emploi_id` pour éviter les erreurs `ActiveRecord::RecordNotUnique` lorsque ces champs ne sont pas remplis.