### PR TITLE
Ajout d'une validation pour les organisations avec un téléphone à 4 chiffres

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -3,11 +3,11 @@ class Organisation < ApplicationRecord
 
   include PgSearch::Model
   include HasLogo
-  include Phonable
 
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, presence: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
+  validate :validate_organisation_phone_number
 
   belongs_to :department
   belongs_to :messages_configuration, optional: true
@@ -44,10 +44,14 @@ class Organisation < ApplicationRecord
     super.merge(department_number: department_number, motif_categories: motif_categories)
   end
 
-  def phone_number_is_valid?
-    # Override phone_number_is_valid? method from Phonable for 4 digits organisations
-    return true if phone_number.match(/^\d{4}$/)
+  def validate_organisation_phone_number
+    return if phone_number_is_valid?
 
-    super
+    errors.add(:phone_number, :invalid)
+  end
+
+  def phone_number_is_valid?
+    # Blank, Valid Phone, 4 digits phone (organisations only)
+    phone_number.blank? || Phonelib.parse(phone_number).valid? || phone_number.match(/^\d{4}$/)
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -43,4 +43,11 @@ class Organisation < ApplicationRecord
   def as_json(_opts = {})
     super.merge(department_number: department_number, motif_categories: motif_categories)
   end
+
+  def phone_number_is_valid?
+    # Override phone_number_is_valid? method from Phonable for 4 digits organisations
+    return true if phone_number.match(/^\d{4}$/)
+
+    super
+  end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -52,8 +52,14 @@ describe Organisation do
       it { expect(organisation).to be_valid }
     end
 
+    context "4 digits numbers are valids for organisations" do
+      let(:organisation) { build(:organisation, phone_number: "3949") }
+
+      it { expect(organisation).to be_valid }
+    end
+
     context "phone_number is invalid" do
-      let(:organisation) { build(:organisation, phone_number: "0102") }
+      let(:organisation) { build(:organisation, phone_number: "12345") }
 
       it "adds errors" do
         expect(organisation).not_to be_valid


### PR DESCRIPTION
https://github.com/betagouv/rdv-insertion/issues/933

J'ai modifié uniquement le modèle `organisation`. J'ai pas touché au module `Phonable` pour qu'il reste générique.
La PR coté RDV-S est merge (https://github.com/betagouv/rdv-solidarites.fr/pull/3421)
