### PR TITLE
feat(invitations): change standard orientations messages

### DIFF
--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -20,8 +20,8 @@ module Invitations
     end
 
     def standard_content
-      "#{applicant.full_name},\nVous êtes #{applicant_designation} et vous devez vous présenter à un #{rdv_title}." \
-        " Pour choisir la date et l'horaire du RDV, " \
+      "#{applicant.full_name},\nVous êtes #{applicant_designation} et vous êtes #{applicant.conjugate('invité')} à" \
+        " participer à un #{rdv_title}. Pour choisir la date et l'horaire du RDV, " \
         "cliquez sur le lien suivant dans les #{number_of_days_to_accept_invitation} jours: " \
         "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "#{mandatory_warning}" \

--- a/app/views/letters/invitations/short.html.erb
+++ b/app/views/letters/invitations/short.html.erb
@@ -10,7 +10,7 @@
 </div>
 <div class="main-content">
   <p><%= applicant.title.capitalize %>,</p>
-  <p>Vous êtes <%= "#{applicant.conjugate('invité')}" %> pour un <%= rdv_title %>.</p>
+  <p>Vous êtes <%= applicant.conjugate('invité') %> pour un <%= rdv_title %>.</p>
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -10,7 +10,7 @@
 </div>
 <div class="main-content">
   <p><%= applicant.title.capitalize %>,</p>
-  <p>Vous êtes <%= applicant_designation %> et à ce titre vous devez vous présenter à un <%= rdv_title %> afin de <%= rdv_purpose %>.</p>
+  <p>Vous êtes <%= applicant_designation %> et à ce titre vous êtes <%= applicant.conjugate('invité') %> à participer à un <%= rdv_title %> afin de <%= rdv_purpose %>.</p>
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
   <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>

--- a/app/views/mailers/invitation_mailer/short_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/short_invitation.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>Vous êtes <%= "#{@applicant.conjugate('invité')}" %> pour un <%= @rdv_title %>.</p>
+<p>Vous êtes <%= @applicant.conjugate('invité') %> pour un <%= @rdv_title %>.</p>
 <p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant :</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>

--- a/app/views/mailers/invitation_mailer/standard_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/standard_invitation.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
-<p>Vous êtes <%= @applicant_designation %> et à ce titre vous devez vous présenter à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
+<p>Vous êtes <%= @applicant_designation %> et à ce titre vous êtes <%= @applicant.conjugate('invité') %> à participer à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
 <p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans les <%= @invitation.number_of_days_to_accept_invitation %> jours</span>:</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous d'orientation" \
-          " afin de démarrer un parcours d'accompagnement"
+          "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer " \
+          "à un rendez-vous d'orientation afin de démarrer un parcours d'accompagnement"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -84,8 +84,8 @@ RSpec.describe InvitationMailer do
           expect(body_string).to match("Le département de la Drôme.")
           expect(body_string).to match("01 39 39 39 39")
           expect(body_string).to match(
-            "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous d'accompagnement" \
-            " afin de démarrer un parcours d'accompagnement"
+            "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer " \
+            "à un rendez-vous d'accompagnement afin de démarrer un parcours d'accompagnement"
           )
           expect(body_string).to match("Ce rendez-vous est obligatoire.")
           expect(body_string).to match(
@@ -121,8 +121,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous de signature de " \
-          "CER afin de construire et signer votre Contrat d'Engagement Réciproque"
+          "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à un " \
+          "rendez-vous de signature de CER afin de construire et signer votre Contrat d'Engagement Réciproque"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -155,8 +155,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous " \
-          "de suivi afin de faire un point avec votre référent de parcours"
+          "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer " \
+          "à un rendez-vous de suivi afin de faire un point avec votre référent de parcours"
         )
         expect(body_string).not_to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -189,8 +189,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un entretien de main tendue " \
-          "afin de faire le point sur votre situation"
+          "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer " \
+          "à un entretien de main tendue afin de faire le point sur votre situation"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -225,8 +225,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un atelier collectif " \
-          "afin de vous aider dans votre parcours d'insertion"
+          "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer " \
+          "à un atelier collectif afin de vous aider dans votre parcours d'insertion"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -260,8 +260,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes demandeur d'emploi et à ce titre vous devez vous présenter à un rendez-vous d'accompagnement" \
-          " afin de démarrer un parcours d'accompagnement"
+          "Vous êtes demandeur d'emploi et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à un " \
+          "rendez-vous d'accompagnement afin de démarrer un parcours d'accompagnement"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).to match(
@@ -293,8 +293,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("Le département de la Drôme.")
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to match(
-          "Vous êtes bénéficiaire du RSA et à ce titre vous devez vous présenter à un rendez-vous d'information" \
-          " afin de vous renseigner sur vos droits et vos devoirs"
+          "Vous êtes bénéficiaire du RSA et à ce titre vous êtes #{applicant.conjugate('invité')} à participer " \
+          "à un rendez-vous d'information afin de vous renseigner sur vos droits et vos devoirs"
         )
         expect(body_string).to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(
@@ -327,8 +327,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to include(
           "Vous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
-          " et à ce titre vous devez vous présenter à un entretien d'embauche afin de poursuivre" \
-          " le processus de recrutement"
+          " et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à un entretien d'embauche " \
+          "afin de poursuivre le processus de recrutement"
         )
         expect(body_string).not_to match("Ce rendez-vous est obligatoire.")
         expect(body_string).not_to match(

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -133,7 +133,8 @@ describe Invitations::GenerateLetter, type: :service do
         content = unescape_html(invitation.content)
         expect(content).to include("Objet : Rendez-vous d'orientation dans le cadre de votre RSA")
         expect(content).to include(
-          "vous devez vous présenter à un rendez-vous d'orientation afin de démarrer un parcours d'accompagnement"
+          "vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous d'orientation afin de démarrer " \
+          "un parcours d'accompagnement"
         )
         expect(content).to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).not_to include(
@@ -150,7 +151,8 @@ describe Invitations::GenerateLetter, type: :service do
         content = unescape_html(invitation.content)
         expect(content).to include("Objet : Rendez-vous d'accompagnement dans le cadre de votre RSA")
         expect(content).to include(
-          "vous devez vous présenter à un rendez-vous d'accompagnement afin de démarrer un parcours d'accompagnement"
+          "vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous d'accompagnement " \
+          "afin de démarrer un parcours d'accompagnement"
         )
         expect(content).to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).to include(
@@ -182,7 +184,7 @@ describe Invitations::GenerateLetter, type: :service do
           "Objet : Rendez-vous de signature de CER dans le cadre de votre RSA"
         )
         expect(content).to include(
-          "vous devez vous présenter à un rendez-vous de signature de CER afin de " \
+          "vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous de signature de CER afin de " \
           "construire et signer votre Contrat d'Engagement Réciproque"
         )
         expect(content).to include("Nous vous remercions de prendre ce rendez-vous")
@@ -202,7 +204,8 @@ describe Invitations::GenerateLetter, type: :service do
           "Objet : Rendez-vous de suivi dans le cadre de votre RSA"
         )
         expect(content).to include(
-          "vous devez vous présenter à un rendez-vous de suivi afin de faire un point avec votre référent de parcours"
+          "vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous de suivi afin de faire un point" \
+          " avec votre référent de parcours"
         )
         expect(content).not_to include("Nous vous remercions de prendre ce rendez-vous")
         expect(content).not_to include(

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -40,8 +40,8 @@ describe Invitations::SendSms, type: :service do
 
   let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_orientation) }
   let!(:content) do
-    "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous " \
-      "d'orientation. " \
+    "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à participer" \
+      " à un rendez-vous d'orientation. " \
       "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
       "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
       "Ce rendez-vous est obligatoire. En cas de problème technique, contactez le 0147200001."
@@ -122,8 +122,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context) }
       let!(:configuration) { create(:configuration) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous " \
-          "d'accompagnement." \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à " \
+          "participer à un rendez-vous d'accompagnement." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
           "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
@@ -224,8 +224,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_cer_signature) }
       let!(:configuration) { create(:configuration, motif_category: category_rsa_cer_signature) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un rendez-vous de signature de CER." \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à participer" \
+          " à un rendez-vous de signature de CER." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
@@ -274,8 +274,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_main_tendue) }
       let!(:configuration) { create(:configuration, motif_category: category_rsa_main_tendue) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un entretien de main tendue." \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à participer" \
+          " à un entretien de main tendue." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
@@ -323,8 +323,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_atelier_collectif_mandatory) }
       let!(:configuration) { create(:configuration, motif_category: category_rsa_atelier_collectif_mandatory) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un atelier collectif." \
-          " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à participer" \
+          " à un atelier collectif. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "Ce rendez-vous est obligatoire. " \
@@ -371,8 +371,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_spie) }
       let!(:configuration) { create(:configuration, motif_category: category_rsa_spie) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes demandeur d'emploi et vous devez vous présenter à un rendez-vous " \
-          "d'accompagnement." \
+        "Monsieur John DOE,\nVous êtes demandeur d'emploi et vous êtes #{applicant.conjugate('invité')} à participer" \
+          " à un rendez-vous d'accompagnement." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
           "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "Ce rendez-vous est obligatoire. En l'absence d'action de votre part, " \
@@ -422,7 +422,7 @@ describe Invitations::SendSms, type: :service do
       let!(:configuration) { create(:configuration, motif_category: category_siae_interview) }
       let!(:content) do
         "Monsieur John DOE,\nVous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
-          " et vous devez vous présenter à un entretien d'embauche." \
+          " et vous êtes #{applicant.conjugate('invité')} à participer à un entretien d'embauche." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
           "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "En cas de problème technique, contactez le 0147200001."
@@ -491,8 +491,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_integration_information) }
       let!(:configuration) { create(:configuration, motif_category: category_rsa_integration_information) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à un rendez-vous " \
-          "d'information." \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à participer" \
+          " à un rendez-vous d'information." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
           "dans les 9 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "Ce rendez-vous est obligatoire. " \
@@ -611,8 +611,8 @@ describe Invitations::SendSms, type: :service do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_rsa_follow_up) }
       let!(:configuration) { create(:configuration, motif_category: category_rsa_follow_up) }
       let!(:content) do
-        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous devez vous présenter à " \
-          "un rendez-vous de suivi. " \
+        "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{applicant.conjugate('invité')} à participer" \
+          " à un rendez-vous de suivi. " \
           "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "9 jours: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \


### PR DESCRIPTION
closes #938 
Dans cette PR, je change le message standard pour remplacer la notion de `devoir prendre un rendez-vous` par celle d'être `invité à` en prendre un.