### PR TITLE
fix(linter): linter fix for organisations PR

### DIFF
--- a/app/services/organisations/create.rb
+++ b/app/services/organisations/create.rb
@@ -36,7 +36,7 @@ module Organisations
       # to allow an instant redirection, we create the agent_role directl
       # the rdv_solidarites_agent_role_id will be added to this agent_role record thanks to the webhook
       # this is safe because the transaction succeeds only if the agent is a territorial admin in the department
-      @agent_role_for_new_organisation ||= \
+      @agent_role_for_new_organisation ||=
         AgentRole.new(agent_id: @current_agent.id, organisation_id: @organisation.id, level: "admin")
     end
 

--- a/app/services/rdv_solidarites_api/create_webhook_endpoint.rb
+++ b/app/services/rdv_solidarites_api/create_webhook_endpoint.rb
@@ -17,7 +17,7 @@ module RdvSolidaritesApi
     private
 
     def rdv_solidarites_response
-      @rdv_solidarites_response ||= \
+      @rdv_solidarites_response ||=
         rdv_solidarites_client.create_webhook_endpoint(@rdv_solidarites_organisation_id, @subscriptions)
     end
   end


### PR DESCRIPTION
Le merge de la PR #965 a entraîné des erreurs de lint dans la PR #962 approuvée avant mais déployée ensuite. Cette petit PR corrige ce souci.