### PR TITLE
feat(configuration): change create organisation button position

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -29,9 +29,6 @@ class OrganisationsController < ApplicationController
     @organisation.assign_attributes(**organisation_params)
     authorize @organisation
     if create_organisation.success?
-      p @organisation
-      p @department
-      p @organisation.department
       redirect_to organisation_applicants_path(@organisation)
     else
       render turbo_stream: turbo_stream.replace(

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,7 +2,8 @@
 
 class OrganisationsController < ApplicationController
   PERMITTED_PARAMS = [
-    :name, :phone_number, :email, :slug, :independent_from_cd, :logo_filename, :rdv_solidarites_organisation_id
+    :name, :phone_number, :email, :slug, :independent_from_cd, :logo_filename, :rdv_solidarites_organisation_id,
+    :department_id
   ].freeze
 
   before_action :set_organisation, :set_department, :authorize_organisation_configuration, only: [:show, :edit, :update]
@@ -16,7 +17,6 @@ class OrganisationsController < ApplicationController
   def show; end
 
   def new
-    @department = Department.find(params[:department_id])
     @organisation = Organisation.new
     authorize @organisation
   end
@@ -24,11 +24,14 @@ class OrganisationsController < ApplicationController
   def edit; end
 
   def create
-    @department = Department.find(params[:department_id])
+    @department = Department.find_by(id: params[:department_id])
     @organisation = Organisation.new(department: @department)
     @organisation.assign_attributes(**organisation_params)
     authorize @organisation
     if create_organisation.success?
+      p @organisation
+      p @department
+      p @organisation.department
       redirect_to organisation_applicants_path(@organisation)
     else
       render turbo_stream: turbo_stream.replace(

--- a/app/views/organisations/_organisation_form.html.erb
+++ b/app/views/organisations/_organisation_form.html.erb
@@ -1,10 +1,13 @@
 <%= render "common/remote_modal", title: "Lier une organisation" do %>
-  <%= simple_form_for(organisation, url: department_organisations_path(department), html: { method: :post }) do |f| %>
+  <%= simple_form_for(organisation, url: organisations_path, html: { method: :post }) do |f| %>
     <% if local_assigns[:errors].present? %>
       <%= render "common/error_list", errors: errors %>
     <% end %>
-    <div class="d-flex">
-      ID de l'orga RDVS&nbsp; <%= f.input :rdv_solidarites_organisation_id %>
+    <div class="d-flex justify-content-between">
+      ID de l'orga RDVS <%= f.input :rdv_solidarites_organisation_id %>
+    </div>
+    <div class="d-flex justify-content-between mt-2">
+      Département <%= f.input :department_id, as: :select, collection: Department.all, required: true %>
     </div>
     <%= f.button :submit, "Enregistrer", class: "btn btn-blue mt-3" %>
   <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -6,10 +6,6 @@
     <div class="row mt-5 justify-content-center">
       <div class="col-8">
         <p>Sélectionnez votre organisation:</p>
-      </div>
-    </div>
-    <div class="row justify-content-center">
-      <div class="col-8">
         <% @organisations_by_department.each do |department, organisations| %>
           <div class="card-container">
             <div class="card d-flex flex-row justify-content-center card-organisation mb-3">
@@ -30,13 +26,7 @@
                       <% end %>
                     <% end %>
                   </ul>
-                <% if current_agent.super_admin? %>
-                  <%= link_to new_department_organisation_path(department), data: { turbo_frame: 'remote_modal' } do %>
-                    <%= button_tag "Lier une organisation RDVS", class: "btn btn-blue-out" %>
-                  <% end %>
-                <% end %>
                 </div>
-
               </div>
               <div class="d-flex flex-column justify-content-center mx-2 py-4 text-center">
                 <div>
@@ -51,6 +41,13 @@
                 </div>
               </div>
             </div>
+          </div>
+        <% end %>
+        <% if current_agent.super_admin? %>
+          <div class="my-4 d-flex justify-content-center">
+            <%= link_to new_organisation_path, data: { turbo_frame: 'remote_modal' } do %>
+              <%= button_tag "Lier une organisation RDVS", class: "btn btn-blue" %>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
                                      path: '/parcours_insertion',
                                      only: [:show]
 
-  resources :organisations, only: [:index, :show, :edit, :update] do
+  resources :organisations, only: [:index, :new, :show, :edit, :create, :update] do
     get :geolocated, on: :collection
     get :search, on: :collection
     resources :applicants, only: [:index, :create, :show, :update, :edit, :new] do
@@ -65,7 +65,6 @@ Rails.application.routes.draw do
   end
 
   resources :departments, only: [] do
-    resources :organisations, only: [:new, :create]
     resources :department_organisations, only: [:index], as: :organisations, path: "/organisations"
     resources :applicants, only: [:index, :new, :create, :show, :edit, :update] do
       collection { resources :uploads, only: [:new] }


### PR DESCRIPTION
Dans cette PR, je change la position du bouton "Lier une organisation RDVS" sur la page `index` des `organisations`.
Il était jusqu'alors proposé dans chaque tuile département ; il est désormais positionné en bas de page, en dehors du contexte d'un département. Le but de ce changement est de permettre aux agents d'ajouter une orga dans un département qui existe mais n'apparaît pas dans leur liste d'organisations. Pour leur faciliter la tâche, la modal `new` leur propose un dropdown listant tous les départements existants.