### PR TITLE
fix(migrations): fix migrations for france travail motif category

### DIFF
--- a/db/migrate/20230411153039_add_custom_sentence_to_templates.rb
+++ b/db/migrate/20230411153039_add_custom_sentence_to_templates.rb
@@ -1,0 +1,5 @@
+class AddCustomSentenceToTemplates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :templates, :custom_sentence, :text
+  end
+end

--- a/db/migrate/20230411153056_add_france_travail_orientation_template.rb
+++ b/db/migrate/20230411153056_add_france_travail_orientation_template.rb
@@ -1,7 +1,5 @@
-class AddOrientationFtTemplate < ActiveRecord::Migration[7.0]
+class AddFranceTravailOrientationTemplate < ActiveRecord::Migration[7.0]
   def up
-    add_column :templates, :custom_sentence, :text
-
     template = Template.create!(
       model: "standard",
       rdv_title: "rendez-vous d'orientation",
@@ -17,7 +15,7 @@ class AddOrientationFtTemplate < ActiveRecord::Migration[7.0]
     )
 
     # This context already exist on production
-    mc = MotifCategory.find_or_create_by!(
+    mc = MotifCategory.find_or_initialize_by(
       name: "RSA orientation France Travail",
       short_name: "rsa_orientation_france_travail",
       participation_optional: false
@@ -28,8 +26,8 @@ class AddOrientationFtTemplate < ActiveRecord::Migration[7.0]
   end
 
   def down
-    MotifCategory.find_by(short_name: "rsa_orientation_france_travail").destroy!
-    Template.find_by(rdv_title: "premier rendez-vous d'orientation France Travail", model: "standard").destroy!
+    MotifCategory.find_by(short_name: "rsa_orientation_france_travail")&.destroy!
+    Template.find_by(rdv_title: "rendez-vous d'orientation", model: "standard")&.destroy!
 
     remove_column :templates, :custom_sentence
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_05_143015) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_11_153056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Dans cette PR, je corrige l'erreur de migration liée [la PR #969](https://github.com/betagouv/rdv-insertion/pull/969), et j'en profite pour séparer en deux le fichier de migration pour une meilleur logique (cf un commentaire de @aminedhobb sur la PR citée plus haut).