### PR TITLE
fix(participations) : fix notifications reminders

### DIFF
--- a/app/jobs/send_convocation_reminders_job.rb
+++ b/app/jobs/send_convocation_reminders_job.rb
@@ -2,7 +2,7 @@ class SendConvocationRemindersJob < ApplicationJob
   def perform
     return if staging_env?
 
-    NotifyParticipationsJob.perform_async(participations_to_send_reminders_to.ids, "participation_reminder")
+    NotifyParticipationsJob.perform_async(participations_to_send_reminders_to.ids, "reminder")
     notify_on_mattermost
   end
 

--- a/spec/jobs/notify_participations_job_spec.rb
+++ b/spec/jobs/notify_participations_job_spec.rb
@@ -54,5 +54,51 @@ describe NotifyParticipationsJob do
         subject
       end
     end
+
+    context "when reminder" do
+      let!(:event_to_notify) { "reminder" }
+
+      it "enqueues notification jobs for each applicants and each format" do
+        expect(NotifyParticipationJob).to receive(:perform_async)
+          .with(participation1.id, "sms", "participation_reminder")
+        expect(NotifyParticipationJob).to receive(:perform_async)
+          .with(participation1.id, "email", "participation_reminder")
+        expect(NotifyParticipationJob).to receive(:perform_async)
+          .with(participation2.id, "sms", "participation_reminder")
+        expect(NotifyParticipationJob).to receive(:perform_async)
+          .with(participation2.id, "email", "participation_reminder")
+        subject
+      end
+
+      context "when phone number is not mobile" do
+        before { applicant1.update!(phone_number: "0101010101") }
+
+        it "does not enqueue a notification by sms job" do
+          expect(NotifyParticipationJob).not_to receive(:perform_async)
+            .with(participation1.id, "sms", "participation_reminder")
+          subject
+        end
+      end
+
+      context "when the phone number is blank" do
+        before { applicant1.update!(phone_number: nil) }
+
+        it "does not enqueue a notification by sms job" do
+          expect(NotifyParticipationJob).not_to receive(:perform_async)
+            .with(participation1.id, "sms", "participation_reminder")
+          subject
+        end
+      end
+
+      context "when there is no email" do
+        before { applicant1.update!(email: nil) }
+
+        it "does not enqueue a notification by email job" do
+          expect(NotifyParticipationJob).not_to receive(:perform_async)
+            .with(participation1.id, "email", "participation_reminder")
+          subject
+        end
+      end
+    end
   end
 end

--- a/spec/jobs/send_convocation_reminders_job_spec.rb
+++ b/spec/jobs/send_convocation_reminders_job_spec.rb
@@ -19,7 +19,7 @@ describe SendConvocationRemindersJob do
 
     it "notifies the convocable participation that starts in 2 days" do
       expect(NotifyParticipationsJob).to receive(:perform_async)
-        .with([239], "participation_reminder")
+        .with([239], "reminder")
       subject
     end
 


### PR DESCRIPTION
L'envoi de rappel de convocations ne fonctionnait pas parce que le nom de l'`event` envoyé au `NotifyParticipationsJob` n'était pas le bon (bug remonté dans [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/35421/?project=16&query=is%3Aunresolved)). Cette PR permet de corriger ce souci.