### PR TITLE
fix(api): Allow api call without invitation attributes

### DIFF
--- a/app/controllers/api/v1/applicants_controller.rb
+++ b/app/controllers/api/v1/applicants_controller.rb
@@ -22,10 +22,13 @@ module Api
       private
 
       def applicants_attributes
-        create_and_invite_params.to_h.deep_symbolize_keys[:applicants]
+        create_and_invite_params.to_h.deep_symbolize_keys[:applicants].map do |applicant_attributes|
+          applicant_attributes[:invitation] ||= {}
+          applicant_attributes
+        end
       end
 
-      def invitations_params
+      def invitations_attributes
         applicants_attributes.pluck(:invitation)
       end
 

--- a/app/controllers/concerns/api/v1/params_validation_concern.rb
+++ b/app/controllers/concerns/api/v1/params_validation_concern.rb
@@ -14,7 +14,7 @@ module Api
 
         validate_applicants_length
         validate_applicants_attributes
-        validate_invitations_params
+        validate_invitations_attributes
       end
 
       def validate_applicants_length
@@ -35,16 +35,27 @@ module Api
         end
       end
 
-      def validate_invitations_params
+      def validate_invitations_attributes
         possible_motif_category_names = @organisation.configurations.map(&:motif_category_name)
 
-        invitations_params.each_with_index do |invitation_params, idx|
+        invitations_attributes.each_with_index do |invitation_params, idx|
           motif_category_name = invitation_params[:motif_category_name]
-          # we don't have to precise the context if there is only one context possible
-          next if (motif_category_name.blank? && possible_motif_category_names.length == 1) ||
-                  motif_category_name.in?(possible_motif_category_names)
 
-          @params_validation_errors << { "Entrée #{idx + 1}": "Catégorie de motifs #{motif_category_name} invalide" }
+          if motif_category_name.blank?
+            # we don't have to precise the context if there is only one context possible
+            next if possible_motif_category_names.length == 1
+
+            @params_validation_errors << {
+              "Entrée #{idx + 1}": { "motif_category_name" => ["La catégorie de motifs doit être précisée"] }
+            }
+            next
+          end
+
+          next if motif_category_name.in?(possible_motif_category_names)
+
+          @params_validation_errors << {
+            "Entrée #{idx + 1}": { "motif_category_name" => ["Catégorie de motifs #{motif_category_name} invalide"] }
+          }
         end
       end
 


### PR DESCRIPTION
Ce mail fait suite au mail reçu par le Cantal et est lié à cette erreur sur Sentry: https://sentry.incubateur.net/organizations/betagouv/issues/34431/?project=16&query=is%3Aunresolved

On doit pouvoir pouvoir appeler l'API sans préciser de catégorie de motifs (qui se trouve derrière la clé "invitation") lorsque l'organisation ne gère qu'une seule catégorie de motif. Le fix introduit dans cette PR le permet.
On renvoie également des messages d'erreurs différents lorsque la catégorie n'est pas précisée alors qu'elle doit l'être et lorsque la catégorie est invalide.