### PR TITLE
feat(nir): allow 13 numbers nir

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,6 +413,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-17
   x86_64-linux
 

--- a/app/models/concerns/applicant/nir.rb
+++ b/app/models/concerns/applicant/nir.rb
@@ -2,23 +2,23 @@ module Applicant::Nir
   extend ActiveSupport::Concern
 
   included do
+    before_validation :add_nir_key, if: :nir?
     validate :nir_is_valid, if: :nir?
-    after_validation :add_nir_key
   end
 
   private
 
   def add_nir_key
-    self.nir = "#{nir}#{nir_key}" if nir&.length == 13
+    return unless nir.length == 13
+
+    self.nir = "#{nir}#{nir_key}"
   end
 
   def nir_is_valid
-    unless (nir.length == 13 || nir.length == 15) && nir.match?(/\A\d+\Z/)
+    if nir.length != 15 || nir !~ /\A\d+\Z/
       errors.add(:nir, :invalid, message: "Le NIR doit être une série de 13 ou 15 chiffres")
       return
     end
-
-    return unless nir.length == 15
 
     return if nir_sum_checked?
 

--- a/app/models/concerns/applicant/nir.rb
+++ b/app/models/concerns/applicant/nir.rb
@@ -3,15 +3,22 @@ module Applicant::Nir
 
   included do
     validate :nir_is_valid, if: :nir?
+    after_validation :add_nir_key
   end
 
   private
 
+  def add_nir_key
+    self.nir = "#{nir}#{nir_key}" if nir.length == 13
+  end
+
   def nir_is_valid
-    if nir.length != 15 || nir !~ /\A\d+\Z/
-      errors.add(:nir, :invalid, message: "Le NIR doit être une série de 15 chiffres")
+    unless (nir.length == 13 || nir.length == 15) && nir.match?(/\A\d+\Z/)
+      errors.add(:nir, :invalid, message: "Le NIR doit être une série de 13 ou 15 chiffres")
       return
     end
+
+    return unless nir.length == 15
 
     return if nir_sum_checked?
 
@@ -19,6 +26,10 @@ module Applicant::Nir
   end
 
   def nir_sum_checked?
-    97 - (nir.first(13).to_i % 97) == nir.last(2).to_i
+    nir_key == nir.last(2).to_i
+  end
+
+  def nir_key
+    97 - (nir.first(13).to_i % 97)
   end
 end

--- a/app/models/concerns/applicant/nir.rb
+++ b/app/models/concerns/applicant/nir.rb
@@ -9,7 +9,7 @@ module Applicant::Nir
   private
 
   def add_nir_key
-    self.nir = "#{nir}#{nir_key}" if nir.length == 13
+    self.nir = "#{nir}#{nir_key}" if nir&.length == 13
   end
 
   def nir_is_valid

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -201,6 +201,25 @@ describe Applicant do
       it { expect(applicant).to be_valid }
     end
 
+    context "when nir is 13 characters" do
+      let!(:nir) { generate_random_nir }
+      let(:applicant) { build(:applicant, nir: nir.first(13)) }
+
+      it { expect(applicant).to be_valid }
+
+      it "adds a 2 digits key to the nir saved in db" do
+        applicant.save
+        expect(applicant.reload.nir).to eq(nir)
+      end
+    end
+
+    context "when nir is a valid 15 characters string" do
+      let!(:nir) { generate_random_nir }
+      let(:applicant) { build(:applicant, nir: nir) }
+
+      it { expect(applicant).to be_valid }
+    end
+
     context "when nir exists already" do
       let!(:existing_applicant) { create(:applicant, nir: "123456789012311") }
       let(:applicant) { build(:applicant, nir: "123456789012311") }
@@ -208,14 +227,14 @@ describe Applicant do
       it { expect(applicant).not_to be_valid }
     end
 
-    context "when nir is not 15 characters" do
-      let(:applicant) { build(:applicant, nir: "1234567890123") }
+    context "when nir is not 13 or 15 characters" do
+      let(:applicant) { build(:applicant, nir: "12345678901") }
 
       it "add errors" do
         expect(applicant).not_to be_valid
         expect(applicant.errors.details).to eq({ nir: [{ error: :invalid }] })
         expect(applicant.errors.full_messages.to_sentence)
-          .to include("Le NIR doit être une série de 15 chiffres")
+          .to include("Le NIR doit être une série de 13 ou 15 chiffres")
       end
     end
 
@@ -226,11 +245,11 @@ describe Applicant do
         expect(applicant).not_to be_valid
         expect(applicant.errors.details).to eq({ nir: [{ error: :invalid }] })
         expect(applicant.errors.full_messages.to_sentence)
-          .to include("Le NIR doit être une série de 15 chiffres")
+          .to include("Le NIR doit être une série de 13 ou 15 chiffres")
       end
     end
 
-    context "when luhn formula is not matched" do
+    context "when nir is 15 characters and luhn formula is not matched" do
       let(:applicant) { build(:applicant, nir: "123456789012312") }
 
       it "add errors" do


### PR DESCRIPTION
closes #994 
Dans cette PR, je permets aux agents de renseigner des NIR à 13 chiffres.
Pour garder des NIR cohérents à 15 chiffres en db, j'ajoute après validation, lorsque les NIR sont à 13 chiffres, la clé de sécurité sociale.
Ce dernier point n'est pas forcément indispensable : on pourrait stocker les NIR à 13 chiffres et faire l'ajout plus tard si nécessaire?

N.B. : je fais passer dans cette PR un petit ajout au `Gemfile.lock` consécutif à la montée de version de ruby