### PR TITLE
fix(invitations): Invite without referents in mixed configurations departments

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -94,8 +94,10 @@ class InvitationsController < ApplicationController
   end
 
   def set_current_configuration
-    @current_configuration = @organisations.preload(:configurations)
-                                           .flat_map(&:configurations).find { |c| c.motif_category == @motif_category }
+    @current_configuration = @organisations.where(id: @applicant.organisations)
+                                           .preload(:configurations)
+                                           .flat_map(&:configurations)
+                                           .find { |c| c.motif_category == @motif_category }
   end
 
   def set_motif_category


### PR DESCRIPTION
closes #992 
Dans cette PR, je fix le bug rencontré par le MIE Genevois lorsqu'ils tentaient d'inviter au niveau de "toutes les organisations" des bénéficiaires sans référents, ce qui ne fonctionnait pas à cause des autres organisations de leur département qui réclamaient un référent (voir l'issue pour plus de détail). J'ai fait des tests fonctionnels ça résout bien le problème (sans effet de bord a priori)