### PR TITLE
refactor(app): Remove applicant phone_number_formatted method

### DIFF
--- a/app/controllers/applicants/searches_controller.rb
+++ b/app/controllers/applicants/searches_controller.rb
@@ -31,7 +31,7 @@ module Applicants
 
     def formatted_phone_numbers
       applicants_params[:phone_numbers].map do |phone_number|
-        PhoneNumberFormatter.format_phone_number(phone_number)
+        PhoneNumberHelper.format_phone_number(phone_number)
       end.compact
     end
 

--- a/app/controllers/applicants/searches_controller.rb
+++ b/app/controllers/applicants/searches_controller.rb
@@ -1,7 +1,5 @@
 module Applicants
   class SearchesController < ApplicationController
-    include PhoneNumberFormatter
-
     before_action :set_organisations, :search_applicants, only: [:create]
 
     def create
@@ -32,7 +30,9 @@ module Applicants
     end
 
     def formatted_phone_numbers
-      applicants_params[:phone_numbers].map { |phone_number| format_phone_number(phone_number) }.compact
+      applicants_params[:phone_numbers].map do |phone_number|
+        PhoneNumberFormatter.format_phone_number(phone_number)
+      end.compact
     end
 
     def search_in_department_organisations

--- a/app/lib/phone_number_formatter.rb
+++ b/app/lib/phone_number_formatter.rb
@@ -13,18 +13,20 @@ module PhoneNumberFormatter
   # Cf: Plan national de numérotation téléphonique,
   # https://www.arcep.fr/uploads/tx_gsavis/05-1085.pdf  “Numéros mobiles à 10 chiffres”, page 6
 
-  def parsed_number(phone_number)
-    return if phone_number.blank?
+  class << self
+    def parsed_number(phone_number)
+      return if phone_number.blank?
 
-    COUNTRY_CODES.each do |country_code|
-      parsed_attempt = Phonelib.parse(phone_number, country_code)
-      return parsed_attempt if parsed_attempt.valid?
+      COUNTRY_CODES.each do |country_code|
+        parsed_attempt = Phonelib.parse(phone_number, country_code)
+        return parsed_attempt if parsed_attempt.valid?
+      end
+
+      nil
     end
 
-    nil
-  end
-
-  def format_phone_number(phone_number)
-    parsed_number(phone_number)&.e164
+    def format_phone_number(phone_number)
+      parsed_number(phone_number)&.e164
+    end
   end
 end

--- a/app/lib/phone_number_helper.rb
+++ b/app/lib/phone_number_helper.rb
@@ -1,4 +1,4 @@
-module PhoneNumberFormatter
+module PhoneNumberHelper
   COUNTRY_CODES = [:FR, :GP, :GF, :MQ, :RE, :YT].freeze
   # See issue #1471 in RDV-Solidarités. This setup allows:
   # * international (e164) phone numbers

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -18,7 +18,7 @@ class Applicant < ApplicationRecord
   include Applicant::Nir
 
   before_validation :generate_uid
-  before_save :set_phone_number_formatted
+  before_save :format_phone_number
 
   has_and_belongs_to_many :organisations
   has_and_belongs_to_many :agents
@@ -130,8 +130,8 @@ class Applicant < ApplicationRecord
     self.uid = Base64.strict_encode64("#{affiliation_number} - #{role}")
   end
 
-  def set_phone_number_formatted
-    self.phone_number = format_phone_number(phone_number)
+  def format_phone_number
+    self.phone_number = PhoneNumberFormatter.format_phone_number(phone_number)
   end
 
   def birth_date_validity

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -131,7 +131,7 @@ class Applicant < ApplicationRecord
   end
 
   def format_phone_number
-    self.phone_number = PhoneNumberFormatter.format_phone_number(phone_number)
+    self.phone_number = PhoneNumberHelper.format_phone_number(phone_number)
   end
 
   def birth_date_validity

--- a/app/models/concerns/phone_number_validation.rb
+++ b/app/models/concerns/phone_number_validation.rb
@@ -1,19 +1,12 @@
-# Concern to include in application models
-# Models need to have a :phone_number and a :phone_number_formatted attributes
 module PhoneNumberValidation
   extend ActiveSupport::Concern
-  include PhoneNumberFormatter
 
   included do
     validate :phone_number_is_valid
   end
 
-  def phone_number_formatted
-    format_phone_number(phone_number)
-  end
-
   def phone_number_is_mobile?
-    types = parsed_number(phone_number)&.types
+    types = PhoneNumberFormatter.parsed_number(phone_number)&.types
     types&.include?(:mobile)
   end
 
@@ -25,13 +18,7 @@ module PhoneNumberValidation
     errors.add(:phone_number, :invalid) unless phone_number_is_valid?
   end
 
-  def phone_number_is_mobile
-    return if phone_number.blank?
-
-    errors.add(:phone_number, :invalid) unless phone_number_is_valid?
-  end
-
   def phone_number_is_valid?
-    parsed_number(phone_number).present?
+    PhoneNumberFormatter.parsed_number(phone_number).present?
   end
 end

--- a/app/models/concerns/phone_number_validation.rb
+++ b/app/models/concerns/phone_number_validation.rb
@@ -6,7 +6,7 @@ module PhoneNumberValidation
   end
 
   def phone_number_is_mobile?
-    types = PhoneNumberFormatter.parsed_number(phone_number)&.types
+    types = PhoneNumberHelper.parsed_number(phone_number)&.types
     types&.include?(:mobile)
   end
 
@@ -19,6 +19,6 @@ module PhoneNumberValidation
   end
 
   def phone_number_is_valid?
-    PhoneNumberFormatter.parsed_number(phone_number).present?
+    PhoneNumberHelper.parsed_number(phone_number).present?
   end
 end

--- a/app/models/concerns/sendable.rb
+++ b/app/models/concerns/sendable.rb
@@ -1,7 +1,7 @@
 module Sendable
   extend ActiveSupport::Concern
 
-  delegate :email, :phone_number, :phone_number_formatted, :phone_number_is_mobile?,
+  delegate :email, :phone_number, :phone_number_is_mobile?,
            :address, :street_address, :zipcode_and_city,
            to: :applicant
   delegate :signature_lines, :sender_city, :help_address, :display_europe_logos, :display_department_logo,

--- a/app/models/rdv_solidarites/user.rb
+++ b/app/models/rdv_solidarites/user.rb
@@ -1,7 +1,7 @@
 module RdvSolidarites
   class User < Base
     RECORD_ATTRIBUTES = [
-      :id, :first_name, :last_name, :birth_date, :email, :phone_number, :phone_number_formatted,
+      :id, :first_name, :last_name, :birth_date, :email, :phone_number,
       :birth_name, :address, :affiliation_number
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)

--- a/app/services/applicants/find_or_initialize.rb
+++ b/app/services/applicants/find_or_initialize.rb
@@ -43,7 +43,7 @@ module Applicants
     end
 
     def find_applicant_by_phone_number
-      phone_number_formatted = PhoneNumberFormatter.format_phone_number(@attributes[:phone_number])
+      phone_number_formatted = PhoneNumberHelper.format_phone_number(@attributes[:phone_number])
       return if phone_number_formatted.blank?
 
       Applicant.where(phone_number: phone_number_formatted).find do |applicant|

--- a/app/services/applicants/find_or_initialize.rb
+++ b/app/services/applicants/find_or_initialize.rb
@@ -1,7 +1,5 @@
 module Applicants
   class FindOrInitialize < BaseService
-    include PhoneNumberFormatter
-
     def initialize(applicant_attributes:, department_id:)
       @attributes = applicant_attributes.deep_symbolize_keys
       @department_id = department_id
@@ -45,9 +43,10 @@ module Applicants
     end
 
     def find_applicant_by_phone_number
-      return if format_phone_number(@attributes[:phone_number]).blank?
+      phone_number_formatted = PhoneNumberFormatter.format_phone_number(@attributes[:phone_number])
+      return if phone_number_formatted.blank?
 
-      Applicant.where(phone_number: format_phone_number(@attributes[:phone_number])).find do |applicant|
+      Applicant.where(phone_number: phone_number_formatted).find do |applicant|
         applicant.first_name.split.first.downcase == @attributes[:first_name].split.first.downcase
       end
     end

--- a/app/services/concerns/messengers/send_sms.rb
+++ b/app/services/concerns/messengers/send_sms.rb
@@ -10,10 +10,10 @@ module Messengers::SendSms
     fail!("Le numéro de téléphone doit être un mobile") unless sendable.phone_number_is_mobile?
   end
 
-  def send_sms(sms_sender_name, phone_number_formatted, content)
+  def send_sms(sms_sender_name, phone_number, content)
     return Rails.logger.info(content) if Rails.env.development?
 
-    SendTransactionalSms.call(phone_number_formatted: phone_number_formatted,
+    SendTransactionalSms.call(phone_number: phone_number,
                               sender_name: sms_sender_name, content: content)
   end
 end

--- a/app/services/invitations/send_sms.rb
+++ b/app/services/invitations/send_sms.rb
@@ -12,7 +12,7 @@ module Invitations
     def call
       verify_format!(invitation)
       verify_phone_number!(invitation)
-      send_sms(invitation.sms_sender_name, invitation.phone_number_formatted, content)
+      send_sms(invitation.sms_sender_name, invitation.phone_number, content)
     end
 
     private

--- a/app/services/notifications/send_sms.rb
+++ b/app/services/notifications/send_sms.rb
@@ -14,7 +14,7 @@ module Notifications
     def call
       verify_format!(notification)
       verify_phone_number!(notification)
-      send_sms(notification.sms_sender_name, notification.phone_number_formatted, content)
+      send_sms(notification.sms_sender_name, notification.phone_number, content)
     end
 
     private

--- a/app/services/send_transactional_sms.rb
+++ b/app/services/send_transactional_sms.rb
@@ -1,7 +1,7 @@
 class SendTransactionalSms < BaseService
-  def initialize(phone_number_formatted:, sender_name:, content:)
+  def initialize(phone_number:, sender_name:, content:)
     @sender_name = sender_name
-    @phone_number_formatted = phone_number_formatted
+    @phone_number = phone_number
     @content = content
   end
 
@@ -19,7 +19,7 @@ class SendTransactionalSms < BaseService
       e,
       extra: {
         response_body: e.response_body,
-        phone_number: @phone_number_formatted,
+        phone_number: @phone_number,
         content: formatted_content
       }
     )
@@ -29,7 +29,7 @@ class SendTransactionalSms < BaseService
   def transactional_sms
     SibApiV3Sdk::SendTransacSms.new(
       sender: @sender_name,
-      recipient: @phone_number_formatted,
+      recipient: @phone_number,
       content: formatted_content,
       type: "transactional"
     )

--- a/app/views/letters/notifications/by_phone_participation_created.html.erb
+++ b/app/views/letters/notifications/by_phone_participation_created.html.erb
@@ -8,7 +8,7 @@
 <div class="main-content">
   <p><%= applicant.title.capitalize %>,</p>
   <p>Vous êtes <%= applicant_designation %> et à ce titre <span class="bold-blue">vous êtes <%= applicant.conjugate("convoqué") %> à un <%= rdv_title %></span> afin de <%= rdv_purpose %>.</p>
-  <p>Un travailleur social vous appellera <span class="bold-blue">le <%= I18n.l(rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="bold-blue"><%= applicant.phone_number_formatted %></span>.</p>
+  <p>Un travailleur social vous appellera <span class="bold-blue">le <%= I18n.l(rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="bold-blue"><%= applicant.phone_number %></span>.</p>
   <% if display_mandatory_warning %>
     <p><span class="bold-blue">Ce rendez-vous est obligatoire</span>.</p>
   <% end  %>

--- a/app/views/mailers/notification_mailer/by_phone_participation_created.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_created.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>Vous êtes <%= @applicant_designation %> et à ce titre vous êtes <%= @applicant.conjugate("convoqué") %> à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
-<p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number_formatted %></span>.</p>
+<p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number %></span>.</p>
 <% if @display_mandatory_warning %>
   <p><span class="font-weight-bold">Ce rendez-vous est obligatoire</span>.</p>
 <% end  %>

--- a/app/views/mailers/notification_mailer/by_phone_participation_reminder.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_reminder.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>Vous êtes <%= @applicant_designation %> et à ce titre vous avez été <%= @applicant.conjugate("convoqué") %> à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
-<p>Nous vous rappelons qu'un travailleur social vous appellera <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number_formatted %></span>.</p>
+<p>Nous vous rappelons qu'un travailleur social vous appellera <span class="font-weight-bold">le <%= @rdv.formatted_start_date %> à <%= @rdv.formatted_start_time %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number %></span>.</p>
 <% if @display_mandatory_warning %>
   <p><span class="font-weight-bold">Ce rendez-vous est obligatoire</span>.</p>
 <% end  %>

--- a/app/views/mailers/notification_mailer/by_phone_participation_updated.html.erb
+++ b/app/views/mailers/notification_mailer/by_phone_participation_updated.html.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@applicant.first_name} #{@applicant.last_name.upcase}" %>,</h1>
 <p>Votre <%= @rdv_title %> dans le cadre de votre <%= @rdv_subject %> a été modifié.</p>
-<p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number_formatted %></span>.</p>
+<p>Un travailleur social vous appellera <span class="font-weight-bold">le <%= I18n.l(@rdv.starts_at, format: :human) %></span> sur votre numéro de téléphone: <span class="font-weight-bold"><%= @applicant.phone_number %></span>.</p>
 <% if @display_mandatory_warning %>
   <p><span class="font-weight-bold">Ce rendez-vous est obligatoire</span>.</p>
 <% end %>

--- a/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_user_job_spec.rb
@@ -8,7 +8,7 @@ describe RdvSolidaritesWebhooks::ProcessUserJob do
       "id" => rdv_solidarites_user_id,
       "first_name" => "John",
       "last_name" => "Doe",
-      "phone_number_formatted" => "+33624242424",
+      "phone_number" => "+33624242424",
       "affiliation_number" => "CAUCSCUAHSC",
       "email" => "user@something.com"
     }.deep_symbolize_keys

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -8,8 +8,7 @@ describe Invitations::SendSms, type: :service do
   include_context "with all existing categories"
 
   let!(:help_phone_number) { "0147200001" }
-  let!(:phone_number) { "0782605941" }
-  let!(:phone_number_formatted) { "+33782605941" }
+  let!(:phone_number) { "+33782605941" }
   let!(:applicant) do
     create(
       :applicant,
@@ -59,7 +58,7 @@ describe Invitations::SendSms, type: :service do
     it "calls the send sms service with the right content" do
       expect(SendTransactionalSms).to receive(:call)
         .with(
-          phone_number_formatted: phone_number_formatted, content: content,
+          phone_number: phone_number, content: content,
           sender_name: sms_sender_name
         )
       subject
@@ -111,7 +110,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -143,7 +142,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -167,7 +166,7 @@ describe Invitations::SendSms, type: :service do
           it "calls the send transactional service with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -191,7 +190,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -212,7 +211,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -238,7 +237,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -262,7 +261,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -288,7 +287,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -311,7 +310,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -336,7 +335,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -359,7 +358,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -385,7 +384,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -409,7 +408,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -433,7 +432,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -457,7 +456,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -480,7 +479,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -505,7 +504,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -528,7 +527,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -552,7 +551,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -575,7 +574,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -600,7 +599,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -624,7 +623,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -648,7 +647,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -672,7 +671,7 @@ describe Invitations::SendSms, type: :service do
       it "calls the send transactional service with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -696,7 +695,7 @@ describe Invitations::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject

--- a/spec/services/notifications/send_sms_spec.rb
+++ b/spec/services/notifications/send_sms_spec.rb
@@ -7,8 +7,7 @@ describe Notifications::SendSms, type: :service do
 
   include_context "with all existing categories"
 
-  let!(:phone_number) { "0782605941" }
-  let!(:phone_number_formatted) { "+33782605941" }
+  let!(:phone_number) { "+33782605941" }
   let!(:sms_sender_name) { "provider" }
   let!(:applicant) do
     create(
@@ -104,7 +103,7 @@ describe Notifications::SendSms, type: :service do
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -127,7 +126,7 @@ describe Notifications::SendSms, type: :service do
         it "calls the messenger service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -150,7 +149,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -173,7 +172,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -193,7 +192,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -215,7 +214,7 @@ describe Notifications::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -238,7 +237,7 @@ describe Notifications::SendSms, type: :service do
           it "calls the send transactional service with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -262,7 +261,7 @@ describe Notifications::SendSms, type: :service do
           it "sends the sms with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -288,7 +287,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -311,7 +310,7 @@ describe Notifications::SendSms, type: :service do
           it "sends the sms with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -331,7 +330,7 @@ describe Notifications::SendSms, type: :service do
           it "sends the sms with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -353,7 +352,7 @@ describe Notifications::SendSms, type: :service do
           it "calls the send transactional service with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -377,7 +376,7 @@ describe Notifications::SendSms, type: :service do
             it "calls the send transactional service with the right content" do
               expect(SendTransactionalSms).to receive(:call)
                 .with(
-                  phone_number_formatted: phone_number_formatted, content: content,
+                  phone_number: phone_number, content: content,
                   sender_name: sms_sender_name
                 )
               subject
@@ -402,7 +401,7 @@ describe Notifications::SendSms, type: :service do
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -425,7 +424,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -446,7 +445,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -468,7 +467,7 @@ describe Notifications::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -491,7 +490,7 @@ describe Notifications::SendSms, type: :service do
           it "calls the send transactional service with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -514,7 +513,7 @@ describe Notifications::SendSms, type: :service do
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -535,7 +534,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -556,7 +555,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -577,7 +576,7 @@ describe Notifications::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -599,7 +598,7 @@ describe Notifications::SendSms, type: :service do
           it "calls the send transactional service with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject
@@ -623,7 +622,7 @@ describe Notifications::SendSms, type: :service do
       it "sends the sms with the right content" do
         expect(SendTransactionalSms).to receive(:call)
           .with(
-            phone_number_formatted: phone_number_formatted, content: content,
+            phone_number: phone_number, content: content,
             sender_name: sms_sender_name
           )
         subject
@@ -647,7 +646,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -668,7 +667,7 @@ describe Notifications::SendSms, type: :service do
         it "sends the sms with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -690,7 +689,7 @@ describe Notifications::SendSms, type: :service do
         it "calls the send transactional service with the right content" do
           expect(SendTransactionalSms).to receive(:call)
             .with(
-              phone_number_formatted: phone_number_formatted, content: content,
+              phone_number: phone_number, content: content,
               sender_name: sms_sender_name
             )
           subject
@@ -714,7 +713,7 @@ describe Notifications::SendSms, type: :service do
           it "calls the send transactional service with the right content" do
             expect(SendTransactionalSms).to receive(:call)
               .with(
-                phone_number_formatted: phone_number_formatted, content: content,
+                phone_number: phone_number, content: content,
                 sender_name: sms_sender_name
               )
             subject

--- a/spec/services/send_transactional_sms_spec.rb
+++ b/spec/services/send_transactional_sms_spec.rb
@@ -1,10 +1,10 @@
 describe SendTransactionalSms, type: :service do
   subject do
-    described_class.call(phone_number_formatted: phone_number_formatted, sender_name: sender_name, content: content)
+    described_class.call(phone_number: phone_number, sender_name: sender_name, content: content)
   end
 
   let(:sender_name) { "Dept26" }
-  let(:phone_number_formatted) { "+33648498119" }
+  let(:phone_number) { "+33648498119" }
   let(:content) { "Bienvenue sur RDV-Solidarités" }
   let(:sib_api_mock) { instance_double(SibApiV3Sdk::TransactionalSMSApi) }
   let(:send_transac_mock) { instance_double(SibApiV3Sdk::SendTransacSms) }
@@ -15,7 +15,7 @@ describe SendTransactionalSms, type: :service do
       allow(SibApiV3Sdk::SendTransacSms).to receive(:new)
         .with(
           sender: sender_name,
-          recipient: phone_number_formatted,
+          recipient: phone_number,
           content: content,
           type: "transactional"
         )


### PR DESCRIPTION
Dans cette PR j'enlève la méthode `applicants#phone_number_formatted` qui n'est plus utilisée depuis #976 , puisqu'on formate toujours les numéros de téléphones avant de sauvegarder en base maintenant.
J'en profite pour refactorer le module `PhoneNumberFormatter` pour que ses méthodes soient accessibles depuis l'extérieur sans inclure le module (en faisant des méthodes de classe), et ainsi je pense améliorer la lisibilité.