### PR TITLE
bug(jobs) Add `prescripteur` in `created_by` enum

### DIFF
--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -25,7 +25,7 @@ class Rdv < ApplicationRecord
 
   validate :rdv_contexts_motif_categories_are_uniq
 
-  enum created_by: { agent: 0, user: 1, file_attente: 2 }, _prefix: :created_by
+  enum created_by: { agent: 0, user: 1, file_attente: 2, prescripteur: 3 }, _prefix: :created_by
 
   delegate :presential?, :by_phone?, to: :motif
   delegate :department, to: :organisation


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/1029
A priori c'est la première fois que l'on reçoit un rdv créé par un prescripteur et sidekiq n'aime pas trop car la valeur prescripteur ne fait pas partie de l'enum du model.
Je ne modifie aucun comportement de l'app, j'ajoute juste la valeur `prescripteur` à l'enum du `created_by` du rdv.