### PR TITLE
fix(show): fix rdv_context closing redirect

### DIFF
--- a/app/views/applicants/_close_rdv_context_button.html.erb
+++ b/app/views/applicants/_close_rdv_context_button.html.erb
@@ -1,5 +1,5 @@
 <% if rdv_context.status == "closed" %>
-  <%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:department_id], department_id: params[:department_id], applicant_id: applicant.id), method: :delete do %>
+  <%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:organisation_id], department_id: params[:department_id], applicant_id: applicant.id), method: :delete do %>
     <div data-controller="tooltip" data-action="mouseover->tooltip#reopenRdvContextButton">
       <button class="btn btn-blue">
         Rouvrir "<%= rdv_context.motif_category.name %>"
@@ -7,7 +7,7 @@
     </div>
   <% end %>
 <% else %>
-  <%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:department_id], department_id: params[:department_id], applicant_id: applicant.id), method: :post do %>
+  <%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:organisation_id], department_id: params[:department_id], applicant_id: applicant.id), method: :post do %>
     <div data-controller="tooltip" data-action="mouseover->tooltip#closeRdvContextButton">
       <button class="btn btn-blue">
         Clôturer "<%= rdv_context.motif_category.name %>"


### PR DESCRIPTION
Dans cette PR, je fix la redirection lorsq'un rdv_context est close au niveau de l'organisation. Le param passé dans le formulaire n'était pas le bon.

@aminedhobb je me permets de le déployer direct car c'est un hotfix et il n'y a que deux lignes qui changent.