### PR TITLE
Revert "fix(notifications): forbid pdf generation if applicant address is invalid"

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,7 +3,9 @@ class NotificationsController < ApplicationController
 
   def create
     if notify_participation.success?
-      send_data pdf, filename: pdf_filename, layout: "application/pdf"
+      respond_to do |format|
+        format.pdf { send_data pdf, filename: pdf_filename, layout: "application/pdf" }
+      end
     else
       render turbo_stream: turbo_stream.replace(
         "remote_modal", partial: "common/error_modal", locals: {

--- a/app/views/applicants/_convocations.html.erb
+++ b/app/views/applicants/_convocations.html.erb
@@ -5,7 +5,7 @@
   <div>Email 📧</div>
 <% end %>
 <% if participation.in_the_future? || participation.revoked? %>
-  <%= simple_form_for(:notification, url: participation_notifications_path(participation), html: { method: :post }) do |f| %>
+  <%= simple_form_for(:notification, url: participation_notifications_path(participation, format: "pdf"), html: { method: :post }) do |f| %>
     <%= f.input :format,
                 as: :hidden,
                 input_html: { class: "form-control", value: "postal" }

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -56,14 +56,8 @@
               <td class="px-4 py-3"><%= format_date(participation.created_at) %></td>
               <td class="px-4 py-3"><%= format_date(participation.starts_at) %></td>
               <td class="px-2 py-3"><%= participation.motif_name %></td>
-              <% if convocable_participations.present? %>
-                <td class="px-4 py-2">
-                  <% if participation.convocable? %>
-                    <%= render("convocations", applicant: @applicant, participation: participation, sms_convocations: participation.sent_sms_convocations, email_convocations: participation.sent_email_convocations) %>
-                  <% else %>
-                    -
-                  <% end %>
-                </td>
+              <% if convocable_participations.present?  %>
+                <td class="px-4 py-2"><%= participation.convocable? ? render("convocations", participation: participation, sms_convocations: participation.sent_sms_convocations, email_convocations: participation.sent_email_convocations) : " - " %></td>
               <% end %>
               <td class="px-4 py-3 <%= background_class_for_participation_status(participation) %>">
                 <%= display_participation_status(participation) %>


### PR DESCRIPTION
Reverts betagouv/rdv-insertion#981

Le fait de ne plus préciser le format empêche la génération du courrier.
Je revert en attendant de résoudre le problème initial (affichage de l'erreur lorsque la génération est impossible)