### PR TITLE
fix(notifications): Show postal convocation generation errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
+  gem "pdf-reader"
   gem "rack_session_access"
   # Easy installation and use of web drivers to run system tests with browsers
   gem "webdrivers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.0)
     actioncable (7.0.4.3)
       actionpack (= 7.0.4.3)
       activesupport (= 7.0.4.3)
@@ -68,6 +69,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.2)
       public_suffix (>= 2.0.2, < 6.0)
+    afm (0.2.2)
     ast (2.4.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -129,6 +131,7 @@ GEM
     groupdate (6.2.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
+    hashery (2.1.2)
     htmlentities (4.3.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -194,6 +197,12 @@ GEM
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
+    pdf-reader (2.11.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.4.6)
     pg_search (2.3.6)
       activerecord (>= 5.2)
@@ -315,6 +324,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -367,6 +377,7 @@ GEM
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
+    ttfunk (1.7.0)
     turbo-rails (1.4.0)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -433,6 +444,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web
   listen (~> 3.2)
+  pdf-reader
   pg (>= 0.18, < 2.0)
   pg_search
   phonelib

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -7,11 +7,12 @@ class NotificationsController < ApplicationController
         format.pdf { send_data pdf, filename: pdf_filename, layout: "application/pdf" }
       end
     else
-      render turbo_stream: turbo_stream.replace(
-        "remote_modal", partial: "common/error_modal", locals: {
-          errors: notify_participation.errors
-        }
-      )
+      respond_to do |format|
+        format.pdf do
+          flash[:error] = notify_participation.errors.join(", ")
+          redirect_to request.referer
+        end
+      end
     end
   end
 

--- a/app/javascript/react/lib/createInvitationLetter.js
+++ b/app/javascript/react/lib/createInvitationLetter.js
@@ -26,9 +26,7 @@ const createInvitationLetter = async (
     if (result.errors[0] === "Le format de l'adresse est invalide") {
       Swal.fire({
         title: "Impossible d'inviter l'utilisateur",
-        html: `L'adresse n'est pas complète ou elle n'est pas enregistrée correctement.
-        <br/><br/>
-        Format attendu&nbsp;:<br/>10 rue de l'envoi 12345 - La Ville`,
+        html: "L'adresse n'est pas complète ou elle n'est pas enregistrée correctement",
         icon: "error",
       });
     } else {

--- a/app/services/concerns/messengers/generate_letter.rb
+++ b/app/services/concerns/messengers/generate_letter.rb
@@ -7,7 +7,7 @@ module Messengers::GenerateLetter
 
   def verify_address!(sendable)
     fail!("L'adresse doit être renseignée") if sendable.address.blank?
-    fail!("Le format de l'adresse est invalide") \
+    fail!("Le format de l'adresse est invalide. Le format attendu est le suivant: 10 rue de l'envoi 12345 - La Ville") \
       if sendable.street_address.blank? || sendable.zipcode_and_city.blank?
   end
 end

--- a/app/views/applicants/_convocations.html.erb
+++ b/app/views/applicants/_convocations.html.erb
@@ -4,7 +4,7 @@
 <% if email_convocations.any? %>
   <div>Email 📧</div>
 <% end %>
-<% if participation.in_the_future? || participation.revoked? %>
+<% if participation.pending? || participation.revoked? %>
   <%= simple_form_for(:notification, url: participation_notifications_path(participation, format: "pdf"), html: { method: :post }) do |f| %>
     <%= f.input :format,
                 as: :hidden,

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -56,8 +56,14 @@
               <td class="px-4 py-3"><%= format_date(participation.created_at) %></td>
               <td class="px-4 py-3"><%= format_date(participation.starts_at) %></td>
               <td class="px-2 py-3"><%= participation.motif_name %></td>
-              <% if convocable_participations.present?  %>
-                <td class="px-4 py-2"><%= participation.convocable? ? render("convocations", participation: participation, sms_convocations: participation.sent_sms_convocations, email_convocations: participation.sent_email_convocations) : " - " %></td>
+              <% if convocable_participations.present? %>
+                <td class="px-4 py-2">
+                  <% if participation.convocable? %>
+                    <%= render("convocations", applicant: @applicant, participation: participation, sms_convocations: participation.sent_sms_convocations, email_convocations: participation.sent_email_convocations) %>
+                  <% else %>
+                    -
+                  <% end %>
+                </td>
               <% end %>
               <td class="px-4 py-3 <%= background_class_for_participation_status(participation) %>">
                 <%= display_participation_status(participation) %>

--- a/app/views/common/_flash.html.erb
+++ b/app/views/common/_flash.html.erb
@@ -1,6 +1,6 @@
 <% [:success, :notice, :error, :alert].each do |type| %>
   <% if flash[type] %>
-    <div class="row text-center flash_message" data-controller="flash" data-action="animationend->flash#remove">
+    <div class="row text-center <%= type == :error ? "" : "flash_message" %>" data-controller="flash" data-action="animationend->flash#remove">
       <div class="alert <%= alert_class_for(type) %> alert-dismissible fade show" role="alert">
         <%= flash[type] %>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -346,8 +346,11 @@ describe ApplicantsController do
           expect(response.body).not_to include("Email 📧")
         end
 
-        context "when the rdv is in the future" do
-          before { rdv_orientation1.update! starts_at: 2.days.from_now }
+        context "when the rdv is pending" do
+          before do
+            rdv_orientation1.update! starts_at: 2.days.from_now
+            participation.update! status: "unknown"
+          end
 
           it "shows the courrier generation button" do
             get :show, params: show_params

--- a/spec/features/agent_can_generate_convocation_pdf_spec.rb
+++ b/spec/features/agent_can_generate_convocation_pdf_spec.rb
@@ -1,0 +1,121 @@
+describe "Agents can generate convocation pdf", js: true do
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:organisation) { create(:organisation) }
+  let!(:applicant) { create(:applicant, organisations: [organisation]) }
+  let!(:motif_category) { create(:motif_category) }
+  let!(:motif) do
+    create(:motif, organisation: organisation, motif_category: motif_category, location_type: "public_office")
+  end
+  let!(:rdv_context) do
+    create(:rdv_context, motif_category: motif_category, applicant: applicant, status: "rdv_pending")
+  end
+  let!(:configuration) { create(:configuration, organisation: organisation, motif_category: motif_category) }
+  let!(:participation) do
+    create(
+      :participation,
+      rdv_context: rdv_context, rdv: rdv, applicant: applicant, status: "unknown"
+    )
+  end
+  let!(:rdv) do
+    create(
+      :rdv,
+      convocable: true, starts_at: Time.zone.parse("2022-06-22 08:30"), organisation: organisation, lieu: lieu,
+      motif: motif
+    )
+  end
+  let!(:lieu) { create(:lieu, organisation: organisation) }
+
+  before do
+    travel_to(Time.zone.parse("2022-06-20"))
+    setup_agent_session(agent)
+  end
+
+  it "can generate a pdf" do
+    visit organisation_applicant_path(organisation, applicant)
+
+    expect(page).to have_button "Courrier"
+
+    click_button "Courrier"
+
+    wait_for_download
+    expect(downloads.length).to eq(1)
+
+    pdf = download_content(format: "pdf")
+    pdf_text = extract_raw_text(pdf)
+
+    expect(pdf_text).to include(lieu.name)
+    expect(pdf_text).to include(lieu.address)
+    expect(pdf_text).to include("mercredi 22 juin 2022 à 08h30")
+  end
+
+  context "when it is a phone rdv" do
+    before { motif.update! location_type: "phone" }
+
+    it "generates the matching pdf" do
+      visit organisation_applicant_path(organisation, applicant)
+
+      expect(page).to have_button "Courrier"
+
+      click_button "Courrier"
+
+      wait_for_download
+      expect(downloads.length).to eq(1)
+
+      pdf = download_content(format: "pdf")
+      pdf_text = extract_raw_text(pdf)
+
+      expect(pdf_text).not_to include(lieu.name)
+      expect(pdf_text).not_to include(lieu.address)
+      expect(pdf_text).to include(applicant.phone_number)
+      expect(pdf_text).to include("mercredi 22 juin 2022 à 08h30")
+    end
+  end
+
+  context "when the rdv is passed" do
+    before { rdv.update! starts_at: 2.days.ago }
+
+    it "cannot generate a pdf" do
+      visit organisation_applicant_path(organisation, applicant)
+
+      expect(page).not_to have_button "Courrier"
+    end
+
+    context "when the participation is revoked" do
+      before { participation.update! status: "revoked" }
+
+      it "can generate a revoked participation pdf" do
+        visit organisation_applicant_path(organisation, applicant)
+
+        expect(page).to have_button "Courrier"
+
+        click_button "Courrier"
+
+        wait_for_download
+        expect(downloads.length).to eq(1)
+
+        pdf = download_content(format: "pdf")
+        pdf_text = extract_raw_text(pdf)
+
+        expect(pdf_text).to include("a été annulé")
+      end
+    end
+  end
+
+  context "when the pdf cannot be generated" do
+    before { applicant.update! address: "format invalide" }
+
+    it "returns an error" do
+      visit organisation_applicant_path(organisation, applicant)
+
+      expect(page).to have_button "Courrier"
+
+      click_button "Courrier"
+
+      expect(page).to have_content(
+        "Le format de l'adresse est invalide. Le format attendu est le suivant: 10 rue de l'envoi 12345 - La Ville"
+      )
+
+      expect(page).to have_button "Courrier"
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,7 +41,17 @@ RSpec.configure do |config|
   config.include MotifCategoriesHelper
   config.include NirHelper
   config.include StubHelper
+  config.include DownloadHelper
+  config.include PdfHelper
   config.include ActiveSupport::Testing::TimeHelpers
+
+  ## Clear downloads
+  config.before(:each, js: true) do
+    clear_downloads
+  end
+  config.after(:each, js: true) do
+    clear_downloads
+  end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -65,7 +65,11 @@ describe Invitations::GenerateLetter, type: :service do
       it("is a failure") { is_a_failure }
 
       it "returns the error" do
-        expect(subject.errors).to eq(["Le format de l'adresse est invalide"])
+        expect(subject.errors).to eq(
+          [
+            "Le format de l'adresse est invalide. Le format attendu est le suivant: 10 rue de l'envoi 12345 - La Ville"
+          ]
+        )
       end
     end
 

--- a/spec/services/notifications/generate_letter_spec.rb
+++ b/spec/services/notifications/generate_letter_spec.rb
@@ -158,7 +158,11 @@ describe Notifications::GenerateLetter, type: :service do
       it("is a failure") { is_a_failure }
 
       it "returns the error" do
-        expect(subject.errors).to eq(["Le format de l'adresse est invalide"])
+        expect(subject.errors).to eq(
+          [
+            "Le format de l'adresse est invalide. Le format attendu est le suivant: 10 rue de l'envoi 12345 - La Ville"
+          ]
+        )
       end
     end
   end

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -2,16 +2,18 @@ WebMock.disable_net_connect!(
   allow: ["127.0.0.1", "localhost", "chromedriver.storage.googleapis.com"]
 )
 Capybara.register_driver :selenium do |app|
-  # these args seem to reduce test flakyness
-  args = %w[headless no-sandbox disable-gpu window-size=1500,1000]
+  browser_options = Selenium::WebDriver::Chrome::Options.new(
+    # these args seem to reduce test flakyness
+    args: %w[headless no-sandbox disable-gpu window-size=1500,1000],
+    "goog:loggingPrefs": { browser: "ALL" }
+  )
+  browser_options.add_preference(:download, prompt_for_download: false, default_directory: DownloadHelper::PATH.to_s)
+  browser_options.add_preference(:browser, set_download_behavior: { behavior: "allow" })
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    capabilities: [Selenium::WebDriver::Chrome::Options.new(
-      args: args,
-      "goog:loggingPrefs": { browser: "ALL" }
-    )]
+    options: browser_options
   )
 end
 

--- a/spec/support/download_helper.rb
+++ b/spec/support/download_helper.rb
@@ -1,0 +1,35 @@
+# Inspired by https://dev.to/coorasse/test-downloaded-files-with-rspec-and-system-tests-55mn
+module DownloadHelper
+  TIMEOUT = 10
+  PATH = Rails.root.join("tmp/downloads")
+
+  def downloads
+    Dir[PATH.join("*")]
+  end
+
+  def download
+    downloads.first
+  end
+
+  def download_content(format: nil)
+    format == "pdf" ? PDF::Reader.new(download) : File.read(download)
+  end
+
+  def wait_for_download
+    Timeout.timeout(TIMEOUT) do
+      sleep 0.1 until downloaded?
+    end
+  end
+
+  def downloaded?
+    !downloading? && downloads.any?
+  end
+
+  def downloading?
+    downloads.grep(/\.crdownload$/).any?
+  end
+
+  def clear_downloads
+    FileUtils.rm_f(downloads)
+  end
+end

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -1,0 +1,10 @@
+module PdfHelper
+  def extract_raw_text(pdf)
+    pdf.pages
+       .map(&:text)
+       .join(" ")
+       .gsub("\t", " ")
+       .gsub("\n", " ")
+       .gsub(/ +/, " ")
+  end
+end


### PR DESCRIPTION
Suite de #1045 .

## Contexte 

Je retente de fixer le bug décrit #950 , la dernière tentative ayant été revert dans #1045.

## Implémentation technique 

Pour montrer les erreurs à la génération du courrier de convocation, je set simplement un flash avec l'erreur rencontrée et je recharge la page. 
Au passage, j'enlève l'animation des flashs lorsque ce sont des flashs d'erreurs (je l'avais fait aussi dans #1026 ) car il me semble important de pouvoir lire les messages erreurs et de bien les montrer.
J'en profite également pour ajouter des tests d'intégrations sur cette feature. Pour se faire j'introduis de nouveaux helpers de test qui aident à gérer les download sur les tests d'intégration ainsi que la lecture des pdfs pour tester leur contenu. Pour ce dernier point j'importe la gem `pdf-reader` dans notre environnement de test. 