### PR TITLE
fix(configurations): avoid blank sender city and letter sender name

### DIFF
--- a/app/controllers/messages_configurations_controller.rb
+++ b/app/controllers/messages_configurations_controller.rb
@@ -45,9 +45,9 @@ class MessagesConfigurationsController < ApplicationController
   end
 
   def formatted_params
-    # we nullify some blank params for unicity exceptions (ActiveRecord::RecordNotUnique) not to raise
+    # we nullify some blank params
     messages_configuration_params.to_h do |k, v|
-      [k, k.in?([:sms_sender_name]) ? v.presence : v]
+      [k, k.in?([:sms_sender_name, :letter_sender_name, :sender_city]) ? v.presence : v]
     end
   end
 

--- a/spec/controllers/messages_configurations_controller_spec.rb
+++ b/spec/controllers/messages_configurations_controller_spec.rb
@@ -186,7 +186,7 @@ describe MessagesConfigurationsController do
       expect { post :create, params: create_params }.to change(MessagesConfiguration, :count).by(1)
     end
 
-    it "assigns the corrent attributes" do
+    it "assigns the correct attributes" do
       post :create, params: create_params
 
       expect(MessagesConfiguration.last.direction_names).to eq(["Sous-direction à l'insertion"])
@@ -197,6 +197,19 @@ describe MessagesConfigurationsController do
       expect(MessagesConfiguration.last.display_europe_logos).to eq(true)
       expect(MessagesConfiguration.last.sms_sender_name).to eq("Marseille13")
       expect(MessagesConfiguration.last.display_department_logo).to eq(false)
+    end
+
+    context "when letter_sender_name and sender_city are blank" do
+      let!(:create_params) do
+        { messages_configuration: { sender_city: "  ", letter_sender_name: "" }, organisation_id: organisation.id }
+      end
+
+      it "saves thoses attributes as nil values" do
+        post :create, params: create_params
+
+        expect(MessagesConfiguration.last.sender_city).to eq(nil)
+        expect(MessagesConfiguration.last.letter_sender_name).to eq(nil)
+      end
     end
 
     context "when the create succeeds" do


### PR DESCRIPTION
Lorsqu'un record de `MessageConfiguration` était modifié depuis le formulaire, les attributs `sender_city` et `letter_sender_name` étaient save avec des strings vides, ce qui avait des conséquences indésirables pour les courriers. Ce fix corrige ce problème en nullifiant les params lorsqu'ils sont blank.

Side note : ce hotfix rouvre la question de l'issue #922. Je pense que le plus simple/le plus pertinent pour résoudre cette issue serait de passer par des callbacks `before_validation` dans les modèles. Cette logique devrait en effet plutôt être gérée au niveau du modèle que du contrôleur selon moi