### PR TITLE
fix(nir): Prepend 0 when a key is one digit

### DIFF
--- a/app/lib/nir_helper.rb
+++ b/app/lib/nir_helper.rb
@@ -1,0 +1,15 @@
+module NirHelper
+  class << self
+    def format_nir(nir)
+      return if nir.blank?
+      return nir if nir.length != 13
+
+      "#{nir}#{nir_key(nir)}"
+    end
+
+    def nir_key(nir)
+      key = 97 - (nir.first(13).to_i % 97)
+      key.to_s.length == 2 ? key.to_s : "0#{key}"
+    end
+  end
+end

--- a/app/models/concerns/applicant/nir.rb
+++ b/app/models/concerns/applicant/nir.rb
@@ -2,16 +2,14 @@ module Applicant::Nir
   extend ActiveSupport::Concern
 
   included do
-    before_validation :add_nir_key, if: :nir?
+    before_validation :format_nir, if: :nir?
     validate :nir_is_valid, if: :nir?
   end
 
   private
 
-  def add_nir_key
-    return unless nir.length == 13
-
-    self.nir = "#{nir}#{nir_key}"
+  def format_nir
+    self.nir = NirHelper.format_nir(nir)
   end
 
   def nir_is_valid
@@ -26,10 +24,6 @@ module Applicant::Nir
   end
 
   def nir_sum_checked?
-    nir_key == nir.last(2).to_i
-  end
-
-  def nir_key
-    97 - (nir.first(13).to_i % 97)
+    NirHelper.nir_key(nir) == nir.last(2)
   end
 end

--- a/spec/lib/nir_helper_spec.rb
+++ b/spec/lib/nir_helper_spec.rb
@@ -1,0 +1,19 @@
+describe NirHelper, type: :module do
+  describe "#nir_key" do
+    subject { described_class.nir_key(base_nir) }
+
+    context "when the key is one digit" do
+      let!(:base_nir) do
+        loop do
+          base_nir = "180#{10.times.map { rand(1..9) }.join}"
+          break base_nir if (97 - (base_nir.first(13).to_i % 97)) < 10
+        end
+      end
+
+      it "prepends a 0 to the key" do
+        expect(subject.length).to eq(2)
+        expect(subject.first).to eq("0")
+      end
+    end
+  end
+end

--- a/spec/support/nir_helper.rb
+++ b/spec/support/nir_helper.rb
@@ -1,12 +1,7 @@
 module NirHelper
   def generate_random_nir
-    loop do
-      # choosing random male born in 80
-      base = "180#{10.times.map { rand(1..9) }.join}"
-      # we concatenate key calculation. Can be < 10, that is why we loop, to be sure
-      # to have a 15 digits nir
-      nir = base + (97 - (base.to_i % 97)).to_s
-      break nir if nir.length == 15
-    end
+    # choosing random male born in 80
+    base_nir = "180#{10.times.map { rand(1..9) }.join}"
+    NirHelper.format_nir(base_nir)
   end
 end


### PR DESCRIPTION
Dans cette PR j'introduis le `NirHelper` que j'avais déjà mis en place dans #1026 et j'ajoute la règle pour rajouter un "0" quand la clé est à un chiffre.
NB: Pour les nir à 13 chiffres on fait une vérification de la clé après qu'on l'ait calculé: ça ne coûte rien et c'est plus lisible d'avoir la même validation pour tous les nir une fois qu'ils sont formattés. 