### PR TITLE
fix(jsapp): Send full address even when address column not filled

### DIFF
--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -313,7 +313,7 @@ export default class Applicant {
       title: this.title,
       last_name: this.lastName,
       first_name: this.firstName,
-      ...(this.address && { address: this.fullAddress }),
+      ...(this.fullAddress && { address: this.fullAddress }),
       ...(this.role && { role: this.role }),
       ...(this.affiliationNumber && { affiliation_number: this.affiliationNumber }),
       ...(this.phoneNumber && { phone_number: this.phoneNumber }),


### PR DESCRIPTION
On ne propose pas dans l'interface de configuration du fichier d'entrée de remplir le champ qui correspond au champ "adresse" mais que les compléments d'adresse. Ce qui faisait que l'adresse n'était pas envoyée à la création des bénéficiaires.
Cette PR répare cela. Il faudra également faire un changement dans l'interface de config pour  proposer la colonne d'adresse principale.