### PR TITLE
fix(upload): allow `m` for `monsieur`

### DIFF
--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -9,6 +9,7 @@ const ROLES = {
 };
 
 const TITLES = {
+  m: "monsieur",
   mr: "monsieur",
   mme: "madame",
 };


### PR DESCRIPTION
Micro fix pour permettre aux départements d'utiliser la valeur `M`ou `m`pour la civilité masculine ; jusque là, seuls `mr`et `monsieur`étaient acceptés.