### PR TITLE
fix(applicant): Add pagination for archives

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -246,7 +246,8 @@ class ApplicantsController < ApplicationController
   def set_archives
     return unless archived_scope?
 
-    @archives = Archive.where(applicant_id: @applicants.ids, department_id: @department.id).order(created_at: :desc)
+    @archives = Archive.where(applicant_id: @applicants.ids, department_id: @department.id)
+                       .order(created_at: :desc).page(page)
   end
 
   def set_rdv_contexts

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -1,11 +1,11 @@
 <div class="container mt-5 mb-5">
   <%= render "applicants_list_header" %>
   <div class="row card-white justify-content-center">
-    <% if @current_configuration || @applicants_scope == "archived" %>
+    <% if @all_configurations.empty? %>
+      Merci de configurer votre organisation avant de pouvoir inviter des bénéficiaires
+    <% else %>
       <%= render "applicants_list_tabs" %>
       <%= render "applicants_list_table" %>
-    <% else %>
-      Merci de configurer votre organisation avant de pouvoir inviter des bénéficiaires
     <% end %>
   </div>
 </div>

--- a/db/migrate/20230509205431_create_archives.rb
+++ b/db/migrate/20230509205431_create_archives.rb
@@ -8,7 +8,7 @@ class CreateArchives < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    Applicant.where.not(archived_at: nil).find_each do |applicant|
+    Applicant.active.where.not(archived_at: nil).find_each do |applicant|
       archive = ::Archive.new(
         applicant_id: applicant.id,
         department_id: applicant.organisations.first.department_id,


### PR DESCRIPTION
Sur la page "archivés", les personnes sont listés via les `@archives` pour pouvoir facilement les lister par ordre de création d'archive. Du coup il faut paginer ces records `@archives` comme ce qu'on fait pour les `@applicants`.
J'en profite pour simplifier une condition dans le template index (qui je me rends compte va probablement disparaitre de toutes façons avec #982 )