### PR TITLE
fix(archive): Sort applicants by archives

### DIFF
--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -6,10 +6,6 @@ class Archive < ApplicationRecord
 
   after_save :invalidate_related_invitations
 
-  delegate :first_name, :last_name,
-           :last_invitation_sent_at, :first_invitation_relative_to_last_participation_sent_at,
-           to: :applicant, prefix: true
-
   private
 
   def invalidate_related_invitations

--- a/app/views/applicants/_applicants_archived_table.html.erb
+++ b/app/views/applicants/_applicants_archived_table.html.erb
@@ -9,16 +9,16 @@
     <th scope="col"></th>
   </thead>
   <tbody class="align-middle">
-    <% @archives.each do |archive| %>
+    <% @applicants.each do |applicant| %>
       <tr class="table-danger">
-        <td><%= display_attribute archive.applicant_last_name %></td>
-        <td><%= display_attribute archive.applicant_first_name %></td>
-        <td><%= display_attribute format_date(archive.applicant_first_invitation_relative_to_last_participation_sent_at) %></td>
-        <td><%= display_attribute(format_date(archive.applicant_last_invitation_sent_at)) %></td>
-        <td><%= display_attribute format_date(archive.created_at) %></td>
-        <td><%= display_attribute archive.archiving_reason %></td>
+        <td><%= display_attribute applicant.last_name %></td>
+        <td><%= display_attribute applicant.first_name %></td>
+        <td><%= display_attribute format_date(applicant.first_invitation_relative_to_last_participation_sent_at) %></td>
+        <td><%= display_attribute(format_date(applicant.last_invitation_sent_at)) %></td>
+        <td><%= display_attribute format_date(applicant.archive_for(@department.id).created_at) %></td>
+        <td><%= display_attribute applicant.archive_for(@department.id).archiving_reason %></td>
         <td class="padding-left-15">
-          <%= link_to compute_show_path(archive.applicant, @organisation, @department) do %>
+          <%= link_to compute_show_path(applicant, @organisation, @department) do %>
             <button class="btn btn-blue">Gérer</button>
           <% end %>
         </td>


### PR DESCRIPTION
En déployant #1066 je me suis rendu compte que la recherche ne marchait pas pour les personnes archivées et qu'il y avait en fait une solution beaucoup plus simple pour trier les personnes en fonction de la date d'archivage.. 
