### PR TITLE
fix(configuration): trigger webhook after organisation creation

### DIFF
--- a/app/clients/rdv_solidarites_client.rb
+++ b/app/clients/rdv_solidarites_client.rb
@@ -160,25 +160,27 @@ class RdvSolidaritesClient
     )
   end
 
-  def create_webhook_endpoint(organisation_id, subscriptions)
+  def create_webhook_endpoint(organisation_id, subscriptions, trigger)
     Faraday.post(
       "#{@url}/api/v1/organisations/#{organisation_id}/webhook_endpoints",
       {
         target_url: "#{ENV['HOST']}/rdv_solidarites_webhooks",
         secret: ENV["RDV_SOLIDARITES_SECRET"],
-        subscriptions: subscriptions
+        subscriptions: subscriptions,
+        trigger: trigger
       }.to_json,
       request_headers
     )
   end
 
-  def update_webhook_endpoint(webhook_endpoint_id, organisation_id, subscriptions)
+  def update_webhook_endpoint(webhook_endpoint_id, organisation_id, subscriptions, trigger)
     Faraday.patch(
       "#{@url}/api/v1/organisations/#{organisation_id}/webhook_endpoints/#{webhook_endpoint_id}",
       {
         target_url: "#{ENV['HOST']}/rdv_solidarites_webhooks",
         secret: ENV["RDV_SOLIDARITES_SECRET"],
-        subscriptions: subscriptions
+        subscriptions: subscriptions,
+        trigger: trigger
       }.to_json,
       request_headers
     )

--- a/app/jobs/rdv_solidarites_webhooks/trigger_endpoint_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/trigger_endpoint_job.rb
@@ -1,0 +1,30 @@
+module RdvSolidaritesWebhooks
+  class TriggerEndpointJob < ApplicationJob
+    def perform(
+      rdv_solidarites_webhook_endpoint_id, rdv_solidarites_organisation_id, rdv_solidarites_session_credentials
+    )
+      @rdv_solidarites_webhook_endpoint_id = rdv_solidarites_webhook_endpoint_id
+      @rdv_solidarites_organisation_id = rdv_solidarites_organisation_id
+      @rdv_solidarites_session_credentials = rdv_solidarites_session_credentials.deep_symbolize_keys
+
+      return if trigger_webhook_endpoint.success?
+
+      raise StandardError, trigger_webhook_endpoint.errors.join(" - ")
+    end
+
+    private
+
+    def trigger_webhook_endpoint
+      @trigger_webhook_endpoint ||= RdvSolidaritesApi::UpdateWebhookEndpoint.call(
+        rdv_solidarites_webhook_endpoint_id: @rdv_solidarites_webhook_endpoint_id,
+        rdv_solidarites_organisation_id: @rdv_solidarites_organisation_id,
+        rdv_solidarites_session: rdv_solidarites_session,
+        trigger: true
+      )
+    end
+
+    def rdv_solidarites_session
+      @rdv_solidarites_session ||= RdvSolidaritesSessionFactory.create_with(**@rdv_solidarites_session_credentials)
+    end
+  end
+end

--- a/app/services/organisations/create.rb
+++ b/app/services/organisations/create.rb
@@ -15,12 +15,22 @@ module Organisations
         upsert_rdv_solidarites_webhook_endpoint
         tag_rdv_solidarites_organisation
       end
+      trigger_rdv_solidarites_webhook_endpoint
     end
 
     private
 
     def upsert_rdv_solidarites_webhook_endpoint
+      # webhook_endpoint is upserted but not triggered because organisation is not persisted yet
       rdv_solidarites_webhook_endpoint.present? ? update_rdvs_webhook_endpoint : create_rdvs_webhook_endpoint
+    end
+
+    def trigger_rdv_solidarites_webhook_endpoint
+      RdvSolidaritesWebhooks::TriggerEndpointJob.perform_async(
+        rdv_solidarites_webhook_endpoint.id,
+        @organisation.rdv_solidarites_organisation_id,
+        @rdv_solidarites_session.to_h
+      )
     end
 
     def check_rdv_solidarites_organisation_id

--- a/app/services/rdv_solidarites_api/create_webhook_endpoint.rb
+++ b/app/services/rdv_solidarites_api/create_webhook_endpoint.rb
@@ -3,11 +3,13 @@ module RdvSolidaritesApi
     def initialize(
       rdv_solidarites_organisation_id:,
       rdv_solidarites_session:,
-      subscriptions: RdvSolidarites::WebhookEndpoint::ALL_SUBSCRIPTIONS
+      subscriptions: RdvSolidarites::WebhookEndpoint::ALL_SUBSCRIPTIONS,
+      trigger: false
     )
       @rdv_solidarites_organisation_id = rdv_solidarites_organisation_id
       @rdv_solidarites_session = rdv_solidarites_session
       @subscriptions = subscriptions
+      @trigger = trigger
     end
 
     def call
@@ -18,7 +20,7 @@ module RdvSolidaritesApi
 
     def rdv_solidarites_response
       @rdv_solidarites_response ||=
-        rdv_solidarites_client.create_webhook_endpoint(@rdv_solidarites_organisation_id, @subscriptions)
+        rdv_solidarites_client.create_webhook_endpoint(@rdv_solidarites_organisation_id, @subscriptions, @trigger)
     end
   end
 end

--- a/app/services/rdv_solidarites_api/update_webhook_endpoint.rb
+++ b/app/services/rdv_solidarites_api/update_webhook_endpoint.rb
@@ -4,12 +4,14 @@ module RdvSolidaritesApi
       rdv_solidarites_webhook_endpoint_id:,
       rdv_solidarites_organisation_id:,
       rdv_solidarites_session:,
-      subscriptions: RdvSolidarites::WebhookEndpoint::ALL_SUBSCRIPTIONS
+      subscriptions: RdvSolidarites::WebhookEndpoint::ALL_SUBSCRIPTIONS,
+      trigger: false
     )
       @rdv_solidarites_webhook_endpoint_id = rdv_solidarites_webhook_endpoint_id
       @rdv_solidarites_organisation_id = rdv_solidarites_organisation_id
       @rdv_solidarites_session = rdv_solidarites_session
       @subscriptions = subscriptions
+      @trigger = trigger
     end
 
     def call
@@ -20,7 +22,7 @@ module RdvSolidaritesApi
 
     def rdv_solidarites_response
       @rdv_solidarites_response ||= rdv_solidarites_client.update_webhook_endpoint(
-        @rdv_solidarites_webhook_endpoint_id, @rdv_solidarites_organisation_id, @subscriptions
+        @rdv_solidarites_webhook_endpoint_id, @rdv_solidarites_organisation_id, @subscriptions, @trigger
       )
     end
   end


### PR DESCRIPTION
closes #1067 

Dans cette PR, je fais en sorte que la synchro du webhook d'une organisation rdvs nouvellement créée sur rdvi soit effectuée une fois l'orga persistée en DB. Pour ce faire, je tire parti de la possibilité de passer un params `trigger` dans la requête de création ou d'update d'un `WebhookEndpoint` rdvs. 

Par défaut, je fais en sorte que les appels aux services de `create` et `update` de cette ressource ne triggerent plus la synchronisation. Cette synchro est trigger dans un second temps via un job (ce qui me paraît un compromis acceptable : si cela fail, il y aura des retry, et on pourra toujours s'en occuper manuellement si l'erreur remonte)