### PR TITLE
fix(notifications): Remove instruction for rdv from sms

### DIFF
--- a/app/services/concerns/notifications/sms_content.rb
+++ b/app/services/concerns/notifications/sms_content.rb
@@ -1,7 +1,7 @@
 module Notifications
   module SmsContent
     delegate :rdv, :applicant, :rdv_title, :applicant_designation, :mandatory_warning,
-             :punishable_warning, :instruction_for_rdv, :rdv_subject,
+             :punishable_warning, :rdv_subject,
              to: :notification
     delegate :formatted_start_date, :formatted_start_time, :lieu, :phone_number, to: :rdv
 
@@ -14,7 +14,6 @@ module Notifications
         "#{rdv_title}. Vous êtes #{applicant.conjugate('attendu')} le #{formatted_start_date} à " \
         "#{formatted_start_time} ici: #{lieu.full_name}. " \
         "#{mandatory_warning_message}" \
-        "#{instruction_for_rdv_message}" \
         "#{punishable_warning_message}" \
         "En cas d’empêchement, appelez rapidement le #{phone_number}."
     end
@@ -25,7 +24,6 @@ module Notifications
         "#{rdv_title}. Un travailleur social vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. " \
         "#{mandatory_warning_message}" \
-        "#{instruction_for_rdv_message}" \
         "#{punishable_warning_message}" \
         "En cas d’empêchement, appelez rapidement le #{phone_number}."
     end
@@ -36,7 +34,6 @@ module Notifications
         "Vous êtes #{applicant.conjugate('attendu')} le #{formatted_start_date} à #{formatted_start_time}" \
         " ici: #{lieu.full_name}. " \
         "#{mandatory_warning_message}" \
-        "#{instruction_for_rdv_message}" \
         "#{punishable_warning_message}" \
         "En cas d’empêchement, appelez rapidement le #{phone_number}."
     end
@@ -46,7 +43,6 @@ module Notifications
         "Un travailleur social vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. " \
         "#{mandatory_warning_message}" \
-        "#{instruction_for_rdv_message}" \
         "#{punishable_warning_message}" \
         "En cas d’empêchement, appelez rapidement le #{phone_number}."
     end
@@ -58,7 +54,6 @@ module Notifications
         "#{rdv_title}. Vous êtes #{applicant.conjugate('attendu')} le #{formatted_start_date} à " \
         "#{formatted_start_time} ici: #{lieu.full_name}. " \
         "#{mandatory_warning_message}" \
-        "#{instruction_for_rdv_message}" \
         "#{punishable_warning_message}" \
         "En cas d’empêchement, appelez rapidement le #{phone_number}."
     end
@@ -69,7 +64,6 @@ module Notifications
         "#{rdv_title}. Un travailleur social vous appellera le #{formatted_start_date}" \
         " à partir de #{formatted_start_time} sur ce numéro. " \
         "#{mandatory_warning_message}" \
-        "#{instruction_for_rdv_message}" \
         "#{punishable_warning_message}" \
         "En cas d’empêchement, appelez rapidement le #{phone_number}."
     end
@@ -92,10 +86,6 @@ module Notifications
       else
         ""
       end
-    end
-
-    def instruction_for_rdv_message
-      instruction_for_rdv.present? ? "#{instruction_for_rdv} " : ""
     end
   end
 end

--- a/spec/services/notifications/send_sms_spec.rb
+++ b/spec/services/notifications/send_sms_spec.rb
@@ -101,7 +101,7 @@ describe Notifications::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué à un " \
           "rendez-vous d'orientation. Vous êtes attendu le 20/12/2021" \
           " à 10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-          "Ce RDV est obligatoire. Merci de venir au RDV avec un justificatif de domicile et une pièce d'identité. " \
+          "Ce RDV est obligatoire. " \
           "En cas d’empêchement, appelez rapidement le 0101010101."
       end
 
@@ -124,7 +124,7 @@ describe Notifications::SendSms, type: :service do
           "Madame Jane DOE,\nVous êtes bénéficiaire du RSA et à ce titre vous êtes convoquée à un " \
             "rendez-vous d'orientation. Vous êtes attendue le 20/12/2021" \
             " à 10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. Merci de venir au RDV avec un justificatif de domicile et une pièce d'identité. " \
+            "Ce RDV est obligatoire. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
         end
 
@@ -147,7 +147,7 @@ describe Notifications::SendSms, type: :service do
           "Monsieur John DOE,\nVotre rendez-vous d'orientation dans le cadre de votre RSA a été modifié. " \
             "Vous êtes attendu le 20/12/2021 à " \
             "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. Merci de venir au RDV avec un justificatif de domicile et une pièce d'identité. " \
+            "Ce RDV est obligatoire. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
         end
 
@@ -170,7 +170,7 @@ describe Notifications::SendSms, type: :service do
           "RAPPEL: Monsieur John DOE,\nVous êtes bénéficiaire du RSA et à ce titre vous avez été convoqué à un " \
             "rendez-vous d'orientation. Vous êtes attendu le 20/12/2021" \
             " à 10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. Merci de venir au RDV avec un justificatif de domicile et une pièce d'identité. " \
+            "Ce RDV est obligatoire. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
         end
 
@@ -284,7 +284,7 @@ describe Notifications::SendSms, type: :service do
           "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et à ce titre vous êtes convoqué à un " \
             "rendez-vous d'accompagnement. Vous êtes attendu " \
             "le 20/12/2021 à 10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-            "Ce RDV est obligatoire. Merci de venir au RDV avec un justificatif de domicile et une pièce d'identité. " \
+            "Ce RDV est obligatoire. " \
             "En cas d'absence, votre RSA pourra être suspendu ou réduit. " \
             "En cas d’empêchement, appelez rapidement le 0101010101."
         end
@@ -307,8 +307,8 @@ describe Notifications::SendSms, type: :service do
             "Monsieur John DOE,\nVotre rendez-vous d'accompagnement dans le cadre de votre RSA a été modifié. " \
               "Vous êtes attendu le 20/12/2021 à " \
               "10:00 ici: DINUM - 20 avenue de Ségur 75007 Paris. " \
-              "Ce RDV est obligatoire. Merci de venir au RDV avec un justificatif de domicile " \
-              "et une pièce d'identité. En cas d'absence, votre RSA pourra être suspendu ou réduit. " \
+              "Ce RDV est obligatoire. " \
+              "En cas d'absence, votre RSA pourra être suspendu ou réduit. " \
               "En cas d’empêchement, appelez rapidement le 0101010101."
           end
 


### PR DESCRIPTION
Nous avons certains sms de convocations qui n'arrivent pas à leur destinataire (voir [sentry](https://sentry.incubateur.net/organizations/betagouv/issues/39795/?project=16&query=is%3Aunresolved&referrer=issue-stream)) car les instructions configurées sur le motif dans RDVS sont trop longues pour être mises dans un SMS. En voici un exemple pour des sms qui n'ont pas pu être délivrées: 
<img width="1642" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/7602809/8f733fe7-1581-4275-a759-f6cbe08febe7">

Je pense qu'on ne peut pas de toutes façons laisser un champ libre pour les SMS. 
On pourrait faire en sorte de n'insérer l'instruction que si elle est inférieure à un certain nombre de caractère, mais il faudrait un moyen de l'afficher explicitement sur l'appli (quand on pourra configurer les motifs sur RDVI par exemple), sinon on risque d'entrainer de la confusion chez nos utilisateurs qui ne sauront pas les règles appliquées.