### PR TITLE
feat(csv): Add referents to csv export

### DIFF
--- a/app/controllers/applicants/searches_controller.rb
+++ b/app/controllers/applicants/searches_controller.rb
@@ -14,7 +14,7 @@ module Applicants
         .active
         .where(id: search_in_all_applicants.ids + search_in_department_organisations.ids)
         .preload(
-          :rdvs, :agents, :archives,
+          :rdvs, :referents, :archives,
           invitations: :rdv_context,
           rdv_contexts: [:participations, :motif_category],
           organisations: [:motif_categories, :department, :configurations]

--- a/app/controllers/concerns/applicants/filterable.rb
+++ b/app/controllers/concerns/applicants/filterable.rb
@@ -28,7 +28,7 @@ module Applicants::Filterable
   def filter_applicants_by_current_agent
     return unless params[:filter_by_current_agent] == "true"
 
-    @applicants = @applicants.joins(:agents).where(agents: current_agent)
+    @applicants = @applicants.joins(:referents).where(referents: { id: current_agent.id })
   end
 
   def filter_applicants_by_search_query

--- a/app/controllers/referent_assignations_controller.rb
+++ b/app/controllers/referent_assignations_controller.rb
@@ -48,7 +48,7 @@ class ReferentAssignationsController < ApplicationController
   end
 
   def set_applicant
-    @applicant = policy_scope(Applicant).includes(:agents).find(applicant_id)
+    @applicant = policy_scope(Applicant).includes(:referents).find(applicant_id)
   end
 
   def set_department

--- a/app/javascript/react/models/Applicant.js
+++ b/app/javascript/react/models/Applicant.js
@@ -150,7 +150,7 @@ export default class Applicant {
       "postal",
       this.currentConfiguration.motif_category_id
     );
-    this.agents = upToDateApplicant.agents;
+    this.referents = upToDateApplicant.referents;
   }
 
   updatePhoneNumber(phoneNumber) {
@@ -293,8 +293,8 @@ export default class Applicant {
   referentAlreadyAssigned() {
     return (
       this.referentEmail &&
-      this.agents &&
-      this.agents.some((agent) => agent.email === this.referentEmail)
+      this.referents &&
+      this.referents.some((referent) => referent.email === this.referentEmail)
     );
   }
 

--- a/app/jobs/rdv_solidarites_webhooks/process_referent_assignation_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_referent_assignation_job.rb
@@ -43,15 +43,15 @@ module RdvSolidaritesWebhooks
     end
 
     def attach_agent_to_applicant
-      return if applicant.reload.agent_ids.include?(agent.id)
+      return if applicant.reload.referent_ids.include?(agent.id)
 
-      applicant.agents << agent
+      applicant.referents << agent
     end
 
     def remove_agent_from_applicant
-      return unless applicant.reload.agent_ids.include?(agent.id)
+      return unless applicant.reload.referent_ids.include?(agent.id)
 
-      applicant.agents.delete(agent)
+      applicant.referents.delete(agent)
     end
   end
 end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -5,12 +5,13 @@ class Agent < ApplicationRecord
   validates :rdv_solidarites_agent_id, uniqueness: true, allow_nil: true
 
   has_many :agent_roles, dependent: :destroy
-  has_and_belongs_to_many :applicants
+  has_many :referent_assignations, dependent: :destroy
 
   has_many :organisations, through: :agent_roles
   has_many :departments, -> { distinct }, through: :organisations
   has_many :configurations, through: :organisations
   has_many :motif_categories, -> { distinct }, through: :organisations
+  has_many :applicants, through: :referent_assignations
 
   scope :not_betagouv, -> { where.not("agents.email LIKE ?", "%beta.gouv.fr") }
   scope :super_admins, -> { where(super_admin: true) }

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -28,11 +28,13 @@ class Applicant < ApplicationRecord
   has_many :invitations, dependent: :destroy
   has_many :participations, dependent: :destroy
   has_many :archives, dependent: :destroy
+  has_many :referent_assignations, dependent: :destroy
 
   has_many :rdvs, through: :participations
   has_many :notifications, through: :participations
   has_many :configurations, through: :organisations
   has_many :motif_categories, through: :rdv_contexts
+  has_many :referents, through: :referent_assignations, source: :agent
 
   validates :last_name, :first_name, :title, presence: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
@@ -111,7 +113,7 @@ class Applicant < ApplicationRecord
       invitations: invitations,
       organisations: organisations,
       rdv_contexts: rdv_contexts,
-      agents: agents,
+      referents: referents,
       archives: archives
     )
   end

--- a/app/models/referent_assignation.rb
+++ b/app/models/referent_assignation.rb
@@ -1,0 +1,4 @@
+class ReferentAssignation < ApplicationRecord
+  belongs_to :applicant
+  belongs_to :agent
+end

--- a/app/services/applicants/assign_referent.rb
+++ b/app/services/applicants/assign_referent.rb
@@ -8,7 +8,7 @@ module Applicants
 
     def call
       Applicant.transaction do
-        @applicant.agents << @agent
+        @applicant.referents << @agent
         create_rdv_solidarites_referent_assignation
       end
     end

--- a/app/services/applicants/remove_referent.rb
+++ b/app/services/applicants/remove_referent.rb
@@ -8,7 +8,7 @@ module Applicants
 
     def call
       Applicant.transaction do
-        @applicant.agents.delete(@agent)
+        @applicant.referents.delete(@agent)
         delete_rdv_solidarites_referent_assignation
       end
     end

--- a/app/services/exporters/generate_applicants_csv.rb
+++ b/app/services/exporters/generate_applicants_csv.rb
@@ -50,6 +50,7 @@ module Exporters
        "Date d'orientation",
        Archive.human_attribute_name(:created_at),
        Archive.human_attribute_name(:archiving_reason),
+       Applicant.human_attribute_name(:referents),
        "Nombre d'organisations",
        "Nom des organisations"]
     end
@@ -78,6 +79,7 @@ module Exporters
        display_date(applicant.first_seen_rdv_starts_at),
        display_date(applicant.archive_for(department_id)&.created_at),
        applicant.archive_for(department_id)&.archiving_reason,
+       applicant.referents.map(&:email).join(", "),
        applicant.organisations.to_a.count,
        applicant.organisations.map(&:name).join(", ")]
     end

--- a/app/services/invitations/compute_link.rb
+++ b/app/services/invitations/compute_link.rb
@@ -47,7 +47,7 @@ module Invitations
       }
         .merge(@invitation.rdv_solidarites_lieu_id? ? { lieu_id: @invitation.rdv_solidarites_lieu_id } : geo_attributes)
         .merge(
-          @invitation.rdv_with_referents? ? { referent_ids: applicant.agents.map(&:rdv_solidarites_agent_id) } : {}
+          @invitation.rdv_with_referents? ? { referent_ids: applicant.referents.map(&:rdv_solidarites_agent_id) } : {}
         )
     end
 

--- a/app/services/invitations/validate.rb
+++ b/app/services/invitations/validate.rb
@@ -45,7 +45,7 @@ module Invitations
     end
 
     def validate_referents_are_assigned
-      return if applicant.agent_ids.any?
+      return if applicant.referent_ids.any?
 
       result.errors << "Un référent doit être assigné au bénéficiaire pour les rdvs avec référents"
     end

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -39,7 +39,7 @@
         <%= render "common/attribute_display", record: @archive, attribute: :created_at, as: :date %>
       <% end %>
       <%= render "common/attribute_display", record: @applicant, attribute: :organisations, as: :list, id: "organisations_list" %>
-      <%= render "common/attribute_display", record: @applicant, attribute: :agents, as: :list, id: "agents_list" %>
+      <%= render "common/attribute_display", record: @applicant, attribute: :referents, as: :list, id: "referents_list" %>
     </div>
 
     <div class="row d-flex justify-content-start flex-wrap">

--- a/app/views/letters/invitations/atelier.html.erb
+++ b/app/views/letters/invitations/atelier.html.erb
@@ -5,7 +5,7 @@
     <p>N° allocataire : <%= applicant.affiliation_number %></p>
   <% end %>
   <% if invitation.rdv_with_referents? %>
-    <p><%= "Référent".pluralize(applicant.agents.count) %> de parcours : <%= applicant.agents.order(:last_name).map(&:to_s).join(", ") %></p>
+    <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>
 </div>
 <div class="main-content">

--- a/app/views/letters/invitations/phone_platform.html.erb
+++ b/app/views/letters/invitations/phone_platform.html.erb
@@ -6,7 +6,7 @@
     <p>N° allocataire : <%= applicant.affiliation_number %></p>
   <% end %>
   <% if invitation.rdv_with_referents? %>
-    <p><%= "Référent".pluralize(applicant.agents.count) %> de parcours : <%= applicant.agents.order(:last_name).map(&:to_s).join(", ") %></p>
+    <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>
 </div>
 

--- a/app/views/letters/invitations/short.html.erb
+++ b/app/views/letters/invitations/short.html.erb
@@ -6,7 +6,7 @@
     <p>N° allocataire : <%= applicant.affiliation_number %></p>
   <% end %>
   <% if invitation.rdv_with_referents? %>
-    <p><%= "Référent".pluralize(applicant.agents.count) %> de parcours : <%= applicant.agents.order(:last_name).map(&:to_s).join(", ") %></p>
+    <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>
 </div>
 

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -6,7 +6,7 @@
     <p>N° allocataire : <%= applicant.affiliation_number %></p>
   <% end %>
   <% if invitation.rdv_with_referents? %>
-    <p><%= "Référent".pluralize(applicant.agents.count) %> de parcours : <%= applicant.agents.order(:last_name).map(&:to_s).join(", ") %></p>
+    <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>
 </div>
 

--- a/app/views/referent_assignations/create.turbo_stream.erb
+++ b/app/views/referent_assignations/create.turbo_stream.erb
@@ -1,5 +1,5 @@
-<%= turbo_stream.replace "agents_list" do %>
-  <%= render "common/attribute_display", record: @applicant, attribute: :agents, as: :list, id: "agents_list" %>
+<%= turbo_stream.replace "referents_list" do %>
+  <%= render "common/attribute_display", record: @applicant, attribute: :referents, as: :list, id: "referents_list" %>
 <% end %>
 
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/referent_assignations/destroy.turbo_stream.erb
+++ b/app/views/referent_assignations/destroy.turbo_stream.erb
@@ -1,4 +1,4 @@
-<%= turbo_stream.replace "agents_list" do %>
-  <%= render "common/attribute_display", record: @applicant, attribute: :agents, as: :list, id: "agents_list" %>
+<%= turbo_stream.replace "referents_list" do %>
+  <%= render "common/attribute_display", record: @applicant, attribute: :referents, as: :list, id: "referents_list" %>
 <% end %>
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/referent_assignations/index.html.erb
+++ b/app/views/referent_assignations/index.html.erb
@@ -1,6 +1,6 @@
 <%= render "common/remote_modal", title: "Choisissez un agent référent" do %>
   <% @agents.each do |agent| %>
-    <%= render "referent_assignation", department: @department, agent: agent, applicant: @applicant, assigned: @applicant.agent_ids.include?(agent.id) %>
+    <%= render "referent_assignation", department: @department, agent: agent, applicant: @applicant, assigned: @applicant.referent_ids.include?(agent.id) %>
   <% end %>
 <% end %>
 

--- a/config/locales/models/applicant.fr.yml
+++ b/config/locales/models/applicant.fr.yml
@@ -21,5 +21,5 @@ fr:
         uid: Le couple numéro d'allocataire + rôle
         created_at: Date de création
         status: Statut
-        agents: Référent(s)
+        referents: Référent(s)
         organisation_ids: Organisation

--- a/db/migrate/20230606084749_rename_agents_applicants_to_referent_assignations.rb
+++ b/db/migrate/20230606084749_rename_agents_applicants_to_referent_assignations.rb
@@ -1,0 +1,5 @@
+class RenameAgentsApplicantsToReferentAssignations < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :agents_applicants, :referent_assignations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_17_100211) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_06_084749) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,12 +41,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_17_100211) do
     t.boolean "super_admin", default: false
     t.index ["email"], name: "index_agents_on_email", unique: true
     t.index ["rdv_solidarites_agent_id"], name: "index_agents_on_rdv_solidarites_agent_id", unique: true
-  end
-
-  create_table "agents_applicants", id: false, force: :cascade do |t|
-    t.bigint "applicant_id", null: false
-    t.bigint "agent_id", null: false
-    t.index ["applicant_id", "agent_id"], name: "index_agents_applicants_on_applicant_id_and_agent_id", unique: true
   end
 
   create_table "applicants", force: :cascade do |t|
@@ -320,6 +314,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_17_100211) do
     t.index ["organisation_id"], name: "index_rdvs_on_organisation_id"
     t.index ["rdv_solidarites_rdv_id"], name: "index_rdvs_on_rdv_solidarites_rdv_id", unique: true
     t.index ["status"], name: "index_rdvs_on_status"
+  end
+
+  create_table "referent_assignations", id: false, force: :cascade do |t|
+    t.bigint "applicant_id", null: false
+    t.bigint "agent_id", null: false
+    t.index ["applicant_id", "agent_id"], name: "index_referent_assignations_on_applicant_id_and_agent_id", unique: true
   end
 
   create_table "stats", force: :cascade do |t|

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -639,7 +639,7 @@ describe ApplicantsController do
         }
       end
 
-      before { applicant.agents = [agent] }
+      before { applicant.referents = [agent] }
 
       it "filters on the applicants assigned to the agent" do
         get :index, params: index_params

--- a/spec/controllers/referent_assignations_controller_spec.rb
+++ b/spec/controllers/referent_assignations_controller_spec.rb
@@ -36,7 +36,7 @@ describe ReferentAssignationsController do
   end
 
   describe "#index" do
-    before { applicant.update!(agents: [agent2]) }
+    before { applicant.update!(referents: [agent2]) }
 
     it "shows the agents that can be assigned/removed" do
       get :index, params: { applicant_id: applicant_id, department_id: department.id }

--- a/spec/jobs/rdv_solidarites_webhooks/process_referent_assignation_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_referent_assignation_job_spec.rb
@@ -21,7 +21,7 @@ describe RdvSolidaritesWebhooks::ProcessReferentAssignationJob do
   end
 
   let!(:applicant) do
-    create(:applicant, rdv_solidarites_user_id: rdv_solidarites_user_id, agents: [agent])
+    create(:applicant, rdv_solidarites_user_id: rdv_solidarites_user_id, referents: [agent])
   end
 
   let!(:agent) { create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id) }
@@ -29,17 +29,17 @@ describe RdvSolidaritesWebhooks::ProcessReferentAssignationJob do
   describe "#call" do
     it "removes the agent from the applicant" do
       subject
-      expect(applicant.reload.agents).to eq([])
+      expect(applicant.reload.referents).to eq([])
     end
 
     context "when the applicant cannot be found" do
       let!(:applicant) do
-        create(:applicant, rdv_solidarites_user_id: "some-id", agents: [agent])
+        create(:applicant, rdv_solidarites_user_id: "some-id", referents: [agent])
       end
 
       it "does not remove the organisation from the applicant" do
         subject
-        expect(applicant.reload.agents).to eq([agent])
+        expect(applicant.reload.referents).to eq([agent])
       end
     end
 
@@ -54,7 +54,7 @@ describe RdvSolidaritesWebhooks::ProcessReferentAssignationJob do
 
       it "does not remove the agent from the applicant" do
         subject
-        expect(applicant.reload.agents).to eq([agent])
+        expect(applicant.reload.referents).to eq([agent])
       end
 
       it "sends a notification to mattermost" do
@@ -77,7 +77,7 @@ describe RdvSolidaritesWebhooks::ProcessReferentAssignationJob do
 
       it "does not remove the agent from the applicant" do
         subject
-        expect(applicant.reload.agents).to eq([agent])
+        expect(applicant.reload.referents).to eq([agent])
       end
     end
 
@@ -91,12 +91,12 @@ describe RdvSolidaritesWebhooks::ProcessReferentAssignationJob do
 
       context "when the applicant does not belong to the org" do
         let!(:applicant) do
-          create(:applicant, rdv_solidarites_user_id: rdv_solidarites_user_id, agents: [])
+          create(:applicant, rdv_solidarites_user_id: rdv_solidarites_user_id, referents: [])
         end
 
         it "adds the agent to the applicant" do
           subject
-          expect(applicant.reload.agents.ids).to eq([agent.id])
+          expect(applicant.reload.referents.ids).to eq([agent.id])
         end
       end
     end

--- a/spec/services/applicants/assign_referent_spec.rb
+++ b/spec/services/applicants/assign_referent_spec.rb
@@ -27,7 +27,7 @@ describe Applicants::AssignReferent, type: :service do
 
     it "assigns the agent to the applicant" do
       subject
-      expect(applicant.reload.agents).to include(agent)
+      expect(applicant.reload.referents).to include(agent)
     end
 
     context "when it fails to assign referent through API" do
@@ -46,7 +46,7 @@ describe Applicants::AssignReferent, type: :service do
 
       it "does not assign the agent to the applicant" do
         subject
-        expect(applicant.reload.agents).not_to include(agent)
+        expect(applicant.reload.referents).not_to include(agent)
       end
 
       it "outputs an error" do

--- a/spec/services/applicants/remove_referent_spec.rb
+++ b/spec/services/applicants/remove_referent_spec.rb
@@ -8,7 +8,7 @@ describe Applicants::RemoveReferent, type: :service do
   end
 
   let!(:agent) { create(:agent) }
-  let!(:applicant) { create(:applicant, agents: [agent]) }
+  let!(:applicant) { create(:applicant, referents: [agent]) }
   let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession::Base) }
 
   describe "#call" do
@@ -27,7 +27,7 @@ describe Applicants::RemoveReferent, type: :service do
 
     it "removes the agent from the applicant" do
       subject
-      expect(applicant.reload.agents).not_to include(agent)
+      expect(applicant.reload.referents).to eq([])
     end
 
     context "when it fails to remove referent through API" do
@@ -46,7 +46,7 @@ describe Applicants::RemoveReferent, type: :service do
 
       it "does not remove the agent to the applicant" do
         subject
-        expect(applicant.reload.agents).to include(agent)
+        expect(applicant.reload.referents).to include(agent)
       end
 
       it "outputs an error" do

--- a/spec/services/exporters/generate_applicants_csv_spec.rb
+++ b/spec/services/exporters/generate_applicants_csv_spec.rb
@@ -26,7 +26,8 @@ describe Exporters::GenerateApplicantsCsv, type: :service do
       rights_opening_date: "18/05/2022",
       created_at: "20/05/2022",
       role: "demandeur",
-      organisations: [organisation]
+      organisations: [organisation],
+      referents: [referent]
     )
   end
   let(:applicant2) { create(:applicant, last_name: "Casubolo", organisations: [organisation]) }
@@ -51,6 +52,9 @@ describe Exporters::GenerateApplicantsCsv, type: :service do
                     motif_category: motif_category, participations: [participation_rdv],
                     applicant: applicant1, status: "rdv_needs_status_update"
     )
+  end
+  let!(:referent) do
+    create(:agent, email: "monreferent@gouv.fr")
   end
 
   let!(:applicants) { Applicant.where(id: [applicant1, applicant2, applicant3]) }
@@ -108,6 +112,7 @@ describe Exporters::GenerateApplicantsCsv, type: :service do
         expect(csv).to include("Dernier RDV pris en autonomie ?")
         expect(csv).to include("RDV honoré en - de 30 jours ?")
         expect(csv).to include("Date d'orientation")
+        expect(csv).to include("Référent(s)")
         expect(csv).to include("Nombre d'organisations")
         expect(csv).to include("Nom des organisations")
       end
@@ -167,6 +172,10 @@ describe Exporters::GenerateApplicantsCsv, type: :service do
         it "displays the organisation infos" do
           expect(csv).to include("1")
           expect(csv).to include("Drome RSA")
+        end
+
+        it "displays the referent emails" do
+          expect(csv).to include("monreferent@gouv.fr")
         end
 
         context "when the applicant is archived" do


### PR DESCRIPTION
J'ajoute les emails des agents référents dans l'export CSV.
J'en profite pour faire un renommage et parler de `referents` plutôt que d'`agents` lorsque l'on récupère les référents d'une personne.