### PR TITLE
fix(show): size of the link for the close rdv_context button

### DIFF
--- a/app/views/applicants/_close_rdv_context_button.html.erb
+++ b/app/views/applicants/_close_rdv_context_button.html.erb
@@ -1,17 +1,5 @@
-<% if rdv_context.status == "closed" %>
-  <%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:organisation_id], department_id: params[:department_id], applicant_id: applicant.id), method: :delete do %>
-    <div data-controller="tooltip" data-action="mouseover->tooltip#reopenRdvContextButton">
-      <button class="btn btn-blue">
-        Rouvrir "<%= rdv_context.motif_category.name %>"
-      </button>
-    </div>
-  <% end %>
-<% else %>
-  <%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:organisation_id], department_id: params[:department_id], applicant_id: applicant.id), method: :post do %>
-    <div data-controller="tooltip" data-action="mouseover->tooltip#closeRdvContextButton">
-      <button class="btn btn-blue">
-        Clôturer "<%= rdv_context.motif_category.name %>"
-      </button>
-    </div>
-  <% end %>
+<%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:organisation_id], department_id: params[:department_id], applicant_id: applicant.id), method: :post do %>
+  <button class="btn btn-blue" data-controller="tooltip" data-action="mouseover->tooltip#closeRdvContextButton">
+    Clôturer "<%= rdv_context.motif_category.name %>"
+  </button>
 <% end %>

--- a/app/views/applicants/_rdv_context.html.erb
+++ b/app/views/applicants/_rdv_context.html.erb
@@ -94,7 +94,11 @@
         </div>
       <% end %>
       <div class="m-2 p-2 text-center">
-        <%= render "close_rdv_context_button", rdv_context: rdv_context, applicant: @applicant, organisation: @organisation, department: @department %>
+        <% if rdv_context.status == "closed" %>
+          <%= render "reopen_rdv_context_button", rdv_context: rdv_context, applicant: @applicant, organisation: @organisation, department: @department %>
+        <% else %>
+          <%= render "close_rdv_context_button", rdv_context: rdv_context, applicant: @applicant, organisation: @organisation, department: @department %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/applicants/_reopen_rdv_context_button.html.erb
+++ b/app/views/applicants/_reopen_rdv_context_button.html.erb
@@ -1,0 +1,5 @@
+<%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: params[:organisation_id], department_id: params[:department_id], applicant_id: applicant.id), method: :delete do %>
+  <button class="btn btn-blue"  data-controller="tooltip" data-action="mouseover->tooltip#reopenRdvContextButton">
+    Rouvrir "<%= rdv_context.motif_category.name %>"
+  </button>
+<% end %>


### PR DESCRIPTION
closes #1113 
pas grand chose à ajouter à l'issue : cette PR fix la taille du lien pour le bouton de clôture/réouverture d'un contexte. J'en profite aussi pour séparer les deux boutons dans des partials différentes (afin que l'action corresponde au nom de la view)