### PR TITLE
feat(convocations): allow convocation in more cases

### DIFF
--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -132,7 +132,9 @@ module ApplicantsHelper
   end
 
   def should_convene_for?(rdv_context, configuration)
-    configuration.convene_applicant? &&
+    return unless configuration.convene_applicant?
+
+    rdv_context.status.in?(STATUSES_WITH_CONVOCATION_POSSIBLE) ||
       rdv_context.time_to_accept_invitation_exceeded?(configuration.number_of_days_before_action_required)
   end
 

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -134,7 +134,7 @@ module ApplicantsHelper
   def should_convene_for?(rdv_context, configuration)
     return unless configuration.convene_applicant?
 
-    rdv_context.status.in?(STATUSES_WITH_CONVOCATION_POSSIBLE) ||
+    rdv_context.status.in?(RdvContext::STATUSES_WITH_CONVOCATION_POSSIBLE) ||
       rdv_context.time_to_accept_invitation_exceeded?(configuration.number_of_days_before_action_required)
   end
 

--- a/app/helpers/applicants_helper.rb
+++ b/app/helpers/applicants_helper.rb
@@ -134,7 +134,7 @@ module ApplicantsHelper
   def should_convene_for?(rdv_context, configuration)
     return unless configuration.convene_applicant?
 
-    rdv_context.status.in?(RdvContext::STATUSES_WITH_CONVOCATION_POSSIBLE) ||
+    rdv_context.convocable_status? ||
       rdv_context.time_to_accept_invitation_exceeded?(configuration.number_of_days_before_action_required)
   end
 

--- a/app/models/rdv_context.rb
+++ b/app/models/rdv_context.rb
@@ -17,7 +17,7 @@ class RdvContext < ApplicationRecord
   STATUSES_WITH_ACTION_REQUIRED = %w[
     rdv_needs_status_update rdv_noshow rdv_revoked rdv_excused multiple_rdvs_cancelled
   ].freeze
-  STATUSES_WITH_CONVOCATION_POSSIBLE = %w[
+  CONVOCABLE_STATUSES = %w[
     rdv_noshow rdv_excused multiple_rdvs_cancelled
   ].freeze
 
@@ -37,6 +37,10 @@ class RdvContext < ApplicationRecord
 
   def action_required_status?
     status.in?(STATUSES_WITH_ACTION_REQUIRED)
+  end
+
+  def convocable_status?
+    status.in?(CONVOCABLE_STATUSES)
   end
 
   def time_to_accept_invitation_exceeded?(number_of_days_before_action_required)

--- a/app/models/rdv_context.rb
+++ b/app/models/rdv_context.rb
@@ -17,6 +17,9 @@ class RdvContext < ApplicationRecord
   STATUSES_WITH_ACTION_REQUIRED = %w[
     rdv_needs_status_update rdv_noshow rdv_revoked rdv_excused multiple_rdvs_cancelled
   ].freeze
+  STATUSES_WITH_CONVOCATION_POSSIBLE = %w[
+    rdv_noshow rdv_excused multiple_rdvs_cancelled
+  ].freeze
 
   scope :status, ->(status) { where(status: status) }
   scope :action_required, lambda { |number_of_days_before_action_required|

--- a/spec/features/agent_can_convene_applicant_spec.rb
+++ b/spec/features/agent_can_convene_applicant_spec.rb
@@ -83,7 +83,7 @@ describe "Agents can convene applicant to rdv", js: true do
       end
     end
 
-    context "when the time to accept invitation has not exceeded" do
+    context "when invitation is pending and the time to accept invitation has not exceeded" do
       let!(:invitation) { create(:invitation, rdv_context: rdv_context, sent_at: 3.days.ago) }
 
       it "does not show a convocation button" do
@@ -102,6 +102,45 @@ describe "Agents can convene applicant to rdv", js: true do
         rdv_context.save!
         visit organisation_applicants_path(organisation)
         expect(page).not_to have_content("📅 Convoquer")
+      end
+    end
+
+    context "when there is a noshow rdv" do
+      let!(:rdv_context) do
+        create(:rdv_context, status: "rdv_noshow", applicant: applicant, motif_category: motif_category)
+      end
+
+      it "shows a link to convene the applicant" do
+        visit organisation_applicants_path(organisation)
+        expect(page).to have_content("📅 Convoquer")
+        expect(page).not_to have_css("div[data-action='mouseover->tooltip#disabledConvocationButton']")
+        expect(page).to have_link("📅 Convoquer", href: expected_link)
+      end
+    end
+
+    context "when there is an excused rdv" do
+      let!(:rdv_context) do
+        create(:rdv_context, status: "rdv_excused", applicant: applicant, motif_category: motif_category)
+      end
+
+      it "shows a link to convene the applicant" do
+        visit organisation_applicants_path(organisation)
+        expect(page).to have_content("📅 Convoquer")
+        expect(page).not_to have_css("div[data-action='mouseover->tooltip#disabledConvocationButton']")
+        expect(page).to have_link("📅 Convoquer", href: expected_link)
+      end
+    end
+
+    context "when multiple rdvs were canceled" do
+      let!(:rdv_context) do
+        create(:rdv_context, status: "multiple_rdvs_cancelled", applicant: applicant, motif_category: motif_category)
+      end
+
+      it "shows a link to convene the applicant" do
+        visit organisation_applicants_path(organisation)
+        expect(page).to have_content("📅 Convoquer")
+        expect(page).not_to have_css("div[data-action='mouseover->tooltip#disabledConvocationButton']")
+        expect(page).to have_link("📅 Convoquer", href: expected_link)
       end
     end
 


### PR DESCRIPTION
closes #1061 
Dans cette PR, je permets de convoquer les bénéficiaires plus seulement lorsqu'ils ont une invitation en délai dépassé mais aussi lorsque leur statut est : 
- "RDV annulé à l'initiative de l'allocataire"
- "Absence non excusée au RDV"
- "Plusieurs RDV reportés par l'allocataire".
