### PR TITLE
refactor(app): rename AgentRole attribute level to access_level

### DIFF
--- a/app/models/agent_role.rb
+++ b/app/models/agent_role.rb
@@ -1,5 +1,5 @@
 class AgentRole < ApplicationRecord
-  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:level].freeze
+  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:access_level].freeze
 
   belongs_to :agent
   belongs_to :organisation
@@ -7,5 +7,5 @@ class AgentRole < ApplicationRecord
   validates :rdv_solidarites_agent_role_id, uniqueness: true, allow_nil: true
   validates :agent, uniqueness: { scope: :organisation, message: "est déjà relié à l'organisation" }
 
-  enum level: { basic: 0, admin: 1 }
+  enum access_level: { basic: 0, admin: 1 }
 end

--- a/app/services/organisations/create.rb
+++ b/app/services/organisations/create.rb
@@ -37,7 +37,7 @@ module Organisations
       # the rdv_solidarites_agent_role_id will be added to this agent_role record thanks to the webhook
       # this is safe because the transaction succeeds only if the agent is a territorial admin in the department
       @agent_role_for_new_organisation ||=
-        AgentRole.new(agent_id: @current_agent.id, organisation_id: @organisation.id, level: "admin")
+        AgentRole.new(agent_id: @current_agent.id, organisation_id: @organisation.id, access_level: "admin")
     end
 
     def upsert_rdv_solidarites_webhook_endpoint

--- a/db/migrate/20230613095607_rename_agent_role_level_to_access_level.rb
+++ b/db/migrate/20230613095607_rename_agent_role_level_to_access_level.rb
@@ -1,0 +1,5 @@
+class RenameAgentRoleLevelToAccessLevel < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :agent_roles, :level, :access_level
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_06_084749) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_095607) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "agent_roles", force: :cascade do |t|
-    t.integer "level", default: 0, null: false
+    t.integer "access_level", default: 0, null: false
     t.bigint "agent_id", null: false
     t.bigint "organisation_id", null: false
     t.bigint "rdv_solidarites_agent_role_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_webhook_update_received_at"
+    t.index ["access_level"], name: "index_agent_roles_on_access_level"
     t.index ["agent_id", "organisation_id"], name: "index_agent_roles_on_agent_id_and_organisation_id", unique: true
     t.index ["agent_id"], name: "index_agent_roles_on_agent_id"
-    t.index ["level"], name: "index_agent_roles_on_level"
     t.index ["organisation_id"], name: "index_agent_roles_on_organisation_id"
     t.index ["rdv_solidarites_agent_role_id"], name: "index_agent_roles_on_rdv_solidarites_agent_role_id", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,7 +4,7 @@
 
 # Pour utiliser rdv-insertion proprement en local, en plus de ces seeds, il est nécessaire de créer sur rdv-s :
 # - les territories et organisations correspondant aux départments et organisations créés ci-dessous
-# - rattacher l'agent aux organisations via un AgentRole (level: "admin")
+# - rattacher l'agent aux organisations via un AgentRole (access_level: "admin")
 # - configurer les webhooks de chaque organisation
 
 # Les seeds de rdv-solidarités permettent de créer ces différents éléments

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,7 +28,7 @@ En effet pour utiliser RDV-Insertion proprement en local, il est nécessaire de 
 
 - Les territories et organisations correspondant aux départments et organisations que l'on va utiliser sur RDV-Insertion (voir [Setup](#Setup))
 
-- Rattacher l'agent aux organisations via un `AgentRole` (de préférence avec le level `admin`)
+- Rattacher l'agent aux organisations via un `AgentRole` (de préférence avec le access_level `admin`)
 
 - Configurer les webhooks de chaque organisation pour les envoyer vers l'appli RDV-Insertion en local (`POST http://localhost:8000/rdv_solidarites_webhooks`)
 

--- a/spec/factories/agent_role.rb
+++ b/spec/factories/agent_role.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :agent_role do
     association :organisation
     association :agent
-    level { "basic" }
+    access_level { "basic" }
     sequence(:rdv_solidarites_agent_role_id)
   end
 end

--- a/spec/jobs/rdv_solidarites_webhooks/process_agent_role_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_agent_role_job_spec.rb
@@ -6,7 +6,7 @@ describe RdvSolidaritesWebhooks::ProcessAgentRoleJob do
   let!(:data) do
     {
       "id" => rdv_solidarites_agent_role_id,
-      "level" => "basic",
+      "access_level" => "basic",
       "agent" => { id: rdv_solidarites_agent_id },
       "organisation" => { id: rdv_solidarites_organisation_id }
     }.deep_symbolize_keys

--- a/spec/models/agent_role_spec.rb
+++ b/spec/models/agent_role_spec.rb
@@ -27,10 +27,10 @@ describe AgentRole do
     end
   end
 
-  describe "level inclusion validation" do
-    context "correct level value" do
-      let(:agent_role) { build(:agent_role, level: "basic") }
-      let(:agent_role2) { build(:agent_role, level: "admin") }
+  describe "access_level inclusion validation" do
+    context "correct access_level value" do
+      let(:agent_role) { build(:agent_role, access_level: "basic") }
+      let(:agent_role2) { build(:agent_role, access_level: "admin") }
 
       it { expect(agent_role).to be_valid }
       it { expect(agent_role2).to be_valid }


### PR DESCRIPTION
Fait suite à un changement coté rdvsp ici : https://github.com/betagouv/rdv-solidarites.fr/pull/3609
L'attribut `level` du model `AgentRole` est renommé en `access_level`.
Cela nous permet de gagner en lisibilité (coté rdvsp particuliérement).
Une fois cette PR merge j'enleverai l'attribut `level` du blueprint coté rdvsp.