### PR TITLE
fix(referents): Add primary key to refererent assignations

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -22,7 +22,6 @@ class Applicant < ApplicationRecord
   before_save :format_phone_number
 
   has_and_belongs_to_many :organisations
-  has_and_belongs_to_many :agents
 
   has_many :rdv_contexts, dependent: :destroy
   has_many :invitations, dependent: :destroy

--- a/db/migrate/20230613163040_add_id_to_referent_assignations.rb
+++ b/db/migrate/20230613163040_add_id_to_referent_assignations.rb
@@ -1,0 +1,5 @@
+class AddIdToReferentAssignations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :referent_assignations, :id, :primary_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_095607) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_163040) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -316,7 +316,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_095607) do
     t.index ["status"], name: "index_rdvs_on_status"
   end
 
-  create_table "referent_assignations", id: false, force: :cascade do |t|
+  create_table "referent_assignations", force: :cascade do |t|
     t.bigint "applicant_id", null: false
     t.bigint "agent_id", null: false
     t.index ["applicant_id", "agent_id"], name: "index_referent_assignations_on_applicant_id_and_agent_id", unique: true


### PR DESCRIPTION
On avait un problème lorsqu'un agent était assigné référent au moment de le supprimer à cause de la relation `has_many :referent_assignations, dependent: :destroy`. Comme la table `referent_assignations` n'avait pas de clé primaire on ne sait pas quelles entrées supprimer.
J'ajoute donc une clé primaire à la table `referent_assignations` dans cette PR.