### PR TITLE
feat(app): Choose motif category when adding to org

### DIFF
--- a/app/controllers/applicants_organisations_controller.rb
+++ b/app/controllers/applicants_organisations_controller.rb
@@ -1,7 +1,7 @@
 class ApplicantsOrganisationsController < ApplicationController
   before_action :set_applicant, :set_department, :set_organisations, :set_current_organisation,
                 only: [:index, :create, :destroy]
-  before_action :set_organisation_to_add, only: [:create]
+  before_action :assign_motif_category, :set_organisation_to_add, only: [:create]
   before_action :set_organisation_to_remove, only: [:destroy]
 
   def index; end
@@ -29,7 +29,7 @@ class ApplicantsOrganisationsController < ApplicationController
   private
 
   def applicants_organisation_params
-    params.require(:applicants_organisation).permit(:organisation_id, :applicant_id)
+    params.require(:applicants_organisation).permit(:organisation_id, :applicant_id, :motif_category_id)
   end
 
   def applicant_id
@@ -60,7 +60,7 @@ class ApplicantsOrganisationsController < ApplicationController
   end
 
   def set_organisations
-    @organisations = @department.organisations
+    @organisations = @department.organisations.includes(:motif_categories)
   end
 
   def set_applicant_organisations
@@ -80,6 +80,12 @@ class ApplicantsOrganisationsController < ApplicationController
 
   def applicant_deleted_or_removed_from_current_org?
     @applicant.deleted? || @organisation_to_remove == @current_organisation
+  end
+
+  def assign_motif_category
+    return if applicants_organisation_params[:motif_category_id].blank?
+
+    @applicant.assign_motif_category(applicants_organisation_params[:motif_category_id])
   end
 
   def save_applicant

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -109,6 +109,10 @@ class Applicant < ApplicationRecord
     )
   end
 
+  def assign_motif_category(motif_category_id)
+    assign_attributes(rdv_contexts_attributes: [{ motif_category_id: motif_category_id }])
+  end
+
   def as_json(_opts = {})
     super.merge(
       created_at: created_at,
@@ -123,7 +127,7 @@ class Applicant < ApplicationRecord
   private
 
   def rdv_context_category_handled_already?(rdv_context_attributes)
-    rdv_context_attributes["motif_category_id"].in?(motif_categories.map(&:id))
+    rdv_context_attributes.deep_symbolize_keys[:motif_category_id]&.to_i.in?(motif_categories.map(&:id))
   end
 
   def generate_uid

--- a/app/views/applicants_organisations/_applicants_organisation.html.erb
+++ b/app/views/applicants_organisations/_applicants_organisation.html.erb
@@ -20,7 +20,17 @@
             )
         %>
       <% else %>
-        <%= f.button :submit, "+ Ajouter", class: "btn btn-blue text-white" %>
+        <div class="d-flex justify-content-around">
+          <div class="mx-2">
+            <%= f.input :motif_category_id,
+                        collection: organisation.motif_categories.map { |mc| [mc.name, mc.id] },
+                        include_blank: "Aucune catégorie de suivi",
+                        input_html: { class: "form-control" }
+
+            %>
+          </div>
+          <%= f.button :submit, "+ Ajouter", class: "btn btn-blue text-white" %>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/spec/features/agent_can_add_or_remove_applicant_from_organisations_spec.rb
+++ b/spec/features/agent_can_add_or_remove_applicant_from_organisations_spec.rb
@@ -8,7 +8,8 @@ describe "Agents can add or remove applicant from organisations", js: true do
       # needed for the organisation applicants page
     )
   end
-  let!(:configuration) { create(:configuration, organisation: organisation) }
+  let!(:configuration) { create(:configuration, organisation: organisation, motif_category: motif_category) }
+  let!(:motif_category) { create(:motif_category, name: "Entretien SIAE") }
   let!(:rdv_solidarites_user_id) { 243 }
   let!(:applicant) do
     create(
@@ -18,6 +19,8 @@ describe "Agents can add or remove applicant from organisations", js: true do
     )
   end
   let!(:other_org) { create(:organisation, department: department) }
+  let!(:other_config) { create(:configuration, organisation: other_org, motif_category: other_motif_category) }
+  let!(:other_motif_category) { create(:motif_category, name: "RSA suivi") }
 
   before do
     setup_agent_session(agent)
@@ -55,6 +58,7 @@ describe "Agents can add or remove applicant from organisations", js: true do
       )
 
       visit department_applicant_path(department, applicant)
+
       expect(page).to have_content(organisation.name)
       expect(page).not_to have_content(other_org.name)
 
@@ -62,6 +66,11 @@ describe "Agents can add or remove applicant from organisations", js: true do
 
       expect(page).to have_content(organisation.name)
       expect(page).to have_content(other_org.name)
+      expect(page).to have_select(
+        "applicants_organisation[motif_category_id]", options: ["Aucune catégorie de suivi", "RSA suivi"]
+      )
+      select "Aucune catégorie de suivi", from: "applicants_organisation[motif_category_id]"
+
       click_button("+ Ajouter")
 
       expect(page).to have_content(organisation.name)
@@ -72,6 +81,69 @@ describe "Agents can add or remove applicant from organisations", js: true do
       expect(stub_create_user_profile).to have_been_requested
       expect(stub_update_user).to have_been_requested
       expect(applicant.reload.organisation_ids).to contain_exactly(organisation.id, other_org.id)
+      expect(applicant.reload.motif_categories).not_to include(other_motif_category)
+    end
+
+    context "when a motif category is specified" do
+      it "adds the applicant in that specific category" do
+        stub_other_org_user = stub_request(
+          :get,
+          "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/organisations/#{other_org.rdv_solidarites_organisation_id}/" \
+          "users/#{rdv_solidarites_user_id}"
+        ).with(
+          headers: { "Content-Type" => "application/json" }.merge(session_hash(agent.email))
+        ).to_return(status: 404)
+
+        stub_create_user_profile = stub_request(
+          :post, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/user_profiles"
+        ).with(
+          headers: { "Content-Type" => "application/json" }.merge(session_hash(agent.email)),
+          body: { user_id: rdv_solidarites_user_id, organisation_id: other_org.rdv_solidarites_organisation_id }.to_json
+        ).to_return(
+          status: 200,
+          body: {
+            user_profile: {
+              user_id: rdv_solidarites_user_id, organisation_id: other_org.rdv_solidarites_organisation_id
+            }
+          }.to_json
+        )
+
+        stub_update_user = stub_request(
+          :patch, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/users/#{rdv_solidarites_user_id}"
+        ).to_return(
+          status: 200,
+          body: {
+            user: { id: rdv_solidarites_user_id }
+          }.to_json
+        )
+
+        visit department_applicant_path(department, applicant)
+
+        expect(page).to have_content(organisation.name)
+        expect(page).not_to have_content(other_org.name)
+
+        click_link("Ajouter ou retirer une organisation")
+
+        expect(page).to have_content(organisation.name)
+        expect(page).to have_content(other_org.name)
+        expect(page).to have_select(
+          "applicants_organisation[motif_category_id]", options: ["Aucune catégorie de suivi", "RSA suivi"]
+        )
+
+        select "RSA suivi", from: "applicants_organisation[motif_category_id]"
+
+        click_button("+ Ajouter")
+
+        expect(page).to have_content(organisation.name)
+        expect(page).to have_content(other_org.name)
+        expect(page).to have_content(applicant.last_name)
+
+        expect(stub_other_org_user).to have_been_requested
+        expect(stub_create_user_profile).to have_been_requested
+        expect(stub_update_user).to have_been_requested
+        expect(applicant.reload.organisation_ids).to contain_exactly(organisation.id, other_org.id)
+        expect(applicant.reload.motif_categories).to include(other_motif_category)
+      end
     end
 
     it "can remove from org" do


### PR DESCRIPTION
## Contexte

Suite à #1097 , on ne place plus la personne dans une catégorie lorsqu'on l'ajoute à une organisation. 
Je change ça ici en permettant de spécifier une catégorie dans l'organisation de destination au moment de l'ajout.

## Preview 📷 

<img width="489" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/7602809/8c73265f-fa85-4d4a-964d-d06ef79e102c">

<img width="490" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/7602809/53431d85-2047-4ca4-9d3c-dcc5a2d2b7be">
