### PR TITLE
fix(nir): allow corsica nirs

### DIFF
--- a/app/lib/nir_helper.rb
+++ b/app/lib/nir_helper.rb
@@ -10,11 +10,11 @@ module NirHelper
     end
 
     def nir_key(nir)
-      key = 97 - (digits_nir(nir).first(13).to_i % 97)
+      key = 97 - (nir_without_corsica_letters(nir).first(13).to_i % 97)
       key.to_s.length == 2 ? key.to_s : "0#{key}"
     end
 
-    def digits_nir(nir)
+    def nir_without_corsica_letters(nir)
       # people born in Corsica have "2A" or "2B" in their nirs ; this method deals with this case
       return nir unless nir.match?(/\A\d+(2A|2B){1}\d+\z/)
 

--- a/app/lib/nir_helper.rb
+++ b/app/lib/nir_helper.rb
@@ -2,14 +2,23 @@ module NirHelper
   class << self
     def format_nir(nir)
       return if nir.blank?
+
+      nir = nir.strip.upcase
       return nir if nir.length != 13
 
       "#{nir}#{nir_key(nir)}"
     end
 
     def nir_key(nir)
-      key = 97 - (nir.first(13).to_i % 97)
+      key = 97 - (digits_nir(nir).first(13).to_i % 97)
       key.to_s.length == 2 ? key.to_s : "0#{key}"
+    end
+
+    def digits_nir(nir)
+      # people born in Corsica have "2A" or "2B" in their nirs ; this method deals with this case
+      return nir unless nir.match?(/\A\d+(2A|2B){1}\d+\z/)
+
+      nir.match?(/2A/) ? nir.gsub("2A", "19") : nir.gsub("2B", "18")
     end
   end
 end

--- a/app/models/concerns/applicant/nir.rb
+++ b/app/models/concerns/applicant/nir.rb
@@ -13,7 +13,8 @@ module Applicant::Nir
   end
 
   def nir_is_valid
-    if nir.length != 15 || nir !~ /\A\d+\Z/
+    # nir should be only digits, except for people born in Corsica who have "2A" or "2B" in their nirs
+    if nir.length != 15 || nir !~ /\A\d+(2A|2B){0,1}\d+\z/
       errors.add(:nir, :invalid, message: "Le NIR doit être une série de 13 ou 15 chiffres")
       return
     end

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -171,7 +171,7 @@ describe Applicant do
     end
 
     context "when nir is 13 characters with 2A or 2B in it" do
-      let!(:nir) { generate_random_corsica_nir }
+      let!(:nir) { "123456782A12307" }
       let(:applicant) { build(:applicant, nir: nir.first(13)) }
 
       it { expect(applicant).to be_valid }
@@ -183,7 +183,7 @@ describe Applicant do
     end
 
     context "when nir is a valid 15 characters string with 2A or 2B in it" do
-      let!(:nir) { generate_random_corsica_nir }
+      let!(:nir) { "123456782A12307" }
       let(:applicant) { build(:applicant, nir: nir) }
 
       it { expect(applicant).to be_valid }

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -170,6 +170,25 @@ describe Applicant do
       it { expect(applicant).to be_valid }
     end
 
+    context "when nir is 13 characters with 2A or 2B in it" do
+      let!(:nir) { generate_random_corsica_nir }
+      let(:applicant) { build(:applicant, nir: nir.first(13)) }
+
+      it { expect(applicant).to be_valid }
+
+      it "adds a 2 digits key to the nir saved in db" do
+        applicant.save
+        expect(applicant.reload.nir).to eq(nir)
+      end
+    end
+
+    context "when nir is a valid 15 characters string with 2A or 2B in it" do
+      let!(:nir) { generate_random_corsica_nir }
+      let(:applicant) { build(:applicant, nir: nir) }
+
+      it { expect(applicant).to be_valid }
+    end
+
     context "when nir exists already" do
       let!(:existing_applicant) { create(:applicant, nir: "123456789012311") }
       let(:applicant) { build(:applicant, nir: "123456789012311") }
@@ -189,7 +208,7 @@ describe Applicant do
     end
 
     context "when nir is not all digits" do
-      let(:applicant) { build(:applicant, nir: "123456789012A11") }
+      let(:applicant) { build(:applicant, nir: "123456C78901211") }
 
       it "add errors" do
         expect(applicant).not_to be_valid

--- a/spec/support/nir_helper.rb
+++ b/spec/support/nir_helper.rb
@@ -4,4 +4,10 @@ module NirHelper
     base_nir = "180#{10.times.map { rand(1..9) }.join}"
     NirHelper.format_nir(base_nir)
   end
+
+  def generate_random_corsica_nir
+    # choosing random male born in 80
+    base_nir = "180#{5.times.map { rand(1..9) }.join}2A#{3.times.map { rand(1..9) }.join}"
+    NirHelper.format_nir(base_nir)
+  end
 end

--- a/spec/support/nir_helper.rb
+++ b/spec/support/nir_helper.rb
@@ -4,10 +4,4 @@ module NirHelper
     base_nir = "180#{10.times.map { rand(1..9) }.join}"
     NirHelper.format_nir(base_nir)
   end
-
-  def generate_random_corsica_nir
-    # choosing random male born in 80
-    base_nir = "180#{5.times.map { rand(1..9) }.join}2A#{3.times.map { rand(1..9) }.join}"
-    NirHelper.format_nir(base_nir)
-  end
 end


### PR DESCRIPTION
closes #1124 

Les personnes nées en Corse peuvent avoir un 2A ou un 2B dans leur NIR. Dans ce cas, pour le calcul de la clé de contrôle, le numéro du département 2A (Corse-du-Sud) est remplacé par 19 et celui du 2B (Haute-Corse) par 18 MAIS le nir sauvegardé doit garder 2A ou 2B dedans. Cette PR gère cette particularité.