### PR TITLE
feat(category): add new contexts for siae

### DIFF
--- a/app/models/concerns/motif_category/sortable.rb
+++ b/app/models/concerns/motif_category/sortable.rb
@@ -2,6 +2,7 @@ module MotifCategory::Sortable
   CHRONOLOGICALLY_SORTED_CATEGORIES_SHORT_NAMES = %w[
     rsa_integration_information
     rsa_orientation
+    rsa_orientation_file_active
     rsa_orientation_france_travail
     rsa_orientation_coaching
     rsa_orientation_freelance
@@ -17,6 +18,9 @@ module MotifCategory::Sortable
     rsa_atelier_collectif_mandatory
     rsa_main_tendue
     rsa_spie
+    siae_interview
+    siae_collective_information
+    siae_follow_up
   ].freeze
 
   def position

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -42,8 +42,7 @@ module Invitations
         punishable_warning: @invitation.punishable_warning,
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
-        custom_sentence: @invitation.custom_sentence,
-        motif_category_name: @invitation.motif_category_name
+        custom_sentence: @invitation.custom_sentence
       }
     end
 

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -42,7 +42,8 @@ module Invitations
         punishable_warning: @invitation.punishable_warning,
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
-        custom_sentence: @invitation.custom_sentence
+        custom_sentence: @invitation.custom_sentence,
+        motif_category_name: @invitation.motif_category_name
       }
     end
 

--- a/app/views/letters/invitations/atelier.html.erb
+++ b/app/views/letters/invitations/atelier.html.erb
@@ -1,9 +1,7 @@
 <%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, applicant: applicant %>
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Participation à un atelier dans le cadre de votre <%= rdv_subject %></span></p>
-  <% if applicant.affiliation_number %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
   <% if invitation.rdv_with_referents? %>
     <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>

--- a/app/views/letters/invitations/phone_platform.html.erb
+++ b/app/views/letters/invitations/phone_platform.html.erb
@@ -2,9 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Rendez-vous d’orientation dans le cadre de votre <%= rdv_subject %></span></p>
-  <% if applicant.affiliation_number %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
   <% if invitation.rdv_with_referents? %>
     <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>

--- a/app/views/letters/invitations/short.html.erb
+++ b/app/views/letters/invitations/short.html.erb
@@ -2,9 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : <%= rdv_title.slice(0,1).capitalize + rdv_title.slice(1..-1) %></span></p>
-  <% if applicant.affiliation_number %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
   <% if invitation.rdv_with_referents? %>
     <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -2,9 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : <%= rdv_title.slice(0,1).capitalize + rdv_title.slice(1..-1) %> dans le cadre de votre <%= rdv_subject %></span></p>
-  <% if applicant.affiliation_number && motif_category_name.start_with?("RSA") %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
   <% if invitation.rdv_with_referents? %>
     <p><%= "Référent".pluralize(applicant.referents.count) %> de parcours : <%= applicant.referents.order(:last_name).map(&:to_s).join(", ") %></p>
   <% end %>

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : <%= rdv_title.slice(0,1).capitalize + rdv_title.slice(1..-1) %> dans le cadre de votre <%= rdv_subject %></span></p>
-  <% if applicant.affiliation_number %>
+  <% if applicant.affiliation_number && motif_category_name.start_with?("RSA") %>
     <p>N° allocataire : <%= applicant.affiliation_number %></p>
   <% end %>
   <% if invitation.rdv_with_referents? %>

--- a/app/views/letters/notifications/by_phone_participation_created.html.erb
+++ b/app/views/letters/notifications/by_phone_participation_created.html.erb
@@ -2,9 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue">Objet : Convocation à un <%= rdv_title %> dans le cadre de votre <%= rdv_subject %></p>
-  <% if applicant.affiliation_number %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
 </div>
 
 <div class="main-content">

--- a/app/views/letters/notifications/participation_cancelled.html.erb
+++ b/app/views/letters/notifications/participation_cancelled.html.erb
@@ -2,9 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Votre <%= rdv_title %> dans le cadre de votre <%= rdv_subject %> a été annulé</span></p>
-  <% if applicant.affiliation_number %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
 </div>
 
 <div class="main-content">

--- a/app/views/letters/notifications/presential_participation_created.html.erb
+++ b/app/views/letters/notifications/presential_participation_created.html.erb
@@ -2,9 +2,7 @@
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Convocation à un <%= rdv_title %> dans le cadre de votre <%= rdv_subject %></span></p>
-  <% if applicant.affiliation_number %>
-    <p>N° allocataire : <%= applicant.affiliation_number %></p>
-  <% end %>
+  <%= tag.p("N° allocataire : #{applicant.affiliation_number}") if applicant.affiliation_number %>
 </div>
 
 <div class="main-content">

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -24,3 +24,7 @@ fr:
           rsa_orientation_freelance: RSA orientation - travailleurs indépendants
           rsa_orientation_coaching: RSA orientation - coaching emploi
           atelier_enfants_ados: Atelier Enfants / Ados
+          rsa_orientation_file_active: RSA orientation file active
+          siae_interview: Entretien SIAE
+          siae_collective_information: Info coll. SIAE
+          siae_follow_up: Suivi SIAE

--- a/db/migrate/20230328075606_add_siae_motif_category.rb
+++ b/db/migrate/20230328075606_add_siae_motif_category.rb
@@ -21,6 +21,6 @@ class AddSiaeMotifCategory < ActiveRecord::Migration[7.0]
 
   def down
     MotifCategory.find_by(short_name: "siae_interview").destroy!
-    Template.find_by(rdv_subject: "candidature SIAE", model: "standard").destroy!
+    Template.find_by(rdv_subject: "candidature SIAE", rdv_title: "entretien d'embauche", model: "standard").destroy!
   end
 end

--- a/db/migrate/20230625132307_add_motif_categories_and_templates_for_siae.rb
+++ b/db/migrate/20230625132307_add_motif_categories_and_templates_for_siae.rb
@@ -1,0 +1,46 @@
+class AddMotifCategoriesAndTemplatesForSiae < ActiveRecord::Migration[7.0]
+  def up
+    siae_follow_up_template = Template.create!(
+      model: "standard",
+      rdv_title: "rendez-vous de suivi",
+      rdv_title_by_phone: "rendez-vous de suivi téléphonique",
+      rdv_purpose: "faire un point avec votre référent",
+      applicant_designation: "salarié.e au sein de notre structure",
+      rdv_subject: "suivi SIAE",
+      display_mandatory_warning: false,
+      punishable_warning: ""
+    )
+
+    siae_collective_information_template = Template.create!(
+      model: "standard",
+      rdv_title: "rendez-vous collectif d'information",
+      rdv_title_by_phone: "rendez-vous collectif d'information téléphonique",
+      rdv_purpose: "découvrir cette structure",
+      applicant_designation: "candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)",
+      rdv_subject: "candidature SIAE",
+      display_mandatory_warning: false,
+      punishable_warning: ""
+    )
+
+    MotifCategory.create!(
+      name: "Suivi SIAE",
+      short_name: "siae_follow_up",
+      template: siae_follow_up_template,
+      participation_optional: false
+    )
+
+    MotifCategory.create!(
+      name: "Info coll. SIAE",
+      short_name: "siae_collective_information",
+      template: siae_collective_information_template,
+      participation_optional: false
+    )
+  end
+
+  def down
+    MotifCategory.find_by(short_name: "siae_follow_up").destroy!
+    MotifCategory.find_by(short_name: "siae_collective_information").destroy!
+    Template.find_by(rdv_subject: "Rendez-vous de suivi SIAE", model: "standard").destroy!
+    Template.find_by(rdv_subject: "Information collective SIAE", model: "standard").destroy!
+  end
+end

--- a/db/migrate/20230625132307_add_motif_categories_and_templates_for_siae.rb
+++ b/db/migrate/20230625132307_add_motif_categories_and_templates_for_siae.rb
@@ -40,7 +40,9 @@ class AddMotifCategoriesAndTemplatesForSiae < ActiveRecord::Migration[7.0]
   def down
     MotifCategory.find_by(short_name: "siae_follow_up").destroy!
     MotifCategory.find_by(short_name: "siae_collective_information").destroy!
-    Template.find_by(rdv_subject: "Rendez-vous de suivi SIAE", model: "standard").destroy!
-    Template.find_by(rdv_subject: "Information collective SIAE", model: "standard").destroy!
+    Template.find_by(rdv_subject: "suivi SIAE", model: "standard").destroy!
+    Template.find_by(
+      rdv_subject: "candidature SIAE", rdv_title: "rendez-vous collectif d'information", model: "standard"
+    ).destroy!
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_163040) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_25_132307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -363,8 +363,8 @@ RSpec.describe InvitationMailer do
         expect(body_string).to match("01 39 39 39 39")
         expect(body_string).to include(
           "Vous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
-          " et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous collectif d'information " \
-          "afin de découvrir cette structure"
+          " et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à " \
+          "un rendez-vous collectif d'information afin de découvrir cette structure"
         )
         expect(body_string).not_to match("Ce RDV est obligatoire.")
         expect(body_string).not_to match(

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -342,6 +342,74 @@ RSpec.describe InvitationMailer do
       end
     end
 
+    context "for siae_collective_information" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: category_siae_collective_information) }
+
+      it "renders the headers" do
+        expect(subject.to).to eq([applicant.email])
+      end
+
+      it "renders the subject" do
+        email_subject = unescape_html(subject.subject)
+        expect(email_subject).to eq(
+          "[CANDIDATURE SIAE]: Votre rendez-vous collectif d'information dans le cadre de votre candidature SIAE"
+        )
+      end
+
+      it "renders the body" do
+        body_string = unescape_html(subject.body.encoded)
+        expect(body_string).to match("Bonjour Jean VALJEAN")
+        expect(body_string).to match("Le département de la Drôme.")
+        expect(body_string).to match("01 39 39 39 39")
+        expect(body_string).to include(
+          "Vous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
+          " et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous collectif d'information " \
+          "afin de découvrir cette structure"
+        )
+        expect(body_string).not_to match("Ce RDV est obligatoire.")
+        expect(body_string).not_to match(
+          "votre RSA pourra être suspendu ou réduit."
+        )
+        expect(body_string).to match("/invitations/redirect")
+        expect(body_string).to match("uuid=#{invitation.uuid}")
+        expect(body_string).to match("dans un délai de 3 jours")
+      end
+    end
+
+    context "for siae_follow_up" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: category_siae_follow_up) }
+
+      it "renders the headers" do
+        expect(subject.to).to eq([applicant.email])
+      end
+
+      it "renders the subject" do
+        email_subject = unescape_html(subject.subject)
+        expect(email_subject).to eq(
+          "[SUIVI SIAE]: Votre rendez-vous de suivi dans le cadre de votre suivi SIAE"
+        )
+      end
+
+      it "renders the body" do
+        body_string = unescape_html(subject.body.encoded)
+        expect(body_string).to match("Bonjour Jean VALJEAN")
+        expect(body_string).to match("Le département de la Drôme.")
+        expect(body_string).to match("01 39 39 39 39")
+        expect(body_string).to include(
+          "Vous êtes salarié.e au sein de notre structure" \
+          " et à ce titre vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous de suivi " \
+          "afin de faire un point avec votre référent"
+        )
+        expect(body_string).not_to match("Ce RDV est obligatoire.")
+        expect(body_string).not_to match(
+          "votre RSA pourra être suspendu ou réduit."
+        )
+        expect(body_string).to match("/invitations/redirect")
+        expect(body_string).to match("uuid=#{invitation.uuid}")
+        expect(body_string).to match("dans un délai de 3 jours")
+      end
+    end
+
     context "for rsa_orientation_france_travail" do
       let!(:rdv_context) do
         build(:rdv_context, motif_category: category_rsa_orientation_france_travail)

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -236,6 +236,72 @@ describe Invitations::GenerateLetter, type: :service do
       end
     end
 
+    context "when the context is siae_interview" do
+      let!(:rdv_context) { create(:rdv_context, motif_category: category_siae_interview) }
+
+      it "generates the pdf with the right content" do
+        subject
+        content = unescape_html(invitation.content)
+        expect(content).to include(
+          "Objet : Entretien d'embauche dans le cadre de votre candidature SIAE"
+        )
+        expect(content).to include(
+          "vous êtes #{applicant.conjugate('invité')} à participer à un entretien d'embauche afin de " \
+          "poursuivre le processus de recrutement"
+        )
+        expect(content).to include("saisissez dans un délai de 3 jours à réception de ce courrier")
+        expect(content).not_to include("N° allocataire.")
+        expect(content).not_to include("Ce RDV est obligatoire.")
+        expect(content).not_to include(
+          "En l'absence d'action de votre part, votre RSA pourra être suspendu ou réduit."
+        )
+      end
+    end
+
+    context "when the context is siae_follow_up" do
+      let!(:rdv_context) { create(:rdv_context, motif_category: category_siae_follow_up) }
+
+      it "generates the pdf with the right content" do
+        subject
+        content = unescape_html(invitation.content)
+        expect(content).to include(
+          "Objet : Rendez-vous de suivi dans le cadre de votre suivi SIAE"
+        )
+        expect(content).to include(
+          "vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous de suivi afin de faire un point" \
+          " avec votre référent"
+        )
+        expect(content).to include("saisissez dans un délai de 3 jours à réception de ce courrier")
+        expect(content).not_to include("N° allocataire.")
+        expect(content).not_to include("Ce RDV est obligatoire.")
+        expect(content).not_to include(
+          "En l'absence d'action de votre part, votre RSA pourra être suspendu ou réduit."
+        )
+      end
+    end
+
+    context "when the context is siae_collective_information" do
+      let!(:rdv_context) { create(:rdv_context, motif_category: category_siae_collective_information) }
+
+      it "generates the pdf with the right content" do
+        subject
+        content = unescape_html(invitation.content)
+        expect(content).to include(
+          "Objet : Rendez-vous collectif d'information dans le cadre de votre candidature SIAE"
+        )
+        expect(content).to include(
+          "vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous collectif d'information afin de " \
+          "découvrir cette structure"
+        )
+        expect(content).to include("saisissez dans un délai de 3 jours à réception de ce courrier")
+        expect(content).not_to include("N° allocataire.")
+        expect(content).not_to include("Ce RDV est obligatoire.")
+        expect(content).not_to include(
+          "En l'absence d'action de votre part, votre RSA pourra être suspendu ou réduit."
+        )
+      end
+    end
+
     context "when the context is rsa_insertion_offer" do
       let!(:rdv_context) { create(:rdv_context, motif_category: category_rsa_insertion_offer) }
 

--- a/spec/services/invitations/send_email_spec.rb
+++ b/spec/services/invitations/send_email_spec.rb
@@ -284,5 +284,62 @@ describe Invitations::SendEmail, type: :service do
         subject
       end
     end
+
+    context "for siae_interview" do
+      let!(:invitation) do
+        create(
+          :invitation,
+          applicant: applicant, format: "email",
+          rdv_context: build(:rdv_context, motif_category: category_siae_interview)
+        )
+      end
+
+      before { allow(mailer).to receive_message_chain(:standard_invitation, :deliver_now) }
+
+      it("is a success") { is_a_success }
+
+      it "sends the email" do
+        expect(mailer).to receive_message_chain(:standard_invitation, :deliver_now)
+        subject
+      end
+    end
+
+    context "for siae_follow_up" do
+      let!(:invitation) do
+        create(
+          :invitation,
+          applicant: applicant, format: "email",
+          rdv_context: build(:rdv_context, motif_category: category_siae_follow_up)
+        )
+      end
+
+      before { allow(mailer).to receive_message_chain(:standard_invitation, :deliver_now) }
+
+      it("is a success") { is_a_success }
+
+      it "sends the email" do
+        expect(mailer).to receive_message_chain(:standard_invitation, :deliver_now)
+        subject
+      end
+    end
+
+    context "for siae_collective_information" do
+      let!(:invitation) do
+        create(
+          :invitation,
+          applicant: applicant, format: "email",
+          rdv_context: build(:rdv_context, motif_category: category_siae_collective_information)
+        )
+      end
+
+      before { allow(mailer).to receive_message_chain(:standard_invitation, :deliver_now) }
+
+      it("is a success") { is_a_success }
+
+      it "sends the email" do
+        expect(mailer).to receive_message_chain(:standard_invitation, :deliver_now)
+        subject
+      end
+    end
   end
 end

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -474,6 +474,106 @@ describe Invitations::SendSms, type: :service do
       end
     end
 
+    context "for siae_collective_information" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: category_siae_collective_information) }
+      let!(:configuration) do
+        create(:configuration, organisation: organisation, motif_category: category_siae_collective_information)
+      end
+      let!(:content) do
+        "Monsieur John DOE,\nVous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
+          " et vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous collectif d'information." \
+          " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
+          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "En cas de problème technique, contactez le 0147200001."
+      end
+
+      it("is a success") { is_a_success }
+
+      it "calls the send transactional service with the right content" do
+        expect(SendTransactionalSms).to receive(:call)
+          .with(
+            phone_number: phone_number, content: content,
+            sender_name: sms_sender_name
+          )
+        subject
+      end
+
+      context "when it is a reminder" do
+        let!(:content) do
+          "Monsieur John DOE,\nEn tant que candidat.e dans une Structure d’Insertion par l’Activité Economique " \
+            "(SIAE), vous avez reçu un message il y a 3 jours vous " \
+            "invitant à prendre RDV au créneau de votre choix afin de découvrir cette structure. " \
+            "Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "En cas de problème technique, contactez le " \
+            "0147200001."
+        end
+
+        before do
+          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        end
+
+        it "calls the send transactional service with the right content" do
+          expect(SendTransactionalSms).to receive(:call)
+            .with(
+              phone_number: phone_number, content: content,
+              sender_name: sms_sender_name
+            )
+          subject
+        end
+      end
+    end
+
+    context "for siae_follow_up" do
+      let!(:rdv_context) { build(:rdv_context, motif_category: category_siae_follow_up) }
+      let!(:configuration) do
+        create(:configuration, organisation: organisation, motif_category: category_siae_follow_up)
+      end
+      let!(:content) do
+        "Monsieur John DOE,\nVous êtes salarié.e au sein de notre structure" \
+          " et vous êtes #{applicant.conjugate('invité')} à participer à un rendez-vous de suivi." \
+          " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
+          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "En cas de problème technique, contactez le 0147200001."
+      end
+
+      it("is a success") { is_a_success }
+
+      it "calls the send transactional service with the right content" do
+        expect(SendTransactionalSms).to receive(:call)
+          .with(
+            phone_number: phone_number, content: content,
+            sender_name: sms_sender_name
+          )
+        subject
+      end
+
+      context "when it is a reminder" do
+        let!(:content) do
+          "Monsieur John DOE,\nEn tant que salarié.e au sein de notre structure, " \
+            "vous avez reçu un message il y a 3 jours vous " \
+            "invitant à prendre RDV au créneau de votre choix afin de faire un point avec votre référent. " \
+            "Le lien de prise de RDV suivant expire dans 5 jours: " \
+            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "En cas de problème technique, contactez le " \
+            "0147200001."
+        end
+
+        before do
+          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        end
+
+        it "calls the send transactional service with the right content" do
+          expect(SendTransactionalSms).to receive(:call)
+            .with(
+              phone_number: phone_number, content: content,
+              sender_name: sms_sender_name
+            )
+          subject
+        end
+      end
+    end
+
     context "for psychologue" do
       let!(:rdv_context) { build(:rdv_context, motif_category: category_psychologue) }
       let!(:configuration) { create(:configuration, organisation: organisation, motif_category: category_psychologue) }

--- a/spec/support/motif_categories_helper.rb
+++ b/spec/support/motif_categories_helper.rb
@@ -333,6 +333,42 @@ module MotifCategoriesHelper
         )
       )
     end
+    let!(:category_siae_collective_information) do
+      create(
+        :motif_category,
+        name: "Info coll. SIAE",
+        short_name: "siae_collective_information",
+        participation_optional: false,
+        template: create(
+          :template,
+          model: "standard",
+          rdv_title: "rendez-vous collectif d'information",
+          rdv_title_by_phone: "rendez-vous collectif d'information téléphonique",
+          applicant_designation: "candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)",
+          rdv_subject: "candidature SIAE",
+          rdv_purpose: "découvrir cette structure",
+          display_mandatory_warning: false
+        )
+      )
+    end
+    let!(:category_siae_follow_up) do
+      create(
+        :motif_category,
+        name: "Suivi SIAE",
+        short_name: "siae_follow_up",
+        participation_optional: false,
+        template: create(
+          :template,
+          model: "standard",
+          rdv_title: "rendez-vous de suivi",
+          rdv_title_by_phone: "rendez-vous de suivi téléphonique",
+          applicant_designation: "salarié.e au sein de notre structure",
+          rdv_subject: "suivi SIAE",
+          rdv_purpose: "faire un point avec votre référent",
+          display_mandatory_warning: false
+        )
+      )
+    end
   end
 end
 # rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
closes #993
closes #1111 
Dans cette PR, j'ajoute des `MotifCategory` et des `Template` pour les SIAE : `rendez-vous de suivi` et `rendez-vous d'information collective`. J'en profite pour rajouter des tests manquants sur le contexte `spie_interview` ainsi que dans la méthode `Sortable`.

@amaurydubot & @SalmaBennani par rapport à ce que vous aviez mis dans vos issues, les infos relatives au fichier d'entrée ou aux paramètres tels que les délai d'expiration, par exemple, seront à configurer vous même lorsque vous créerez des configurations pour les structures. Vous pourrez le faire dès que cette PR sera mergée.