### PR TITLE
feat(cdb): add CTA and columns for carnet de bord

### DIFF
--- a/app/javascript/react/components/Applicant.jsx
+++ b/app/javascript/react/components/Applicant.jsx
@@ -5,7 +5,12 @@ import InvitationCells from "./applicant/InvitationCells";
 import ContactInfosExtraLine from "./applicant/ContactInfosExtraLine";
 import ReferentAssignationCell from "./applicant/ReferentAssignationCell";
 
-export default function Applicant({ applicant, isDepartmentLevel, showReferentColumn }) {
+export default function Applicant({
+  applicant,
+  isDepartmentLevel,
+  showCarnetColumn,
+  showReferentColumn,
+}) {
   const [isTriggered, setIsTriggered] = useState({
     creation: false,
     unarchive: false,
@@ -71,6 +76,10 @@ export default function Applicant({ applicant, isDepartmentLevel, showReferentCo
           isTriggered={isTriggered}
           setIsTriggered={setIsTriggered}
         />
+
+        {/* ------------------------------- Carnet creation cell ----------------------------- */}
+
+        {showCarnetColumn && <td />}
 
         {/* ------------------------------- Referent cell ----------------------------- */}
 

--- a/app/javascript/react/components/ApplicantList.jsx
+++ b/app/javascript/react/components/ApplicantList.jsx
@@ -7,6 +7,7 @@ export default function ApplicantList({
   downloadInProgress,
   setDownloadInProgress,
   showReferentColumn,
+  showCarnetColumn,
 }) {
   return applicants.map((applicant) => (
     <Applicant
@@ -16,6 +17,7 @@ export default function ApplicantList({
       setDownloadInProgress={setDownloadInProgress}
       key={applicant.departmentInternalId || applicant.uid}
       showReferentColumn={showReferentColumn}
+      showCarnetColumn={showCarnetColumn}
     />
   ));
 }

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -43,6 +43,7 @@ export default function ApplicantsUpload({
   const [showReferentColumn, setShowReferentColumn] = useState(
     configuration && configuration.rdv_with_referents
   );
+  const showCarnetColumn = !!department.carnet_de_bord_deploiement_id;
 
   const redirectToApplicantList = () => {
     if (configuration) {
@@ -306,9 +307,9 @@ export default function ApplicantsUpload({
                   <th scope="col" style={{ whiteSpace: "nowrap" }}>
                     Création compte
                   </th>
-                  {department.carnet_de_bord_deploiement_id && (
+                  {showCarnetColumn && (
                     <th scope="col" style={{ whiteSpace: "nowrap" }}>
-                      Créer carnet
+                      Création carnet
                     </th>
                   )}
                   {showReferentColumn && <th scope="col-3">Réferent</th>}
@@ -328,7 +329,7 @@ export default function ApplicantsUpload({
                   showReferentColumn={showReferentColumn}
                   applicants={applicants}
                   isDepartmentLevel={isDepartmentLevel}
-                  showCarnetColumn={department.carnet_de_bord_deploiement_id}
+                  showCarnetColumn={showCarnetColumn}
                 />
               </tbody>
             </table>

--- a/app/javascript/react/pages/ApplicantsUpload.jsx
+++ b/app/javascript/react/pages/ApplicantsUpload.jsx
@@ -306,25 +306,20 @@ export default function ApplicantsUpload({
                   <th scope="col" style={{ whiteSpace: "nowrap" }}>
                     Création compte
                   </th>
-                  {showReferentColumn && (
-                    <>
-                      <th scope="col-3">Réferent</th>
-                    </>
+                  {department.carnet_de_bord_deploiement_id && (
+                    <th scope="col" style={{ whiteSpace: "nowrap" }}>
+                      Créer carnet
+                    </th>
                   )}
+                  {showReferentColumn && <th scope="col-3">Réferent</th>}
                   {configuration && configuration.invitation_formats.includes("sms") && (
-                    <>
-                      <th scope="col-3">Invitation SMS</th>
-                    </>
+                    <th scope="col-3">Invitation SMS</th>
                   )}
                   {configuration && configuration.invitation_formats.includes("email") && (
-                    <>
-                      <th scope="col-3">Invitation mail</th>
-                    </>
+                    <th scope="col-3">Invitation mail</th>
                   )}
                   {configuration && configuration.invitation_formats.includes("postal") && (
-                    <>
-                      <th scope="col-3">Invitation courrier</th>
-                    </>
+                    <th scope="col-3">Invitation courrier</th>
                   )}
                 </tr>
               </thead>
@@ -333,6 +328,7 @@ export default function ApplicantsUpload({
                   showReferentColumn={showReferentColumn}
                   applicants={applicants}
                   isDepartmentLevel={isDepartmentLevel}
+                  showCarnetColumn={department.carnet_de_bord_deploiement_id}
                 />
               </tbody>
             </table>

--- a/db/migrate/20230626131432_add_cdb_ids_to_departments_and_applicants.rb
+++ b/db/migrate/20230626131432_add_cdb_ids_to_departments_and_applicants.rb
@@ -1,0 +1,6 @@
+class AddCdbIdsToDepartmentsAndApplicants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :departments, :carnet_de_bord_deploiement_id, :bigint
+    add_column :applicants, :carnet_de_bord_carnet_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_25_190907) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_131432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_25_190907) do
     t.datetime "last_webhook_update_received_at"
     t.string "nir"
     t.string "pole_emploi_id"
+    t.bigint "carnet_de_bord_carnet_id"
     t.index ["department_internal_id"], name: "index_applicants_on_department_internal_id"
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["nir"], name: "index_applicants_on_nir"
@@ -115,6 +116,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_25_190907) do
     t.string "email"
     t.string "phone_number"
     t.boolean "display_in_stats", default: true
+    t.bigint "carnet_de_bord_deploiement_id"
   end
 
   create_table "file_configurations", force: :cascade do |t|


### PR DESCRIPTION
closes #1107 
closes #1104 
Dans cette PR, j'ajoute des colonnes pour stocker les ids des déploiements cdb et des carnets, et j'ajoute un emplacement pour le CTA de la création de carnet sur la page upload.