### PR TITLE
fix(cdb): Change cdb response attribute

### DIFF
--- a/app/services/carnet_de_bord/create_carnet.rb
+++ b/app/services/carnet_de_bord/create_carnet.rb
@@ -40,7 +40,7 @@ class CarnetDeBord::CreateCarnet < BaseService
   def create_carnet!
     return if create_carnet.success?
 
-    fail!("Erreur en créant le carnet: #{parsed_response_body['error']} - #{create_carnet.status}")
+    fail!("Erreur en créant le carnet: #{parsed_response_body['message']} - #{create_carnet.status}")
   end
 
   def create_carnet

--- a/spec/services/carnet_de_bord/create_carnet_spec.rb
+++ b/spec/services/carnet_de_bord/create_carnet_spec.rb
@@ -59,7 +59,7 @@ describe CarnetDeBord::CreateCarnet, type: :service do
       before do
         allow(CarnetDeBordClient).to receive(:create_carnet)
           .with(expected_payload)
-          .and_return(OpenStruct.new(success?: false, status: 401, body: { error: "Not authorized" }.to_json))
+          .and_return(OpenStruct.new(success?: false, status: 401, body: { message: "Not authorized" }.to_json))
       end
 
       it "is a failure" do


### PR DESCRIPTION
L'attribut renvoyé en cas d'erreur est `message` et non pas `error` comme marqué dans le notion