### PR TITLE
fix: Change layout title from Rdv insertion to rdv-insertion

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Rdv Insertion</title>
+    <title>rdv-insertion</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
     <meta name="turbo-cache-control" content="no-cache">


### PR DESCRIPTION
Juste un changement de title 
<img width="160" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/0aa36a53-2155-4e6a-a402-6d15cced3b22">
