### PR TITLE
fix(css): avoid overflow of logos on PDFs

### DIFF
--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -91,7 +91,7 @@ u {
     display: inline-block;
 
     img {
-      max-width: 350px;
+      max-width: 300px;
     }
 
     &:last-child {

--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -89,6 +89,11 @@ u {
 
   div {
     display: inline-block;
+
+    img {
+      max-width: 350px;
+    }
+
     &:last-child {
       margin-right: 0px !important;
     }


### PR DESCRIPTION
Le logo débordait car en l'absence d'autre logo il prenait par défaut sa largeur originale soit `406 × 99`. Je l'ai limité à 350px de largeur ce qui permet d'éviter le débordement. Voici le résultat une fois fixé avec les 4 différentes possibilités. 

Si cette grande taille de logo n'était pas voulu on pourrait mettre plus petit car lorsque il est seul, le logo de RI est quand même assez grand. 300px semblait déjà suffisant.
Maintenant que sa taille maximale sera limitée on pourrait également mettre des logo @2x pour améliorer la qualité des images.

<img width="634" alt="Screenshot 2023-07-17 at 19 29 18" src="https://github.com/betagouv/rdv-insertion/assets/4990201/5fa59ae8-ef6b-46c8-8af7-b8f085b6eb8d">
<img width="633" alt="Screenshot 2023-07-17 at 19 29 34" src="https://github.com/betagouv/rdv-insertion/assets/4990201/27881847-f07a-4f88-991c-1466d2bd7e01">
<img width="634" alt="Screenshot 2023-07-17 at 19 29 56" src="https://github.com/betagouv/rdv-insertion/assets/4990201/5bcb371b-5eac-49cf-80de-cf12dd4e371c">
<img width="633" alt="Screenshot 2023-07-17 at 19 30 23" src="https://github.com/betagouv/rdv-insertion/assets/4990201/092e3d92-63aa-4e61-9b95-46a7c099c612">

Ticket: https://github.com/betagouv/rdv-insertion/issues/1163
