### PR TITLE
refactor(app): remove unused invite_for params

### DIFF
--- a/app/services/rdv_solidarites_api/invite_user.rb
+++ b/app/services/rdv_solidarites_api/invite_user.rb
@@ -1,9 +1,8 @@
 module RdvSolidaritesApi
   class InviteUser < Base
-    def initialize(rdv_solidarites_session:, rdv_solidarites_user_id:, invite_for: nil)
+    def initialize(rdv_solidarites_session:, rdv_solidarites_user_id:)
       @rdv_solidarites_session = rdv_solidarites_session
       @rdv_solidarites_user_id = rdv_solidarites_user_id
-      @invite_for = invite_for
     end
 
     def call
@@ -14,11 +13,7 @@ module RdvSolidaritesApi
     private
 
     def rdv_solidarites_response
-      @rdv_solidarites_response ||= rdv_solidarites_client.invite_user(@rdv_solidarites_user_id, request_body)
-    end
-
-    def request_body
-      @invite_for.present? ? { invite_for: @invite_for } : {}
+      @rdv_solidarites_response ||= rdv_solidarites_client.invite_user(@rdv_solidarites_user_id)
     end
   end
 end

--- a/spec/services/rdv_solidarites_api/invite_user_spec.rb
+++ b/spec/services/rdv_solidarites_api/invite_user_spec.rb
@@ -2,7 +2,7 @@ describe RdvSolidaritesApi::InviteUser, type: :service do
   subject do
     described_class.call(
       rdv_solidarites_session: rdv_solidarites_session,
-      rdv_solidarites_user_id: rdv_solidarites_user_id,
+      rdv_solidarites_user_id: rdv_solidarites_user_id
     )
   end
 

--- a/spec/services/rdv_solidarites_api/invite_user_spec.rb
+++ b/spec/services/rdv_solidarites_api/invite_user_spec.rb
@@ -3,14 +3,12 @@ describe RdvSolidaritesApi::InviteUser, type: :service do
     described_class.call(
       rdv_solidarites_session: rdv_solidarites_session,
       rdv_solidarites_user_id: rdv_solidarites_user_id,
-      invite_for: invite_for
     )
   end
 
   let!(:rdv_solidarites_user_id) { 27 }
   let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession::Base) }
   let!(:rdv_solidarites_client) { instance_double(RdvSolidaritesClient) }
-  let!(:invite_for) { nil }
 
   describe "#call" do
     let!(:invitation_token) { "sometoken" }
@@ -27,22 +25,12 @@ describe RdvSolidaritesApi::InviteUser, type: :service do
 
       it "invites the user" do
         expect(rdv_solidarites_client).to receive(:invite_user)
-          .with(rdv_solidarites_user_id, {})
+          .with(rdv_solidarites_user_id)
         subject
       end
 
       it "returns the token" do
         expect(subject.invitation_token).to eq(invitation_token)
-      end
-
-      context "when invite_for is passed" do
-        let!(:invite_for) { 1800 }
-
-        it "invites the user with a validity duration" do
-          expect(rdv_solidarites_client).to receive(:invite_user)
-            .with(rdv_solidarites_user_id, { invite_for: invite_for })
-          subject
-        end
       end
     end
 


### PR DESCRIPTION
Petite refacto pour être iso avec les changements à venir dans cette PR : https://github.com/betagouv/rdv-solidarites.fr/pull/3690
On utilise plus le params de l'api rdvs `invite_for` pour gérer l'expiration de l'invitation (gérer directement dans rdvi)