### PR TITLE
feat(analytics): Add Matomo tag manager

### DIFF
--- a/app/javascript/components/matomo-script-tag.js
+++ b/app/javascript/components/matomo-script-tag.js
@@ -1,0 +1,15 @@
+class MatomoScriptTag {
+  constructor() {
+    /* eslint no-underscore-dangle: "off" */
+    window._mtm = window._mtm || [];
+    window._mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
+    const matomoScriptTag = document.createElement("script");
+    matomoScriptTag.async = true;
+    matomoScriptTag.src = `https://matomo.inclusion.beta.gouv.fr/js/container_${process.ENV.MATOMO_CONTAINER_ID}.js`;
+
+    const firstScriptTag = document.getElementsByTagName("script")[0];
+    firstScriptTag.parentNode.insertBefore(matomoScriptTag, firstScriptTag);
+  }
+}
+
+export default MatomoScriptTag;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import StatusSelector from "components/status-selector"
 import DepartmentSelector from "components/department-selector"
 import ActionRequiredCheckbox from "components/action-required-checkbox"
 import FilterByCurrentAgentCheckbox from "components/filter-by-current-agent-checkbox"
+import MatomoScriptTag from "components/matomo-script-tag"
 
 import "bootstrap";
 import "stylesheets/application";
@@ -55,4 +56,7 @@ document.addEventListener("turbo:load", () => {
   new DepartmentSelector();
   new ActionRequiredCheckbox();
   new FilterByCurrentAgentCheckbox();
+  if (process.env.NODE_ENV === 'production') {
+    new MatomoScriptTag();
+  }
 });


### PR DESCRIPTION
Dans cette PR je mets en place le mécanisme pour injecter le script de matomo sur nos pages permettant d'utiliser le tag manager de matomo.

<img width="1304" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/7602809/54a8c2e7-f362-4892-a9a6-7c79f6ca021d">
