### PR TITLE
fix(upload): Fix contacts data update

### DIFF
--- a/app/javascript/react/components/applicant/ContactInfosExtraLine.jsx
+++ b/app/javascript/react/components/applicant/ContactInfosExtraLine.jsx
@@ -23,7 +23,7 @@ export default function ContactInfosExtraLine({
 
     const result = await handleApplicantUpdate(
       applicant.currentOrganisation.id,
-      applicant.id,
+      applicant,
       attributes
     );
 

--- a/app/javascript/react/lib/updateApplicantContactsData.js
+++ b/app/javascript/react/lib/updateApplicantContactsData.js
@@ -1,10 +1,16 @@
 const updateExistingApplicantContactsData = async (applicant, parsedApplicantContactsData) => {
-  ["email", "phoneNumber", "rightsOpeningDate"].forEach((attributeName) => {
+  ["email", "rightsOpeningDate"].forEach((attributeName) => {
     const attribute = parsedApplicantContactsData[attributeName];
     if (attribute && applicant[attributeName] !== attribute) {
       applicant[`${attributeName}New`] = attribute;
     }
   });
+
+  const { phoneNumber } = parsedApplicantContactsData;
+  // since the phone are not formatted in the file we compare the 8 last digits
+  if (phoneNumber && applicant.phoneNumber?.slice(-8) !== phoneNumber.slice(-8)) {
+    applicant.phoneNumberNew = phoneNumber;
+  }
   return applicant;
 };
 


### PR DESCRIPTION
Il y avait un souci sur la manière dont on appelait la fonction `handleApplicantUpdate` depuis le component `ContactsInfoExtraLine` suite à un changement précédent qui faisait que l'update ne fonctionnait pas (voir #1193 ).

Je fais un hotfix ici, et j'introduirai des tests d'intégration après pour qu'on n'ait plus ce genre de régression.

J'en profite pour faire en sorte que le numéro de tel du fichier de contact ne soit plus considéré comme nouveau s'il n'y a que son format qui change. Je ne compare plus que les 8 derniers chiffres.