### PR TITLE
refactor(validation): Move id presence validation

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -45,7 +45,7 @@ class Applicant < ApplicationRecord
 
   validates :last_name, :first_name, :title, presence: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
-  validate :birth_date_validity, :identifier_must_be_present
+  validate :birth_date_validity
   validates :rdv_solidarites_user_id, :nir, :pole_emploi_id,
             uniqueness: true, allow_nil: true, unless: :skip_uniqueness_validations
 
@@ -150,17 +150,6 @@ class Applicant < ApplicationRecord
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
     errors.add(:birth_date, "n'est pas valide")
-  end
-
-  def identifier_must_be_present
-    return if deleted?
-    return if [nir, uid, department_internal_id, email, phone_number].any?(&:present?)
-
-    errors.add(
-      :base,
-      "Il doit y avoir au moins un attribut permettant d'identifier la personne " \
-      "(NIR, email, numéro de tel, ID interne, numéro d'allocataire/rôle)"
-    )
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/ClassLength
 class Applicant < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
     :first_name, :last_name, :birth_date, :email, :phone_number, :address, :affiliation_number, :birth_name
@@ -152,4 +151,3 @@ class Applicant < ApplicationRecord
     errors.add(:birth_date, "n'est pas valide")
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/applicants/validate.rb
+++ b/app/services/applicants/validate.rb
@@ -5,6 +5,7 @@ module Applicants
     end
 
     def call
+      validate_identifier_is_present
       validate_uid_uniqueness_inside_department if @applicant.affiliation_number? && @applicant.role?
       validate_department_internal_id_uniqueness if @applicant.department_internal_id?
       validate_email_and_first_name_uniquess if @applicant.email?
@@ -39,6 +40,14 @@ module Applicants
 
       result.errors << "Un allocataire avec le même numéro de téléphone et même prénom est déjà enregistré: " \
                        "#{applicants_with_same_phone_number_and_first_name.pluck(:id)}"
+    end
+
+    def validate_identifier_is_present
+      return if @applicant.nir? || @applicant.department_internal_id? || @applicant.email? || @applicant.phone_number?
+      return if @applicant.affiliation_number? && @applicant.role?
+
+      result.errors << "Il doit y avoir au moins un attribut permettant d'identifier la personne " \
+                       "(NIR, email, numéro de tel, ID interne, numéro d'allocataire/rôle)"
     end
 
     def applicants_from_same_departments

--- a/spec/services/applicants/validate_spec.rb
+++ b/spec/services/applicants/validate_spec.rb
@@ -23,6 +23,24 @@ describe Applicants::Validate, type: :service do
       it("is a success") { is_a_success }
     end
 
+    context "when an applicant has no identifier" do
+      let!(:applicant) do
+        create(
+          :applicant,
+          department_internal_id: nil, nir: nil, affiliation_number: nil, phone_number: nil, email: nil
+        )
+      end
+
+      it("is a failure") { is_a_failure }
+
+      it "returns an error" do
+        expect(subject.errors).to include(
+          "Il doit y avoir au moins un attribut permettant d'identifier la personne " \
+          "(NIR, email, numéro de tel, ID interne, numéro d'allocataire/rôle)"
+        )
+      end
+    end
+
     context "when an applicant shares the same department internal id" do
       let!(:other_applicant) do
         create(


### PR DESCRIPTION
Nous avons 48 personne en DB qui n'ont pas d'attribut `identifier` parce que la règle de présence d'un de ces attributs a été ajoutée récemment. 
Ces 48 records sont donc considérés comme invalides, et donc il est impossible des les mettre à jour lorsque l'on reçoit un webhook les concernant sur rdvs (voir https://www.rdv-insertion.fr/sidekiq/retries). 
Je propose donc de bouger cette règle de validation dans le service `Applicants::Validate` pour qu'elle ne soit utilisée que lors de la création/modification d'une personne via l'interface de RDV-I, et que ces personnes puissent être mises à jour via les webhooks de rdvs.