### PR TITLE
fix(analytics): Call matomo container id correctly

### DIFF
--- a/app/javascript/components/matomo-script-tag.js
+++ b/app/javascript/components/matomo-script-tag.js
@@ -5,7 +5,7 @@ class MatomoScriptTag {
     window._mtm.push({ "mtm.startTime": new Date().getTime(), event: "mtm.Start" });
     const matomoScriptTag = document.createElement("script");
     matomoScriptTag.async = true;
-    matomoScriptTag.src = `https://matomo.inclusion.beta.gouv.fr/js/container_${process.ENV.MATOMO_CONTAINER_ID}.js`;
+    matomoScriptTag.src = `https://matomo.inclusion.beta.gouv.fr/js/container_${process.env.MATOMO_CONTAINER_ID}.js`;
 
     const firstScriptTag = document.getElementsByTagName("script")[0];
     firstScriptTag.parentNode.insertBefore(matomoScriptTag, firstScriptTag);


### PR DESCRIPTION
hotfix sur la manière d'appeler la variable d'environnement `MATOMO_CONTAINER_ID`