### PR TITLE
feat(invitations): no invalidation of invites when participation is optional

### DIFF
--- a/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
@@ -186,7 +186,10 @@ module RdvSolidaritesWebhooks
 
     def invalidate_related_invitations
       # We invalidate the invitations linked to the new or updated rdvs to avoid double appointments
-      related_invitations.each do |invitation|
+      related_invitations
+        .joins(rdv_context: :motif_category)
+        .where(motif_categories: { participation_optional: false })
+        .each do |invitation|
         InvalidateInvitationJob.perform_async(invitation.id)
       end
     end

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -229,6 +229,15 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob do
           expect(InvalidateInvitationJob).not_to receive(:perform_async).with(invitation3.id)
           subject
         end
+
+        context "when participation is optional" do
+          let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", participation_optional: true) }
+
+          it "does not enqueue a job to invalidate the related sent valid invitations" do
+            expect(InvalidateInvitationJob).not_to receive(:perform_async)
+            subject
+          end
+        end
       end
 
       context "it upserts the rdv (for a participation update and destroy)" do


### PR DESCRIPTION
Cette PR permet de continuer à envoyer les rappels d'invitation lorsque plusieurs rendez-vous sont pris. 
Désormais seront invalidés uniquement les rendez-vous rattachés à une catégorie dont la participation est obligatoire (`participation_optional == false`)

Corrige #1226