### PR TITLE
fix(css): prevent table css overflows

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -44,3 +44,8 @@ body {
 .wrapper {
   flex:1
 }
+
+.container {
+  width: 95%;
+  max-width: 1500px;
+}

--- a/app/views/applicants/_applicants_list_table.html.erb
+++ b/app/views/applicants/_applicants_list_table.html.erb
@@ -1,4 +1,4 @@
-<div class="col-12 text-center">
+<div class="col-12 text-center overflow-scroll">
   <% if no_search_results?(@applicants.to_a) %>
     <h4 class="py-4">Aucun allocataire ne correspond à votre recherche</h4>
   <% elsif archived_scope?(@applicants_scope) %>


### PR DESCRIPTION
Cette PR permet d'éviter l'overflow de l'index des usagers

Pour résoudre le problème j'ai ajouté un overflow scroll sur la div parente afin que l'overflow ne soit pas apparent. 
J'ai également élargi un peu la largeur du conteneur global qui était un peu limitant pour les listes assez larges.

Voici le résultat  : 
<img width="1799" alt="Screenshot 2023-08-03 at 15 56 24" src="https://github.com/betagouv/rdv-insertion/assets/4990201/13b42a83-3be8-4995-87c5-5585d8aa7db6">

Corrige #1247