### PR TITLE
refactor(webhooks): Allow applicant creation when processing rdv 

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -46,7 +46,7 @@ class Applicant < ApplicationRecord
   accepts_nested_attributes_for :rdv_contexts, reject_if: :rdv_context_category_handled_already?
   accepts_nested_attributes_for :tag_applicants
 
-  validates :last_name, :first_name, :title, presence: true
+  validates :last_name, :first_name, presence: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
   validate :birth_date_validity
   validates :rdv_solidarites_user_id, :nir, :pole_emploi_id,

--- a/app/services/invitations/validate.rb
+++ b/app/services/invitations/validate.rb
@@ -10,6 +10,7 @@ module Invitations
     end
 
     def call
+      validate_applicant_title_presence
       validate_organisations_are_not_from_different_departments
       validate_it_expires_in_more_than_5_days if @invitation.format_postal?
       validate_applicant_belongs_to_an_org_linked_to_motif_category
@@ -19,6 +20,12 @@ module Invitations
     end
 
     private
+
+    def validate_applicant_title_presence
+      return if applicant.title?
+
+      result.errors << "La civilité de la personne doit être précisée pour pouvoir envoyer une invitation"
+    end
 
     def validate_organisations_are_not_from_different_departments
       return if organisations.map(&:department_id).uniq == [department_id]

--- a/spec/services/invitations/validate_spec.rb
+++ b/spec/services/invitations/validate_spec.rb
@@ -58,6 +58,18 @@ describe Invitations::Validate, type: :service do
       end
     end
 
+    context "when the applicant title is missing" do
+      before { applicant.update! title: nil }
+
+      it("is a failure") { is_a_failure }
+
+      it "stores an error message" do
+        expect(subject.errors).to include(
+          "La civilité de la personne doit être précisée pour pouvoir envoyer une invitation"
+        )
+      end
+    end
+
     context "when it is a postal invitation and the validity is < 5 days" do
       before { invitation.assign_attributes(format: "postal", valid_until: 2.days.from_now) }
 


### PR DESCRIPTION
Cette PR est liée à #1222 . 
Jusqu'à présent nous ignorions toujours les webhooks concernant des utilisateurs n'étant pas sur RDVI. 
Cependant, on peut considérer maintenant qu'un utilisateur ayant pris un rdv sur une catégorie de motif gérée par l'organisation dans RDVI doit être présent dans RDVI.
Dans le cas où la personne n'est pas encore sur RDVI, je la crée donc en traitant le webhook du rdv.
Pour ce faire, j'enlève la validation de la présence de civilité dans le model `Applicant`. On vérifie maintenant la présence de la civilité au moment d'envoyer l'invitation (dans le service `Invitations::Validate`).