### PR TITLE
feat(tags): Dropdown for selecting existing tags

### DIFF
--- a/app/controllers/concerns/applicants/filterable.rb
+++ b/app/controllers/concerns/applicants/filterable.rb
@@ -17,7 +17,12 @@ module Applicants::Filterable
   def filter_applicants_by_tags
     return if params[:tag_ids].blank?
 
-    @applicants = @applicants.joins(:tag_applicants).where(tag_applicants: { tag_id: params[:tag_ids] })
+    @applicants = @applicants.joins(:tag_applicants)
+
+    # We need to filter using AND instead of OR
+    params[:tag_ids].each do |tag_id|
+      @applicants = @applicants.where(tag_applicants: { tag_id: tag_id })
+    end
   end
 
   def filter_applicants_by_status

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -12,7 +12,9 @@ class ConfigurationsController < ApplicationController
   before_action :set_department, :set_file_configurations, only: [:new, :create, :edit, :update]
   before_action :set_back_to_applicants_list_url, :set_messages_configuration, :set_configurations, only: [:index]
 
-  def index; end
+  def index
+    @available_tags = (@department || @organisation.department).tags.distinct
+  end
 
   def show; end
 

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -2,13 +2,13 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {
-    this.input = this.element.querySelector('input')
-    this.dropdown = this.element.querySelector('.autocomplete')
+    this.input = this.element.querySelector("input")
+    this.dropdown = this.element.querySelector(".autocomplete")
     this.disableAutocomplete()
     
-    this.input.addEventListener('keyup', () => this.triggerAutocomplete())
-    this.element.querySelectorAll('button').forEach((button) => {
-      button.addEventListener('click', (event) => this.selectValue(event))
+    this.input.addEventListener("keyup", () => this.triggerAutocomplete())
+    this.element.querySelectorAll("button").forEach((button) => {
+      button.addEventListener("click", (event) => this.selectValue(event))
     })
   }
 
@@ -21,12 +21,12 @@ export default class extends Controller {
     const matches = this.values().filter((value) => value.toLowerCase().includes(this.input.value.toLowerCase()))
     
     if (this.input.value.length > 0 && matches.length > 0) {
-      this.dropdown.classList.remove('d-none')
-      this.element.querySelectorAll('button').forEach((button) => {
+      this.dropdown.classList.remove("d-none")
+      this.element.querySelectorAll("button").forEach((button) => {
         if (matches.includes(button.innerText)) {
-          button.classList.remove('d-none')
+          button.classList.remove("d-none")
         } else {
-          button.classList.add('d-none')
+          button.classList.add("d-none")
         }
       })
     } else {
@@ -35,10 +35,10 @@ export default class extends Controller {
   }
 
   disableAutocomplete() {
-    this.dropdown.classList.add('d-none')
+    this.dropdown.classList.add("d-none")
   }
 
   values() {
-    return [...this.element.querySelectorAll('button')].map((button) => button.innerText)
+    return [...this.element.querySelectorAll("button")].map((button) => button.innerText)
   }
 }

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    this.input = this.element.querySelector('input')
+    this.dropdown = this.element.querySelector('.autocomplete')
+    this.disableAutocomplete()
+    
+    this.input.addEventListener('keyup', () => this.triggerAutocomplete())
+    this.element.querySelectorAll('button').forEach((button) => {
+      button.addEventListener('click', (event) => this.selectValue(event))
+    })
+  }
+
+  selectValue(event) {
+    this.input.value = event.target.innerText
+    this.disableAutocomplete()
+  }
+
+  triggerAutocomplete() {
+    const matches = this.values().filter((value) => value.toLowerCase().includes(this.input.value.toLowerCase()))
+    
+    if (this.input.value.length > 0 && matches.length > 0) {
+      this.dropdown.classList.remove('d-none')
+      this.element.querySelectorAll('button').forEach((button) => {
+        if (matches.includes(button.innerText)) {
+          button.classList.remove('d-none')
+        } else {
+          button.classList.add('d-none')
+        }
+      })
+    } else {
+      this.disableAutocomplete()
+    }
+  }
+
+  disableAutocomplete() {
+    this.dropdown.classList.add('d-none')
+  }
+
+  values() {
+    return [...this.element.querySelectorAll('button')].map((button) => button.innerText)
+  }
+}

--- a/app/javascript/controllers/tags_controller.js
+++ b/app/javascript/controllers/tags_controller.js
@@ -2,15 +2,15 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   connect() {
-    this.element.querySelector("button").disabled = true
+    this.element.querySelector("button[type=submit]").disabled = true
     this.element.querySelector("input[type=\"text\"]").addEventListener("keyup", (event) => {
-      this.element.querySelector("button").disabled = !event.target.value
+      this.element.querySelector("button[type=submit]").disabled = !event.target.value
     })
   }
   
   
   clear() {
     this.element.querySelector("input[type=\"text\"]").value = "";
-    this.element.querySelector("button").disabled = true
+    this.element.querySelector("button[type=submit]").disabled = true
   }
 }

--- a/app/javascript/react/components/applicant/EditTags.jsx
+++ b/app/javascript/react/components/applicant/EditTags.jsx
@@ -33,7 +33,7 @@ const EditTags = observer(({
         />
       )}
       <button type="button" className="btn btn-primary mb-3" onClick={useCallback(() => setIsEditingTags(true))}>
-        <i className="fas fa-pen" /> Modifier les catégories d'usagers
+        <i className="fas fa-pen" /> Modifier les tags
       </button>
     </>
   )

--- a/app/javascript/react/components/applicant/EditableCell.jsx
+++ b/app/javascript/react/components/applicant/EditableCell.jsx
@@ -97,7 +97,7 @@ function EditableCell({ applicant, cell, type, values }) {
       delay={800}
       disabled={isEditing || isEditingTags}
       content={[
-        newTags?.length ? "Les catégories signalées en orange ne seront pas prises en compte, elle doivent d'abord être créées dans la configuration de l'organisation. " : "",
+        newTags?.length ? "Les tags signalés en orange ne seront pas pris en compte, ils doivent d'abord être créés dans la configuration de l'organisation. " : "",
         applicant.triggers[`${cell}Update`] ? "En cours..." : "Double-cliquez pour modifier",
       ].join("")}
     >

--- a/app/javascript/react/components/applicant/EditableTags.jsx
+++ b/app/javascript/react/components/applicant/EditableTags.jsx
@@ -23,20 +23,20 @@ export default observer(({ applicant, cell, values, setIsEditingTags }) => {
       <div className="modal-dialog" role="document">
         <div className="modal-content">
           <div className="modal-header">
-            <h5 className="modal-title">Édition des Catégories d'usagers</h5>
+            <h5 className="modal-title">Édition des Tags</h5>
             <button type="button" className="btn btn-blue-out" onClick={() => setIsEditingTags(false)}>
               Fermer
             </button>
           </div>
           <div className="modal-body d-flex flex-wrap">
             {availableValues.length && !applicant[cell].length ? "Choisissez un élement ci-dessous." : null}
-            {!availableValues.length && !applicant[cell].length ? "Vous pouvez créer des catégories depuis la configuration de l'organisation." : null}
+            {!availableValues.length && !applicant[cell].length ? "Vous pouvez créer des tags depuis la configuration de l'organisation." : null}
             {applicant[cell].length ? applicant[cell].map((tag) => (
               <Tippy
                 placement="top"
                 key={tag} 
                 disabled={values.includes(tag)}
-                content="Cette catégorie ne sera pas prise en compte, elle doit d'abord être créée dans la configuration de l'organisation."
+                content="Ce tag ne sera pas prise en compte, elle doit d'abord être créée dans la configuration de l'organisation."
               >
                 <div className={`badge w-auto d-flex justify-content-between bg-${values.includes(tag) ? "primary" : "warning text-white"} mb-1`}>
                   {tag}
@@ -51,14 +51,14 @@ export default observer(({ applicant, cell, values, setIsEditingTags }) => {
             {availableValues.length ? (
               <>
                 <select id="editable-tags" className="form-control w-50">
-                  <option value=""> Choisir une catégorie </option>
+                  <option value=""> Choisir un tag </option>
                   {availableValues.map(value => (
                       <option key={value} value={value}>{value}</option>
                     ))}
                 </select>
                 <button type="button" onClick={addTag} className="btn btn-primary">Ajouter</button>
               </>
-            ) : <p>Aucune {applicant[cell].length ? "autre" : ""} catégorie disponible pour cette organisation.</p>
+            ) : <p>Aucun {applicant[cell].length ? "autre" : ""} tag disponible pour cette organisation.</p>
             }
           </div>
         </div>

--- a/app/javascript/react/components/applicant/EditableTags.jsx
+++ b/app/javascript/react/components/applicant/EditableTags.jsx
@@ -36,7 +36,7 @@ export default observer(({ applicant, cell, values, setIsEditingTags }) => {
                 placement="top"
                 key={tag} 
                 disabled={values.includes(tag)}
-                content="Ce tag ne sera pas prise en compte, elle doit d'abord être créée dans la configuration de l'organisation."
+                content="Ce tag ne sera pas pris en compte, il doit d'abord être créé dans la configuration de l'organisation."
               >
                 <div className={`badge w-auto d-flex justify-content-between bg-${values.includes(tag) ? "primary" : "warning text-white"} mb-1`}>
                   {tag}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "./_fonts";
 @import "./pages/organisation";
 @import "./pages/applicants";
+@import "./components/autocomplete";
 @import "./components/navbar";
 @import "./components/footer";
 @import "./components/card";

--- a/app/javascript/stylesheets/components/_autocomplete.scss
+++ b/app/javascript/stylesheets/components/_autocomplete.scss
@@ -1,0 +1,26 @@
+.autocomplete-container {
+  position: relative;
+  display: inline-block;
+
+  .autocomplete {
+    position: absolute;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    background: $light;
+    border: 1px solid $light-grey;
+    padding: 10px;
+    border-radius: 5px;
+    margin-top: 5px;
+
+    button {
+      text-align: left;
+      margin-bottom: 8px;
+
+      &:not(.d-none):last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+

--- a/app/views/applicants/_filter_by_tag_button.html.erb
+++ b/app/views/applicants/_filter_by_tag_button.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-1">
   <div class="w-100">
     <%= link_to(new_tags_filtering_path(url_params.merge(department_level? ? { department_id: @department.id } : {organisation_id: @organisation.id })), data: { turbo_frame: 'remote_modal' }) do %>
-      <button class="btn btn-grey w-100">Filtrer par catégorie d'usager</button>
+      <button class="btn btn-grey w-100">Filtrer par tags</button>
     <% end %>
   </div>
 </div>

--- a/app/views/tags/_tag_form.html.erb
+++ b/app/views/tags/_tag_form.html.erb
@@ -2,7 +2,7 @@
   <div class="autocomplete-container" data-controller="autocomplete">
     <%= f.input :value, input_html: { class: "form-control", placeholder: "Nom du tag", autocomplete: "off" } %>
     <div class="autocomplete">
-      <% (@department || @organisation.department).tags.distinct.each do |tag| %>
+      <% @available_tags.each do |tag| %>
         <button type="button"><%= tag.value %></button>
       <% end %>
     </div>

--- a/app/views/tags/_tag_form.html.erb
+++ b/app/views/tags/_tag_form.html.erb
@@ -1,5 +1,12 @@
 <%= simple_form_for(:tag, url: organisation_tags_path, html: { method: :post, class: "d-flex", data: { controller: :tags, action: "turbo:submit-end->tags#clear" } }) do |f| %>
-  <%= f.input :value, input_html: { class: "form-control", placeholder: "Nom du tag" } %>
+  <div class="autocomplete-container" data-controller="autocomplete">
+    <%= f.input :value, input_html: { class: "form-control", placeholder: "Nom du tag", autocomplete: "off" } %>
+    <div class="autocomplete">
+      <% (@department || @organisation.department).tags.distinct.each do |tag| %>
+        <button type="button"><%= tag.value %></button>
+      <% end %>
+    </div>
+  </div>
   <%= button_tag type: 'submit', class: "btn btn-primary mx-2" do %>
     Créer le tag
   <% end  %>

--- a/app/views/tags_filterings/new.html.erb
+++ b/app/views/tags_filterings/new.html.erb
@@ -1,4 +1,4 @@
-<%= render "common/remote_modal", title: "Filtrer par catégorie d'usager" do %>
+<%= render "common/remote_modal", title: "Filtrer par tags" do %>
   <%= form_with method: :get, local: true, url: compute_index_path(@organisation, @department), data: { "turbo-frame" => "_top" } do |form| %>
     <% url_params.except(:tag_ids).each do |key, value| %>
       <%= form.hidden_field key, value: value %>

--- a/config/locales/models/applicant.fr.yml
+++ b/config/locales/models/applicant.fr.yml
@@ -23,4 +23,4 @@ fr:
         status: Statut
         referents: Référent(s)
         organisation_ids: Organisation
-        tags: Catégories d'usagers
+        tags: Tags

--- a/config/locales/models/file_configuration.fr.yml
+++ b/config/locales/models/file_configuration.fr.yml
@@ -26,4 +26,4 @@ fr:
         referent_email_column: Email de l'agent référent
         pole_emploi_id_column: ID Pôle emploi
         nir_column: NIR
-        tags_column: Catégories d'usagers
+        tags_column: Tags

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -691,7 +691,7 @@ describe ApplicantsController do
 
       let!(:applicant2) do
         create(:applicant, organisations: [organisation], first_name: "Marie",
-                           tag_applicants_attributes: [{ tag_id: tags[1].id }])
+                           tag_applicants_attributes: [{ tag_id: tags[0].id }, { tag_id: tags[1].id }])
       end
 
       let!(:applicant3) do
@@ -705,7 +705,7 @@ describe ApplicantsController do
 
       it "filters by tag" do
         get :index, params: index_params
-        expect(response.body).to match(/Michael/)
+        expect(response.body).not_to match(/Michael/)
         expect(response.body).to match(/Marie/)
         expect(response.body).not_to match(/Oliva/)
       end

--- a/spec/features/agent_can_edit_applicant_tags_spec.rb
+++ b/spec/features/agent_can_edit_applicant_tags_spec.rb
@@ -28,7 +28,7 @@ describe "Agents can edit applicants tags", js: true do
   context "the applicant page" do
     it "allows to edit tags" do
       visit organisation_applicant_path(organisation, applicant)
-      click_button("Modifier les catégories d'usagers")
+      click_button("Modifier les tags")
       modal = find(".modal")
 
       modal.find("select option[value=prout]").select_option


### PR DESCRIPTION
Cette PR permet l'ajout d'un dropdown de sélection permettant de créer des tags basés sur ceux existant dans le département plutôt que d'en créer de nouveaux. 
Ceci devrait éviter la duplication de tags ayant des nommages quasi similaires. 

https://github.com/betagouv/rdv-insertion/assets/4990201/bee0f6dd-1dd0-4183-b02d-01b28feb702f

Le dropdown d'autocomplete est ré-utilisable, non associé avec les tags, pour cela il suffit d'avoir le HTML suivant : 
```html
<div class="autocomplete-container" data-controller="autocomplete">
  <input>
   
  <div class="autocomplete">
     <button>pomme</button>
     <button>banane</button>
   </div>
  </div>
```

J'ai également renommé "Catégories d'usagers" en "Tags" ainsi que passé les filtres sur les tags en AND plutôt que OR. 

Corrige #1300 