### PR TITLE
fix(tags): prevent unwanted destroys and minor fixes

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -86,7 +86,7 @@ class ApplicantsController < ApplicationController
   def reset_tag_applicants
     # since we send the exhaustive list of tags, we need to reset the tag_applicants list
     # if tag_applicants_attributes is nil, it means that the user did not change the tags
-    @applicant.tag_applicants.destroy_all if params[:applicant][:tag_applicants_attributes].present?
+    @applicant.tag_applicants.destroy_all unless params[:applicant][:tag_applicants_attributes].nil?
   end
 
   def send_applicants_csv

--- a/app/views/applicants_organisations/_applicants_organisation.html.erb
+++ b/app/views/applicants_organisations/_applicants_organisation.html.erb
@@ -17,7 +17,7 @@
                 :submit,
                 "- Retirer",
                 class: "btn btn-danger text-white",
-                data: organisations_count == 1 ? { confirm: "Cette action va supprimer défintivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?" } : {},
+                data: organisations_count == 1 ? { confirm: "Cette action va supprimer définitivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?" } : {},
                 disabled: !removable
               )
           %>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,6 +1,15 @@
 <%= turbo_frame_tag tag, class: "badge w-auto d-flex justify-content-between bg-primary mb-2" do %>
     <%= tag.value %>
-    <%= link_to organisation_tag_path(organisation_id: @organisation.id, id: tag.id), data: { turbo_method: :delete }, class: 'text-white' do %>
+    <%= 
+      link_to(
+        organisation_tag_path(organisation_id: @organisation.id, id: tag.id), 
+        data: {
+          turbo_method: :delete, 
+          turbo_confirm: "Supprimer ce tag le désaffectera également des usagers qui y sont associés, êtes-vous sur de vouloir le supprimer ?"
+        },
+        class: 'text-white'
+      ) do 
+    %>
       <i class="fas fa-minus icon-sm"></i>
     <% end%>
 <% end %>

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -1078,7 +1078,7 @@ describe ApplicantsController do
             # that return false to .present? and tag_applicants_attributes
             # being an empty array, the controller doesn't receive it
             allow_any_instance_of(described_class).to receive(:params).and_return(
-              update_params
+              ActionController::Parameters.new(update_params)
             )
           end
 
@@ -1099,6 +1099,12 @@ describe ApplicantsController do
               organisation_id: organisation.id,
               format: "json"
             }
+          end
+
+          before do
+            allow_any_instance_of(described_class).to receive(:params).and_return(
+              ActionController::Parameters.new(update_params)
+            )
           end
 
           it "does not remove existing tags" do

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -1059,6 +1059,53 @@ describe ApplicantsController do
           expect(applicant.reload.tags.size).to eq(1)
           expect(applicant.reload.tags.first.id).to eq(tag.id)
         end
+
+        context "with empty tags" do
+          let(:update_params) do
+            {
+              applicant: {
+                birth_date: "20/12/1988",
+                tag_applicants_attributes: []
+              },
+              id: applicant.id,
+              organisation_id: organisation.id,
+              format: "json"
+            }
+          end
+
+          before do
+            # This is unfortunately required because without it Rspec removes all params
+            # that return false to .present? and tag_applicants_attributes
+            # being an empty array, the controller doesn't receive it
+            allow_any_instance_of(described_class).to receive(:params).and_return(
+              update_params
+            )
+          end
+
+          it "removes all existing tags" do
+            post :update, params: update_params
+            expect(applicant.reload.tags.size).to eq(0)
+          end
+        end
+
+        context "without tags given" do
+          let(:update_params) do
+            {
+              applicant: {
+                birth_date: "20/12/1988",
+                tag_applicants_attributes: nil
+              },
+              id: applicant.id,
+              organisation_id: organisation.id,
+              format: "json"
+            }
+          end
+
+          it "does not remove existing tags" do
+            post :update, params: update_params
+            expect(applicant.reload.tags.first).to eq(existing_tag)
+          end
+        end
       end
 
       context "when the creation fails" do

--- a/spec/features/agent_can_add_or_remove_applicant_from_organisations_spec.rb
+++ b/spec/features/agent_can_add_or_remove_applicant_from_organisations_spec.rb
@@ -167,7 +167,7 @@ describe "Agents can add or remove applicant from organisations", js: true do
       expect(page).to have_button("- Retirer", disabled: false)
 
       accept_confirm(
-        "Cette action va supprimer défintivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?"
+        "Cette action va supprimer définitivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?"
       ) do
         click_button("- Retirer")
       end


### PR DESCRIPTION
Cette PR rajoute un confirm sur la suppression d'un tag de l'organisation et corrige un problème empêchant la suppression de l'ensemble des tags d'un utilisateur depuis la page show. 

Corrige #1312