### PR TITLE
feat(mail): notify mail redirection on mattermost

### DIFF
--- a/app/jobs/transfer_email_reply_job.rb
+++ b/app/jobs/transfer_email_reply_job.rb
@@ -12,6 +12,7 @@ class TransferEmailReplyJob < ApplicationJob
     else
       forward_to_default_mailbox
     end
+    notify_on_mattermost
   end
 
   private
@@ -83,5 +84,9 @@ class TransferEmailReplyJob < ApplicationJob
         }
       end
     end
+  end
+
+  def notify_on_mattermost
+    MattermostClient.send_to_notif_channel("📩 Un email d'un usager vient d'être transféré")
   end
 end

--- a/app/mailers/reply_transfer_mailer.rb
+++ b/app/mailers/reply_transfer_mailer.rb
@@ -1,17 +1,17 @@
 class ReplyTransferMailer < ApplicationMailer
   before_action :set_invitation, only: [:forward_invitation_reply_to_organisation]
   before_action :set_rdv, only: [:forward_notification_reply_to_organisation]
-  before_action :set_organisation,
+  before_action :set_organisation, :set_recipient_email,
                 only: [:forward_invitation_reply_to_organisation, :forward_notification_reply_to_organisation]
   before_action :set_source_mail, :set_author, :set_applicant, :set_reply_subject,
                 :set_reply_body, :set_attachment_names
 
   def forward_invitation_reply_to_organisation
-    mail(to: support_email, subject: "Réponse d'un usager à une invitation")
+    mail(to: @recipient_email, subject: "Réponse d'un usager à une invitation")
   end
 
   def forward_notification_reply_to_organisation
-    mail(to: support_email, subject: "Réponse d'un usager à une convocation")
+    mail(to: @recipient_email, subject: "Réponse d'un usager à une convocation")
   end
 
   def forward_to_default_mailbox
@@ -32,8 +32,8 @@ class ReplyTransferMailer < ApplicationMailer
     @organisation = @rdv.present? ? @rdv.organisation : @invitation.organisations.last
   end
 
-  def support_email
-    @organisation.email || "support@rdv-insertion.fr"
+  def set_recipient_email
+    @recipient_email = @organisation.email || "support@rdv-insertion.fr"
   end
 
   def set_source_mail

--- a/app/views/mailers/reply_transfer_mailer/_organisation_email_not_found.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/_organisation_email_not_found.html.erb
@@ -1,0 +1,3 @@
+<p>
+  Cet email a été transféré à "support@rdv-insertion.fr" parce que l'email de l'organisation <strong><%= @organisation.name %></strong> n'est pas sauvegardé sur rdv-insertion. Sauvegardez-le pour que la prochaine fois l'email soit transféré directement à l'organisation.
+</p>

--- a/app/views/mailers/reply_transfer_mailer/forward_invitation_reply_to_organisation.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_invitation_reply_to_organisation.html.erb
@@ -1,3 +1,4 @@
+<%= render "organisation_email_not_found" if @recipient_email == "support@rdv-insertion.fr" %>
 <h1>Bonjour,</h1>
 <p>Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une invitation :</p>
 <%= render "quote_original_mail" %>

--- a/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
@@ -1,3 +1,4 @@
+<%= render "organisation_email_not_found" if @recipient_email == "support@rdv-insertion.fr" %>
 <h1>Bonjour,</h1>
 <p>Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une convocation :</p>
 <%= render "quote_original_mail" %>

--- a/spec/jobs/transfer_email_reply_job_spec.rb
+++ b/spec/jobs/transfer_email_reply_job_spec.rb
@@ -7,6 +7,7 @@ describe TransferEmailReplyJob do
     allow(ReplyTransferMailer).to receive_message_chain(:forward_notification_reply_to_organisation, :deliver_now)
     allow(ReplyTransferMailer).to receive_message_chain(:forward_invitation_reply_to_organisation, :deliver_now)
     allow(ReplyTransferMailer).to receive_message_chain(:forward_to_default_mailbox, :deliver_now)
+    allow(MattermostClient).to receive(:send_to_notif_channel)
   end
 
   let!(:organisation) { create(:organisation, email: "organisation@departement.fr") }
@@ -77,5 +78,11 @@ describe TransferEmailReplyJob do
       expect(ReplyTransferMailer).to receive_message_chain(:forward_to_default_mailbox, :deliver_now)
       subject
     end
+  end
+
+  it "sends a notif on mattermost" do
+    expect(MattermostClient).to receive(:send_to_notif_channel)
+      .with("📩 Un email d'un usager vient d'être transféré")
+    subject
   end
 end


### PR DESCRIPTION
Lié à #1281 . 
On envoie une notif mattermost à chaque fois qu'un email d'usager est transféré.
J'en profite pour ajouter un message dans le mail transféré lorsque le mail est transféré à `support@rdv-insertion.fr` parce que l'email de l'organisation  n'est pas présent sur l'appli.