### PR TITLE
feat(notifications): do not notify applicants not created through rdvi

### DIFF
--- a/app/jobs/notify_participation_job.rb
+++ b/app/jobs/notify_participation_job.rb
@@ -6,6 +6,8 @@ class NotifyParticipationJob < ApplicationJob
     @format = format
     @event = event
 
+    return if applicant.created_through_rdv_solidarites? && applicant.invitations.sent.empty?
+
     Notification.with_advisory_lock "notifying_particpation_#{@participation.id}" do
       return send_already_notified_to_mattermost if already_notified?
 
@@ -14,6 +16,10 @@ class NotifyParticipationJob < ApplicationJob
   end
 
   private
+
+  def applicant
+    @participation.applicant
+  end
 
   def already_notified?
     if @event == "participation_updated"

--- a/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_rdv_job.rb
@@ -94,6 +94,7 @@ module RdvSolidaritesWebhooks
         Applicant.create!(
           rdv_solidarites_user_id: user.id,
           organisations: [organisation],
+          created_through: "rdv_solidarites",
           **user.attributes.slice(*Applicant::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES).compact_blank
         )
       end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -56,6 +56,7 @@ class Applicant < ApplicationRecord
 
   enum role: { demandeur: 0, conjoint: 1 }
   enum title: { monsieur: 0, madame: 1 }
+  enum created_through: { rdv_insertion: 0, rdv_solidarites: 1 }, _prefix: true
 
   scope :active, -> { where(deleted_at: nil) }
   scope :without_rdv_contexts, lambda { |motif_categories|

--- a/db/migrate/20230830142108_add_created_through_to_applicants.rb
+++ b/db/migrate/20230830142108_add_created_through_to_applicants.rb
@@ -1,0 +1,6 @@
+class AddCreatedThroughToApplicants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applicants, :created_through, :integer, default: 0
+    up_only { Applicant.where(title: nil).update_all(created_through: 1) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_29_105540) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_142108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_29_105540) do
     t.string "nir"
     t.string "pole_emploi_id"
     t.string "carnet_de_bord_carnet_id"
+    t.integer "created_through", default: 0
     t.index ["department_internal_id"], name: "index_applicants_on_department_internal_id"
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["nir"], name: "index_applicants_on_nir"

--- a/spec/jobs/notify_participation_job_spec.rb
+++ b/spec/jobs/notify_participation_job_spec.rb
@@ -4,9 +4,8 @@ describe NotifyParticipationJob do
   end
 
   let!(:participation_id) { 3232 }
-  # let!(:rdv) { create(:rdv, id: rdv_id) }
-  # let!(:applicant) { create(:applicant, id: applicant_id) }
-  let!(:participation) { create(:participation, id: participation_id) }
+  let!(:participation) { create(:participation, id: participation_id, applicant:) }
+  let!(:applicant) { create(:applicant) }
   let!(:format) { "sms" }
   let!(:event) { "participation_created" }
 
@@ -87,6 +86,17 @@ describe NotifyParticipationJob do
               )
             subject
           end
+        end
+      end
+
+      context "when the applicant is created through rdv_solidarites and has no invitations" do
+        let!(:applicant) do
+          create(:applicant, created_through: "rdv_solidarites", invitations: [])
+        end
+
+        it "does notify the applicant" do
+          expect(Notifications::NotifyParticipation).not_to receive(:call)
+          subject
         end
       end
     end

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -230,7 +230,8 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob do
               rdv_solidarites_user_id: user_id1,
               organisations: [organisation],
               first_name: "James",
-              last_name: "Cameron"
+              last_name: "Cameron",
+              created_through: "rdv_solidarites"
             )
             subject
           end


### PR DESCRIPTION
Dans cette PR j'ajoute une colonne à la table `applicants` pour différencier les personnes créées depuis rdv-solidarites et celles créées depuis rdv-insertion. 
Comme expliqué [dans cette conversation](https://mattermost.incubateur.net/betagouv/pl/6z6wk8c5xjnm8rm5jy4wyfeige), on décide de ne pas envoyer des messages de convocations aux personnes créées depuis rdv-solidarites qui n'ont pas été invitées.