### PR TITLE
feat(category): add new context for var

### DIFF
--- a/app/models/concerns/motif_category/sortable.rb
+++ b/app/models/concerns/motif_category/sortable.rb
@@ -1,6 +1,7 @@
 module MotifCategory::Sortable
   CHRONOLOGICALLY_SORTED_CATEGORIES_SHORT_NAMES = %w[
     rsa_integration_information
+    rsa_droits_devoirs
     rsa_orientation
     rsa_orientation_file_active
     rsa_orientation_france_travail

--- a/config/locales/models/motif.fr.yml
+++ b/config/locales/models/motif.fr.yml
@@ -5,6 +5,7 @@ fr:
     attributes:
       motif:
         categories:
+          rsa_droits_devoirs: RSA - droits et devoirs
           rsa_orientation: RSA orientation
           rsa_orientation_france_travail: RSA orientation France Travail
           rsa_accompagnement: RSA accompagnement

--- a/db/migrate/20230831090625_add_motif_category_for_var.rb
+++ b/db/migrate/20230831090625_add_motif_category_for_var.rb
@@ -19,6 +19,6 @@ class AddMotifCategoryForVar < ActiveRecord::Migration[7.0]
 
   def down
     MotifCategory.find_by(short_name: "rsa_droits_devoirs").destroy!
-    Template.find_by(rdv_title: "rendez-vous des Droits et Devoirs",).destroy!
+    Template.find_by(rdv_title: "rendez-vous des Droits et Devoirs").destroy!
   end
 end

--- a/db/migrate/20230831090625_add_motif_category_for_var.rb
+++ b/db/migrate/20230831090625_add_motif_category_for_var.rb
@@ -1,0 +1,24 @@
+class AddMotifCategoryForVar < ActiveRecord::Migration[7.0]
+  def up
+    template = Template.create!(
+      model: "standard",
+      rdv_title: "rendez-vous des Droits et Devoirs",
+      rdv_title_by_phone: "rendez-vous téléphonique des Droits et Devoirs",
+      rdv_purpose: "définir votre orientation",
+      applicant_designation: "bénéficiaire du RSA",
+      rdv_subject: "RSA",
+      display_mandatory_warning: true
+    )
+    MotifCategory.create!(
+      short_name: "rsa_droits_devoirs",
+      name: "RSA - droits et devoirs",
+      participation_optional: false,
+      template: template
+    )
+  end
+
+  def down
+    MotifCategory.find_by(short_name: "rsa_droits_devoirs").destroy!
+    Template.find_by(rdv_title: "rendez-vous des Droits et Devoirs",).destroy!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_29_105540) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_31_090625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,6 +37,19 @@ yonne = Department.create!(
 
 # --------------------------------------------------------------------------------------------------------------------
 puts "Creating motif categories..."
+droits_et_devoirs_category = MotifCategory.create!(
+  short_name: "rsa_droits_devoirs", name: "RSA - droits et devoirs",
+  template: Template.find_or_create_by!(
+    model: "standard",
+    rdv_title: "rendez-vous des Droits et Devoirs",
+    rdv_title_by_phone: "rendez-vous téléphonique des Droits et Devoirs",
+    rdv_purpose: "définir votre orientation",
+    applicant_designation: "bénéficiaire du RSA",
+    rdv_subject: "RSA",
+    display_mandatory_warning: true
+  )
+)
+
 orientation_category = MotifCategory.create!(
   short_name: "rsa_orientation", name: "RSA orientation",
   template: Template.find_or_create_by!(
@@ -258,6 +271,15 @@ Configuration.create!(
   convene_applicant: false,
   invitation_formats: ["sms", "email", "postal"],
   motif_category: orientation_category,
+  number_of_days_before_action_required: 10,
+  organisation: drome1_organisation
+)
+
+Configuration.create!(
+  file_configuration: file_config_drome,
+  convene_applicant: false,
+  invitation_formats: ["sms", "email", "postal"],
+  motif_category: droits_et_devoirs_category,
   number_of_days_before_action_required: 10,
   organisation: drome1_organisation
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -37,19 +37,6 @@ yonne = Department.create!(
 
 # --------------------------------------------------------------------------------------------------------------------
 puts "Creating motif categories..."
-droits_et_devoirs_category = MotifCategory.create!(
-  short_name: "rsa_droits_devoirs", name: "RSA - droits et devoirs",
-  template: Template.find_or_create_by!(
-    model: "standard",
-    rdv_title: "rendez-vous des Droits et Devoirs",
-    rdv_title_by_phone: "rendez-vous téléphonique des Droits et Devoirs",
-    rdv_purpose: "définir votre orientation",
-    applicant_designation: "bénéficiaire du RSA",
-    rdv_subject: "RSA",
-    display_mandatory_warning: true
-  )
-)
-
 orientation_category = MotifCategory.create!(
   short_name: "rsa_orientation", name: "RSA orientation",
   template: Template.find_or_create_by!(
@@ -271,15 +258,6 @@ Configuration.create!(
   convene_applicant: false,
   invitation_formats: ["sms", "email", "postal"],
   motif_category: orientation_category,
-  number_of_days_before_action_required: 10,
-  organisation: drome1_organisation
-)
-
-Configuration.create!(
-  file_configuration: file_config_drome,
-  convene_applicant: false,
-  invitation_formats: ["sms", "email", "postal"],
-  motif_category: droits_et_devoirs_category,
   number_of_days_before_action_required: 10,
   organisation: drome1_organisation
 )


### PR DESCRIPTION
@aminedhobb PI il y avait des tests dans les précédentes PR de création de contexte mais comme j'évoquais à Quentin dans `spec/services/invitations/generate_letter_spec.rb` de la ligne 159 à 420 ils devraient pouvoir être enlevés car ils ne font que tester le résultat dans les invitations de record fictifs créés pour le tests (qui ne sont pas liés avec ceux en prod). 
