### PR TITLE
fix: prevent periodic invites to be sent when the configuration is nil

### DIFF
--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -31,6 +31,8 @@ class SendPeriodicInvitesJob < ApplicationJob
   end
 
   def should_send_periodic_invite?(last_sent_invitation, configuration)
+    return false if configuration.number_of_days_before_next_invite.blank?
+
     (Time.zone.today - last_sent_invitation.sent_at.to_date).to_i == configuration.number_of_days_before_next_invite
   end
 

--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -1,5 +1,7 @@
 class SendPeriodicInvitesJob < ApplicationJob
   def perform
+    return if staging_env?
+
     @sent_invites_applicant_ids = []
 
     RdvContext

--- a/db/migrate/20230822125225_add_number_of_days_before_next_invite_to_configurations.rb
+++ b/db/migrate/20230822125225_add_number_of_days_before_next_invite_to_configurations.rb
@@ -1,5 +1,5 @@
 class AddNumberOfDaysBeforeNextInviteToConfigurations < ActiveRecord::Migration[7.0]
   def change
-    add_column :configurations, :number_of_days_before_next_invite, :integer, default: 10
+    add_column :configurations, :number_of_days_before_next_invite, :integer, default: nil
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_31_090625) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_31_122723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,7 +101,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_31_090625) do
     t.bigint "motif_category_id"
     t.bigint "file_configuration_id"
     t.bigint "organisation_id"
-    t.integer "number_of_days_before_next_invite", default: 10
+    t.integer "number_of_days_before_next_invite"
     t.index ["file_configuration_id"], name: "index_configurations_on_file_configuration_id"
     t.index ["motif_category_id"], name: "index_configurations_on_motif_category_id"
     t.index ["organisation_id"], name: "index_configurations_on_organisation_id"

--- a/spec/jobs/send_periodic_invites_job_spec.rb
+++ b/spec/jobs/send_periodic_invites_job_spec.rb
@@ -49,5 +49,20 @@ describe SendPeriodicInvitesJob do
         subject
       end
     end
+
+    context "when configuration is not set" do
+      let!(:configuration) do
+        create(:configuration,
+               organisation: organisation,
+               number_of_days_before_next_invite: nil,
+               motif_category: motif_category)
+      end
+
+      it "does not send periodic invites" do
+        expect(SendPeriodicInviteJob).not_to receive(:perform_async).with(invitation.id, configuration.id, "email")
+        expect(SendPeriodicInviteJob).not_to receive(:perform_async).with(invitation.id, configuration.id, "sms")
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
Cette PR permet d'éviter l'envoi d'invitations périodiques dans le cas où aucune configuration n'a été set. 
Pour cela on enlève la valeur par défaut de la colonne.