### PR TITLE
feat(stats): display stats by organisation

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,23 +1,39 @@
 class StatsController < ApplicationController
   skip_before_action :authenticate_agent!, only: [:index, :show, :deployment_map]
-  before_action :set_department, only: [:show]
+  before_action :set_organisation, :set_department, :set_stat, :set_display_all_stats, only: [:show]
 
   def index
     @department_count = Department.displayed_in_stats.count
-    @stat = Stat.find_by(department_number: "all")
+    @stat = Stat.find_by(statable_type: "Department", statable_id: nil)
   end
 
-  def show
-    @stat = Stat.find_by(department_number: @department.number)
-    # we don't display all stats for departments who don't invite applicants
-    @display_all_stats = @department.configurations.none? { |configuration| configuration.invitation_formats.blank? }
-  end
+  def show; end
 
   def deployment_map; end
 
   private
 
+  def set_organisation
+    @organisation = Organisation.find(params[:organisation_id]) if params[:organisation_id]
+  end
+
   def set_department
-    @department = Department.find(params[:id])
+    @department = if @organisation
+                    @organisation.department
+                  else
+                    Department.find(params[:department_id])
+                  end
+  end
+
+  def set_stat
+    @stat = if @organisation
+              Stat.find_by(statable_type: "Organisation", statable_id: @organisation.id)
+            else
+              Stat.find_by(statable_type: "Department", statable_id: @department.id)
+            end
+  end
+
+  def set_display_all_stats
+    @display_all_stats = @department.configurations.none? { |configuration| configuration.invitation_formats.blank? }
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -5,4 +5,10 @@ module StatsHelper
               .map { |d| ["#{d.number} - #{d.name}", d.id] }
               .unshift(["Tous les départements", "0"])
   end
+
+  def options_for_organisation_select(department)
+    department.organisations
+              .map { |o| [o.name.to_s, o.id] }
+              .unshift(["Toutes les organisations", "0"])
+  end
 end

--- a/app/javascript/components/department-selector.js
+++ b/app/javascript/components/department-selector.js
@@ -14,7 +14,7 @@ class DepartmentSelector {
 
   refreshQuery(selectedDepartment) {
     if (selectedDepartment && selectedDepartment !== "0") {
-      const url = new URL(`${window.location.origin}/stats/${selectedDepartment}`);
+      const url = new URL(`${window.location.origin}/departments/${selectedDepartment}/stats`);
       window.location.href = url;
     } else {
       const url = new URL(`${window.location.origin}/stats`);

--- a/app/javascript/components/organisation-selector.js
+++ b/app/javascript/components/organisation-selector.js
@@ -1,0 +1,27 @@
+class OrganisationSelector {
+  constructor() {
+    this.selectElt = document.querySelector(".js-organisation-selector");
+    if (this.selectElt === null) return;
+
+    this.attachListener();
+  }
+
+  attachListener() {
+    this.selectElt.addEventListener("change", (event) => {
+      this.refreshQuery(event.target.value);
+    });
+  }
+
+  refreshQuery(selectedOrganisation) {
+    if (selectedOrganisation && selectedOrganisation !== "0") {
+      const url = new URL(`${window.location.origin}/organisations/${selectedOrganisation}/stats`);
+      window.location.href = url;
+    } else {
+      const currentDepartmentId = document.getElementById("department_id").value
+      const url = new URL(`${window.location.origin}/departments/${currentDepartmentId}/stats`);
+      window.location.href = url;
+    }
+  }
+}
+
+export default OrganisationSelector;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,7 @@
 import LoginForm from "components/login-form";
 import StatusSelector from "components/status-selector"
 import DepartmentSelector from "components/department-selector"
+import OrganisationSelector from "components/organisation-selector"
 import ActionRequiredCheckbox from "components/action-required-checkbox"
 import FilterByCurrentAgentCheckbox from "components/filter-by-current-agent-checkbox"
 import MatomoScriptTag from "components/matomo-script-tag"
@@ -54,6 +55,7 @@ document.addEventListener("turbo:load", () => {
   new LoginForm();
   new StatusSelector();
   new DepartmentSelector();
+  new OrganisationSelector();
   new ActionRequiredCheckbox();
   new FilterByCurrentAgentCheckbox();
   if (process.env.NODE_ENV === 'production') {

--- a/app/jobs/stats/global_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stat_job.rb
@@ -3,8 +3,9 @@ class StatsJobError < StandardError; end
 module Stats
   module GlobalStats
     class UpsertStatJob < ApplicationJob
-      def perform(department_number)
-        upsert_stat_record_for_global_stats = Stats::GlobalStats::UpsertStat.call(department_number: department_number)
+      def perform(structure_type, structure_id)
+        upsert_stat_record_for_global_stats =
+          Stats::GlobalStats::UpsertStat.call(structure_type: structure_type, structure_id: structure_id)
 
         return if upsert_stat_record_for_global_stats.success?
 

--- a/app/jobs/stats/global_stats/upsert_stats_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stats_job.rb
@@ -2,9 +2,14 @@ module Stats
   module GlobalStats
     class UpsertStatsJob < ApplicationJob
       def perform
-        department_numbers = Department.pluck(:number).push("all")
-        department_numbers.each do |department_number|
-          Stats::GlobalStats::UpsertStatJob.perform_async(department_number)
+        Stats::GlobalStats::UpsertStatJob.perform_async("Department", nil)
+
+        Department.find_each do |department|
+          Stats::GlobalStats::UpsertStatJob.perform_async("Department", department.id)
+        end
+
+        Organisation.find_each do |organisation|
+          Stats::GlobalStats::UpsertStatJob.perform_async("Organisation", organisation.id)
         end
       end
     end

--- a/app/jobs/stats/monthly_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stat_job.rb
@@ -3,10 +3,11 @@ class StatsJobError < StandardError; end
 module Stats
   module MonthlyStats
     class UpsertStatJob < ApplicationJob
-      def perform(department_number, date_string)
-        upsert_stat_record_for_monthly_stats = Stats::MonthlyStats::UpsertStat.call(
-          department_number: department_number, date_string: date_string
-        )
+      def perform(structure_type, structure_id, date_string)
+        upsert_stat_record_for_monthly_stats =
+          Stats::MonthlyStats::UpsertStat.call(
+            structure_type: structure_type, structure_id: structure_id, date_string: date_string
+          )
 
         return if upsert_stat_record_for_monthly_stats.success?
 

--- a/app/jobs/stats/monthly_stats/upsert_stats_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stats_job.rb
@@ -2,10 +2,15 @@ module Stats
   module MonthlyStats
     class UpsertStatsJob < ApplicationJob
       def perform
-        department_numbers = Department.pluck(:number).push("all")
-        department_numbers.each do |department_number|
-          # We upsert the monthly stats with last month stats to only record complete months
-          Stats::MonthlyStats::UpsertStatJob.perform_async(department_number, 1.month.ago)
+        # We upsert the monthly stats with last month stats to only record complete months
+        Stats::MonthlyStats::UpsertStatJob.perform_async("Department", nil, 1.month.ago)
+
+        Department.find_each do |department|
+          Stats::MonthlyStats::UpsertStatJob.perform_async("Department", department.id, 1.month.ago)
+        end
+
+        Organisation.find_each do |organisation|
+          Stats::MonthlyStats::UpsertStatJob.perform_async("Organisation", organisation.id, 1.month.ago)
         end
       end
     end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -17,6 +17,7 @@ class Department < ApplicationRecord
   has_many :rdv_contexts, through: :applicants
   has_many :archived_applicants, through: :archives, source: :applicant
   has_many :tags, through: :organisations
+  has_one :stat, as: :statable, dependent: :destroy
 
   scope :displayed_in_stats, -> { where(display_in_stats: true) }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -11,15 +11,18 @@ class Organisation < ApplicationRecord
   validate :validate_organisation_phone_number
 
   belongs_to :department
+  has_one :stat, as: :statable, dependent: :destroy
   has_one :messages_configuration, dependent: :destroy
   has_many :configurations, dependent: :destroy
   has_many :rdvs, dependent: :nullify
+  has_many :participations, through: :rdvs
   has_many :lieux, dependent: :nullify
   has_many :motifs, dependent: :nullify
   has_many :agent_roles, dependent: :destroy
   has_many :agents, through: :agent_roles
   has_many :motif_categories, -> { distinct }, through: :configurations
   has_many :tag_organisations, dependent: :destroy
+  has_many :archived_applicants, through: :department
 
   has_many :tags, through: :tag_organisations
 

--- a/app/services/stats/global_stats/upsert_stat.rb
+++ b/app/services/stats/global_stats/upsert_stat.rb
@@ -1,8 +1,9 @@
 module Stats
   module GlobalStats
     class UpsertStat < BaseService
-      def initialize(department_number:)
-        @department_number = department_number
+      def initialize(structure_type:, structure_id:)
+        @structure_type = structure_type
+        @structure_id = structure_id
       end
 
       def call
@@ -13,7 +14,7 @@ module Stats
       private
 
       def stat
-        @stat ||= Stat.find_or_initialize_by(department_number: @department_number)
+        @stat ||= Stat.find_or_initialize_by(statable_type: @structure_type, statable_id: @structure_id)
       end
 
       def assign_global_stats_attributes_to_stat_record

--- a/app/services/stats/monthly_stats/upsert_stat.rb
+++ b/app/services/stats/monthly_stats/upsert_stat.rb
@@ -1,8 +1,9 @@
 module Stats
   module MonthlyStats
     class UpsertStat < BaseService
-      def initialize(department_number:, date_string:)
-        @department_number = department_number
+      def initialize(structure_type:, structure_id:, date_string:)
+        @structure_type = structure_type
+        @structure_id = structure_id
         @date_string = date_string
       end
 
@@ -14,7 +15,7 @@ module Stats
       private
 
       def stat
-        @stat ||= Stat.find_or_initialize_by(department_number: @department_number)
+        @stat ||= Stat.find_or_initialize_by(statable_type: @structure_type, statable_id: @structure_id)
       end
 
       def merge_monthly_stats_attributes_for_focused_month_to_stat_record

--- a/app/views/stats/_header.html.erb
+++ b/app/views/stats/_header.html.erb
@@ -12,7 +12,7 @@
   </ul>
 </div>
 <% unless current_page?(action: 'deployment_map') %>
-  <div class="d-flex justify-content-center mt-5">
+  <div class="d-flex justify-content-center mt-4">
     <div>
       <%=
         select(
@@ -23,4 +23,17 @@
       %>
     </div>
   </div>
+  <% if @department || @organisation %>
+    <div class="d-flex justify-content-center my-3">
+      <div>
+        <%=
+          select(
+            "organisation", "id", options_for_organisation_select(@department),
+            { },
+            class: "text-center form-select js-organisation-selector"
+          )
+        %>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,9 +40,10 @@ Rails.application.routes.draw do
       get :confirm_update
     end
     resources :messages_configurations, only: [:show, :new, :edit, :create, :update]
+    resource :stats, only: [:show]
   end
 
-  resources :stats, only: [:index, :show] do
+  resources :stats, only: [:index] do
     get :deployment_map, on: :collection
   end
 
@@ -91,6 +92,7 @@ Rails.application.routes.draw do
     end
     resource :applicants_organisations, only: [:create, :destroy]
     resource :referent_assignations, only: [:create, :destroy]
+    resource :stats, only: [:show]
   end
   resources :invitation_dates_filterings, :creation_dates_filterings, only: [:new]
   resources :tags_filterings, :tags_filterings, only: [:new]

--- a/db/migrate/20230829162511_add_organisation_id_to_stats.rb
+++ b/db/migrate/20230829162511_add_organisation_id_to_stats.rb
@@ -1,0 +1,38 @@
+class AddOrganisationIdToStats < ActiveRecord::Migration[7.0]
+  def up # rubocop:disable Metrics/AbcSize
+    add_reference :stats, :statable, polymorphic: true, index: true
+
+    Stat.find_each do |stat|
+      stat.statable_type = stat.department_number.present? ? "Department" : "Organisation"
+      if stat.department_number.present? && stat.department_number != "all"
+        department = Department.find_by(number: stat.department_number)
+        stat.statable_id = department.id
+      elsif stat.department_number != "all" && Stat.column_names.include?("organisation_id")
+        stat.statable_id = stat.organisation_id
+      end
+      stat.save!
+    end
+
+    remove_column :stats, :department_number
+    remove_column :stats, :organisation_id if Stat.column_names.include?("organisation_id")
+  end
+
+  def down
+    add_column :stats, :department_number, :string
+    add_column :stats, :organisation_id, :bigint
+
+    Stat.find_each do |stat|
+      next unless stat.statable_type == "Department"
+
+      if stat.statable_id.nil?
+        stat.department_number = "all"
+      else
+        department = Department.find(stat.statable_id)
+        stat.department_number = department.number
+      end
+      stat.save!
+    end
+
+    remove_reference :stats, :statable, polymorphic: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_29_105540) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_29_162511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -342,12 +342,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_29_105540) do
     t.float "rate_of_applicants_with_rdv_seen_in_less_than_30_days"
     t.json "rate_of_applicants_with_rdv_seen_in_less_than_30_days_by_month"
     t.integer "agents_count"
-    t.string "department_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.float "rate_of_autonomous_applicants"
     t.json "rate_of_autonomous_applicants_grouped_by_month"
-    t.index ["department_number"], name: "index_stats_on_department_number", unique: true
+    t.string "statable_type"
+    t.bigint "statable_id"
+    t.index ["statable_type", "statable_id"], name: "index_stats_on_statable"
   end
 
   create_table "tag_applicants", force: :cascade do |t|

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -1,17 +1,37 @@
 describe StatsController do
+  let!(:department) { create(:department) }
+  let!(:organisation) { create(:organisation, department: department) }
+
   describe "#index" do
     it "returns a success response" do
       get :index
       expect(response).to be_successful
     end
+  end
 
-    context "when a department is selected" do
-      let(:search_params) { { department: "26" } }
+  describe "#show" do
+    let!(:show_params_for_department) { { department_id: department.id } }
+    let!(:show_params_for_organisation) { { organisation_id: organisation.id } }
 
-      it "filters the data" do
-        get :index, params: search_params
+    context "when for a department" do
+      it "returns a success response" do
+        get :show, params: show_params_for_department
         expect(response).to be_successful
       end
+    end
+
+    context "when for an organisation" do
+      it "returns a success response" do
+        get :show, params: show_params_for_organisation
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "#deployment_map" do
+    it "returns a success response" do
+      get :deployment_map
+      expect(response).to be_successful
     end
   end
 end

--- a/spec/factories/stat.rb
+++ b/spec/factories/stat.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     rate_of_autonomous_applicants { 0.0 }
     rate_of_autonomous_applicants_grouped_by_month { {} }
     agents_count { 1 }
-    sequence(:department_number)
+    statable_type { "Department" }
+    sequence(:statable_id)
   end
 end

--- a/spec/jobs/stats/global_stats/upsert_stat_job_spec.rb
+++ b/spec/jobs/stats/global_stats/upsert_stat_job_spec.rb
@@ -1,6 +1,6 @@
 describe Stats::GlobalStats::UpsertStatJob do
   subject do
-    described_class.new.perform(department.number)
+    described_class.new.perform("Department", department.id)
   end
 
   let!(:department) { create(:department) }
@@ -13,7 +13,7 @@ describe Stats::GlobalStats::UpsertStatJob do
 
     it "calls the appropriate service" do
       expect(Stats::GlobalStats::UpsertStat).to receive(:call)
-        .with(department_number: department.number)
+        .with(structure_type: "Department", structure_id: department.id)
       subject
     end
 

--- a/spec/jobs/stats/global_stats/upsert_stats_job_spec.rb
+++ b/spec/jobs/stats/global_stats/upsert_stats_job_spec.rb
@@ -7,6 +7,9 @@ describe Stats::GlobalStats::UpsertStatsJob do
   let!(:department2) { create(:department) }
   let!(:department3) { create(:department) }
 
+  let!(:organisation1) { create(:organisation, department: department1) }
+  let!(:organisation2) { create(:organisation, department: department2) }
+
   describe "#perform" do
     before do
       allow(Stats::GlobalStats::UpsertStatJob).to receive(:perform_async)
@@ -14,7 +17,7 @@ describe Stats::GlobalStats::UpsertStatsJob do
     end
 
     it "calls the appropriate service the right number of times" do
-      expect(Stats::GlobalStats::UpsertStatJob).to receive(:perform_async).exactly(4).times
+      expect(Stats::GlobalStats::UpsertStatJob).to receive(:perform_async).exactly(6).times
       subject
     end
   end

--- a/spec/jobs/stats/monthly_stats/upsert_stat_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/upsert_stat_job_spec.rb
@@ -1,6 +1,6 @@
 describe Stats::MonthlyStats::UpsertStatJob do
   subject do
-    described_class.new.perform(department.number, date_string)
+    described_class.new.perform("Department", department.id, date_string)
   end
 
   let!(:department) { create(:department) }
@@ -14,7 +14,7 @@ describe Stats::MonthlyStats::UpsertStatJob do
 
     it "calls the appropriate service" do
       expect(Stats::MonthlyStats::UpsertStat).to receive(:call)
-        .with(department_number: department.number, date_string: date_string)
+        .with(structure_type: "Department", structure_id: department.id, date_string: date_string)
       subject
     end
 

--- a/spec/jobs/stats/monthly_stats/upsert_stats_job_spec.rb
+++ b/spec/jobs/stats/monthly_stats/upsert_stats_job_spec.rb
@@ -7,6 +7,9 @@ describe Stats::MonthlyStats::UpsertStatsJob do
   let!(:department2) { create(:department) }
   let!(:department3) { create(:department) }
 
+  let!(:organisation1) { create(:organisation, department: department1) }
+  let!(:organisation2) { create(:organisation, department: department2) }
+
   describe "#perform" do
     before do
       allow(Stats::MonthlyStats::UpsertStatJob).to receive(:perform_async)
@@ -14,7 +17,7 @@ describe Stats::MonthlyStats::UpsertStatsJob do
     end
 
     it "calls the appropriate service the right number of times" do
-      expect(Stats::MonthlyStats::UpsertStatJob).to receive(:perform_async).exactly(4).times
+      expect(Stats::MonthlyStats::UpsertStatJob).to receive(:perform_async).exactly(6).times
       subject
     end
   end

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -1,31 +1,10 @@
 describe Stat do
   include_context "with all existing categories"
 
-  describe "department_number validation" do
-    context "when the department_number is present" do
-      let!(:stat) { build(:stat, department_number: "1") }
-
-      it "is valid" do
-        expect(stat).to be_valid
-      end
-    end
-
-    context "when no department_number is given" do
-      let!(:stat) { build(:stat, department_number: nil) }
-
-      it "adds errors" do
-        expect(stat).not_to be_valid
-        expect(stat.errors.details).to eq({ department_number: [{ :error => :blank }] })
-        expect(stat.errors.full_messages.to_sentence)
-          .to include("Department number doit être rempli(e)")
-      end
-    end
-  end
-
   describe "instance_methods" do
     let!(:department) { create(:department) }
-    let!(:stat) { build(:stat, department_number: department.number) }
-    let(:date) { Time.zone.parse("17/03/2022 12:00") }
+    let!(:stat) { build(:stat, statable_type: "Department", statable_id: department.id) }
+    let(:date) { Time.zone.parse("17/07/2023 12:00") }
     let!(:other_department) { create(:department) }
     let!(:applicant1) do
       create(:applicant, organisations: [organisation],
@@ -63,7 +42,7 @@ describe Stat do
                            participations: [participation2], motif_category: category_rsa_orientation)
     end
 
-    context "when department_number is not 'all'" do
+    context "when statable type is Department and statable_id is present" do
       describe "#all_applicants" do
         it "scopes the collection to the department" do
           expect(stat.all_applicants).to include(applicant1)
@@ -298,9 +277,8 @@ describe Stat do
       end
     end
 
-    context "when department_number is 'all'" do
-      let!(:department_number) { "all" }
-      let!(:stat) { build(:stat, department_number: department_number) }
+    context "when it is the stat record for all departments" do
+      let!(:stat) { build(:stat, statable_type: "Department", statable_id: nil) }
 
       describe "#all_applicants" do
         it "does not scope the collection to the department" do

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -3,7 +3,7 @@ describe Stat do
 
   describe "instance_methods" do
     let!(:department) { create(:department) }
-    let!(:stat) { build(:stat, statable_type: "Department", statable_id: department.id) }
+    let!(:stat) { build(:stat, statable_type: structure_type, statable_id: structure_id) }
     let(:date) { Time.zone.parse("17/07/2023 12:00") }
     let!(:other_department) { create(:department) }
     let!(:applicant1) do
@@ -41,6 +41,8 @@ describe Stat do
       create(:rdv_context, applicant: applicant2, invitations: [invitation2],
                            participations: [participation2], motif_category: category_rsa_orientation)
     end
+    let!(:structure_type) { "Department" }
+    let!(:structure_id) { department.id }
 
     context "when statable type is Department and statable_id is present" do
       describe "#all_applicants" do
@@ -267,6 +269,250 @@ describe Stat do
         end
 
         it "scopes the collection to the department" do
+          expect(stat.applicants_for_30_days_rdvs_seen_sample).to include(applicant1)
+          expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant2)
+        end
+
+        it "does not include the applicants with no motif category for a first rdv RSA" do
+          expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant3)
+        end
+      end
+    end
+
+    context "when statable type is Organisation and statable_id is present" do
+      let!(:structure_type) { "Organisation" }
+      let!(:structure_id) { organisation.id }
+
+      describe "#all_applicants" do
+        it "scopes the collection to the organisation" do
+          expect(stat.all_applicants).to include(applicant1)
+          expect(stat.all_applicants).not_to include(applicant2)
+        end
+      end
+
+      describe "#all_organisations" do
+        it "scopes the collection to the organisation" do
+          expect(stat.all_organisations).to include(organisation)
+          expect(stat.all_organisations).not_to include(other_organisation)
+        end
+      end
+
+      describe "#all_participations" do
+        it "scopes the collection to the organisation" do
+          expect(stat.all_participations).to include(participation1)
+          expect(stat.all_participations).not_to include(participation2)
+        end
+      end
+
+      describe "#invitations_sample" do
+        let!(:invitation1) do
+          create(:invitation, applicant: applicant1, organisations: [organisation], sent_at: date)
+        end
+        let!(:invitation2) do
+          create(:invitation, applicant: applicant2, organisations: [other_organisation], sent_at: date)
+        end
+        let!(:invitation3) { create(:invitation, organisations: [organisation], sent_at: nil) }
+
+        it "scopes the collection to the organisation" do
+          expect(stat.invitations_sample).to include(invitation1)
+          expect(stat.invitations_sample).not_to include(invitation2)
+        end
+
+        it "scopes the collection to sent invitations" do
+          expect(stat.invitations_sample).not_to include(invitation3)
+        end
+      end
+
+      describe "#participations_sample" do
+        it "scopes the collection to the organisation" do
+          expect(stat.participations_sample).to include(participation1)
+          expect(stat.participations_sample).not_to include(participation2)
+        end
+      end
+
+      describe "#organisations_sample" do
+        let!(:organisation_with_no_invitations_formats) { create(:organisation, department: department) }
+        let!(:configuration_with_no_invitations_formats) do
+          create(:configuration, organisation: organisation_with_no_invitations_formats, invitation_formats: [])
+        end
+
+        it "scopes the collection to the organisation" do
+          expect(stat.organisations_sample).to include(organisation)
+          expect(stat.organisations_sample).not_to include(other_organisation)
+        end
+
+        it "scopes the collection to the ones with an active configuration" do
+          expect(stat.organisations_sample).not_to include(organisation_with_no_invitations_formats)
+          expect(stat.organisations_sample).not_to include(organisation_with_no_configuration)
+        end
+      end
+
+      describe "#applicants_sample" do
+        let!(:applicant3) do
+          create(:applicant, organisations: [organisation], deleted_at: date)
+        end
+        let!(:applicant4) do
+          create(:applicant, organisations: [organisation])
+        end
+        let!(:archive) { create(:archive, applicant: applicant4, department: department) }
+        let!(:applicant5) do
+          create(:applicant, organisations: [organisation_with_no_configuration])
+        end
+
+        it "scopes the collection to the organisation" do
+          expect(stat.applicants_sample).to include(applicant1)
+          expect(stat.applicants_sample).not_to include(applicant2)
+        end
+
+        it "does not include the deleted applicants" do
+          expect(stat.applicants_sample).not_to include(applicant3)
+        end
+
+        it "does not include the archived applicants" do
+          expect(stat.applicants_sample).not_to include(applicant4)
+        end
+
+        it "does not include the applicant from irrelevant organisations" do
+          expect(stat.applicants_sample).not_to include(applicant5)
+        end
+      end
+
+      describe "#agents_sample" do
+        let!(:agent3) { create(:agent, organisations: [organisation], has_logged_in: true, email: "a@beta.gouv.fr") }
+        let!(:agent4) { create(:agent, organisations: [organisation], has_logged_in: false) }
+
+        it "scopes the collection to the organisation" do
+          expect(stat.agents_sample).to include(agent1)
+          expect(stat.agents_sample).not_to include(agent2)
+        end
+
+        it "does not include the betagouv agents" do
+          expect(stat.agents_sample).not_to include(agent3)
+        end
+
+        it "does not include the agents who never logged in" do
+          expect(stat.agents_sample).not_to include(agent4)
+        end
+      end
+
+      describe "#rdv_contexts_sample" do
+        let!(:applicant3) { create(:applicant, organisations: [organisation]) }
+        let!(:rdv3) { create(:rdv, organisation: organisation) }
+        let!(:participation3) { create(:participation, rdv: rdv3) }
+        let!(:rdv_context3) { create(:rdv_context, applicant: applicant3, participations: [participation3]) }
+        let!(:applicant4) { create(:applicant, organisations: [organisation]) }
+        let!(:invitation4) { create(:invitation) }
+        let!(:rdv4) { create(:rdv, organisation: organisation) }
+        let!(:participation4) { create(:participation, rdv: rdv4) }
+        let!(:rdv_context4) do
+          create(:rdv_context, applicant: applicant4, invitations: [invitation4], participations: [participation4])
+        end
+        let!(:applicant5) { create(:applicant, organisations: [organisation]) }
+        let!(:invitation5) { create(:invitation) }
+        let!(:rdv_context5) do
+          create(:rdv_context, applicant: applicant5, invitations: [invitation5])
+        end
+        let!(:applicant6) do
+          create(:applicant, organisations: [organisation_with_no_configuration])
+        end
+        let!(:invitation6) { create(:invitation, sent_at: date) }
+        let!(:rdv6) { create(:rdv, organisation: organisation) }
+        let!(:participation6) { create(:participation, rdv: rdv6) }
+        let!(:rdv_context6) do
+          create(:rdv_context, applicant: applicant6, invitations: [invitation6], participations: [participation6])
+        end
+
+        it "scopes the collection to the organisation" do
+          expect(stat.rdv_contexts_sample).to include(rdv_context1)
+          expect(stat.rdv_contexts_sample).not_to include(rdv_context2)
+        end
+
+        it "does not include rdv_contexts with no invitations" do
+          expect(stat.rdv_contexts_sample).not_to include(rdv_context3)
+        end
+
+        it "does not include rdv_contexts with unsent invitations" do
+          expect(stat.rdv_contexts_sample).not_to include(rdv_context4)
+        end
+
+        it "does not include rdv_contexts with no rdvs" do
+          expect(stat.rdv_contexts_sample).not_to include(rdv_context5)
+        end
+
+        it "does not include the rdv_contexts of applicants from irrelevant organisations" do
+          expect(stat.rdv_contexts_sample).not_to include(rdv_context6)
+        end
+      end
+
+      describe "#rdvs_non_collectifs_sample" do
+        let!(:applicant3) do
+          create(:applicant, organisations: [organisation])
+        end
+        let!(:rdv3) { create(:rdv, organisation: organisation, motif: motif_collectif) }
+        let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
+
+        it "does not include collectifs rdvs" do
+          expect(stat.rdvs_non_collectifs_sample).not_to include(rdv3)
+        end
+      end
+
+      describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
+        let!(:applicant3) do
+          create(:applicant, organisations: [organisation_with_no_configuration])
+        end
+        let!(:applicant4) { create(:applicant, organisations: [organisation]) }
+        let!(:applicant5) { create(:applicant, organisations: [organisation]) }
+        let!(:applicant6) { create(:applicant, organisations: [organisation]) }
+        let!(:applicant7) { create(:applicant, organisations: [organisation]) }
+        let!(:invitation3) { create(:invitation, applicant: applicant3, department: department, sent_at: date) }
+        let!(:invitation5) { create(:invitation, applicant: applicant5, department: department) }
+        let!(:invitation6) { create(:invitation, applicant: applicant6, department: department, sent_at: date) }
+        let!(:invitation7) { create(:invitation, applicant: applicant7, department: department, sent_at: date) }
+        let!(:rdv3) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
+        let!(:rdv4) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
+        let!(:rdv5) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
+        let!(:rdv7) { create(:rdv, organisation: organisation, created_by: "user", motif: motif_collectif) }
+        let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
+        let!(:participation4) { create(:participation, rdv: rdv4, applicant: applicant4) }
+        let!(:participation5) { create(:participation, rdv: rdv5, applicant: applicant5) }
+        let!(:participation7) { create(:participation, rdv: rdv7, applicant: applicant7) }
+
+        it "scopes the collection to the organisation" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).to include(applicant1)
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant2)
+        end
+
+        it "does not include the applicant from irrelevant organisations" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant3)
+        end
+
+        it "does not include the applicants whith no invitations" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant4)
+        end
+
+        it "does not include the applicants whith no sent invitation" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant5)
+        end
+
+        it "does not include the applicants whith no rdvs" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant6)
+        end
+
+        it "does not include the applicants whith collectifs rdvs" do
+          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant7)
+        end
+      end
+
+      describe "#applicants_for_30_days_rdvs_seen_sample" do
+        let!(:applicant3) do
+          create(:applicant, organisations: [organisation],
+                             created_at: date)
+        end
+        let!(:rdv_context3) do
+          create(:rdv_context, applicant: applicant3, motif_category: category_rsa_cer_signature)
+        end
+
+        it "scopes the collection to the organisation" do
           expect(stat.applicants_for_30_days_rdvs_seen_sample).to include(applicant1)
           expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant2)
         end

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -1,7 +1,7 @@
 describe Stats::GlobalStats::Compute, type: :service do
   subject { described_class.call(stat: stat) }
 
-  let!(:stat) { create(:stat, department_number: department.number) }
+  let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
 
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department: department) }

--- a/spec/services/stats/global_stats/upsert_stat_spec.rb
+++ b/spec/services/stats/global_stats/upsert_stat_spec.rb
@@ -1,5 +1,5 @@
 describe Stats::GlobalStats::UpsertStat, type: :service do
-  subject { described_class.call(department_number: department.number) }
+  subject { described_class.call(structure_type: structure_type, structure_id: structure_id) }
 
   let!(:department) { create(:department) }
   let!(:stat_attributes) do
@@ -14,7 +14,9 @@ describe Stats::GlobalStats::UpsertStat, type: :service do
       agents_count: 1
     }
   end
-  let!(:stat) { create(:stat, department_number: department.number) }
+  let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
+  let!(:structure_type) { "Department" }
+  let!(:structure_id) { department.id }
 
   describe "#call" do
     before do
@@ -32,10 +34,24 @@ describe Stats::GlobalStats::UpsertStat, type: :service do
       expect(subject.success?).to eq(true)
     end
 
-    it "finds or initializes stat record" do
-      expect(Stat).to receive(:find_or_initialize_by)
-        .with(department_number: department.number)
-      subject
+    context "when department" do
+      it "finds or initializes stat record" do
+        expect(Stat).to receive(:find_or_initialize_by)
+          .with(statable_type: "Department", statable_id: department.id)
+        subject
+      end
+    end
+
+    context "when organisation" do
+      let!(:organisation) { create(:organisation) }
+      let!(:structure_type) { "Organisation" }
+      let!(:structure_id) { organisation.id }
+
+      it "finds or initializes stat record" do
+        expect(Stat).to receive(:find_or_initialize_by)
+          .with(statable_type: "Organisation", statable_id: organisation.id)
+        subject
+      end
     end
 
     it "calls the compute stats service" do

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -1,7 +1,7 @@
 describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
   subject { described_class.call(stat: stat, date: date) }
 
-  let!(:stat) { create(:stat, department_number: department.number) }
+  let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
 
   let(:date) { Time.zone.parse("17/03/2022 12:00") }
   let(:date_from_previous_month) { Time.zone.parse("17/02/2022 12:00") }

--- a/spec/services/stats/monthly_stats/upsert_stat_spec.rb
+++ b/spec/services/stats/monthly_stats/upsert_stat_spec.rb
@@ -1,5 +1,5 @@
 describe Stats::MonthlyStats::UpsertStat, type: :service do
-  subject { described_class.call(department_number: department.number, date_string: date_string) }
+  subject { described_class.call(structure_type: structure_type, structure_id: structure_id, date_string: date_string) }
 
   let!(:department) { create(:department) }
   let!(:date_string) { "2022-03-17 12:00:00 +0100" }
@@ -15,7 +15,9 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
       rate_of_autonomous_applicants_grouped_by_month: 8
     }
   end
-  let!(:stat) { create(:stat, department_number: department.number) }
+  let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
+  let!(:structure_type) { "Department" }
+  let!(:structure_id) { department.id }
 
   describe "#call" do
     before do
@@ -29,10 +31,24 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
       expect(subject.success?).to eq(true)
     end
 
-    it "finds or initializes stat record" do
-      expect(Stat).to receive(:find_or_initialize_by)
-        .with(department_number: department.number)
-      subject
+    context "when department" do
+      it "finds or initializes stat record" do
+        expect(Stat).to receive(:find_or_initialize_by)
+          .with(statable_type: "Department", statable_id: department.id)
+        subject
+      end
+    end
+
+    context "when organisation" do
+      let!(:organisation) { create(:organisation) }
+      let!(:structure_type) { "Organisation" }
+      let!(:structure_id) { organisation.id }
+
+      it "finds or initializes stat record" do
+        expect(Stat).to receive(:find_or_initialize_by)
+          .with(statable_type: "Organisation", statable_id: organisation.id)
+        subject
+      end
     end
 
     it "calls the compute stats service" do


### PR DESCRIPTION
closes #1022 

Dans cette PR, je permets l'affichage de statistiques par organisation.
Afin d'obtenir l'historique mensuel des stats par organisation, je lance les jobs nécessaires dans la migration. J'ai du forcer l'éxecution synchrone de ces jobs car sinon des records multiples étaient créés. `with_advisory_lock`
 ne permettait pas de résoudre le problème. Dans un fonctionnement normal, il n'y aura pas de souci de race condition puisque l'on update les records une seule fois par mois.

<img width="1414" alt="Capture d’écran 2023-08-31 à 16 53 43" src="https://github.com/betagouv/rdv-insertion/assets/46218316/b28ce355-31a0-47f1-a2ca-0d9a8407aabc">
