### PR TITLE
feat(applicants): simpler ordering

### DIFF
--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -242,19 +242,23 @@ class ApplicantsController < ApplicationController
   def set_all_applicants
     @applicants = policy_scope(Applicant)
                   .preload(rdv_contexts: [:invitations])
-                  .active.distinct
+                  .active
+                  .select("DISTINCT(applicants.id), applicants.*")
                   .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
+                  .order(last_organisation_joined_at: :desc)
   end
 
   def set_applicants_for_motif_category
     @applicants = policy_scope(Applicant)
                   .preload(rdv_contexts: [:notifications, :invitations])
-                  .active.distinct
+                  .active
+                  .select("DISTINCT(applicants.id), applicants.*")
                   .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
                   .where.not(id: @department.archived_applicants.ids)
                   .joins(:rdv_contexts)
                   .where(rdv_contexts: { motif_category: @current_motif_category })
                   .where.not(rdv_contexts: { status: "closed" })
+                  .order(last_rdv_context_joined_at: :desc)
   end
 
   def set_archived_applicants

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -26,9 +26,9 @@ class Applicant < ApplicationRecord
   before_validation :generate_uid
   before_save :format_phone_number
 
-  has_and_belongs_to_many :organisations
+  has_and_belongs_to_many :organisations, after_add: :update_last_organisation_joined_at
 
-  has_many :rdv_contexts, dependent: :destroy
+  has_many :rdv_contexts, dependent: :destroy, after_add: :update_last_rdv_context_joined_at
   has_many :invitations, dependent: :destroy
   has_many :participations, dependent: :destroy
   has_many :archives, dependent: :destroy
@@ -153,6 +153,14 @@ class Applicant < ApplicationRecord
     return unless birth_date.present? && (birth_date > Time.zone.today || birth_date < 130.years.ago)
 
     errors.add(:birth_date, "n'est pas valide")
+  end
+
+  def update_last_organisation_joined_at(_organisation)
+    update_columns(last_organisation_joined_at: Time.zone.now)
+  end
+
+  def update_last_rdv_context_joined_at(_rdv_context)
+    update_columns(last_rdv_context_joined_at: Time.zone.now)
   end
 end
 

--- a/db/migrate/20230904122658_add_columns_to_applicants.rb
+++ b/db/migrate/20230904122658_add_columns_to_applicants.rb
@@ -1,0 +1,6 @@
+class AddColumnsToApplicants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applicants, :last_organisation_joined_at, :datetime, default: -> { "now()" }
+    add_column :applicants, :last_rdv_context_joined_at, :datetime, default: -> { "now()" }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_31_090625) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_04_122658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_31_090625) do
     t.string "pole_emploi_id"
     t.string "carnet_de_bord_carnet_id"
     t.integer "created_through", default: 0
+    t.datetime "last_organisation_joined_at", default: -> { "now()" }
+    t.datetime "last_rdv_context_joined_at", default: -> { "now()" }
     t.index ["department_internal_id"], name: "index_applicants_on_department_internal_id"
     t.index ["email"], name: "index_applicants_on_email"
     t.index ["nir"], name: "index_applicants_on_nir"


### PR DESCRIPTION
Dans cette PR j'ai finalement choisi de rajouter 2 colonnes directement dans la table applicants afin de faciliter l'ordering. 
L'idée est simple, dès qu'un RdvContext est créé et dès qu'un applicant est affecté à une organisation on vient simplement actualiser un datetime dans l'applicant. 

De cette façon, l'ordering se fait directement sur la table applicant, ce qui est beaucoup plus performant sans que ce soit pour autant couteux au niveau de la création de donnée (simple update). 

Je pense que cette solution sera pérenne, si jamais on avait trop d'update sur la table applicant je suggérerais créé une table dédiée mais je ne pense pas que ce sera le cas donc le risque de lock la table à cause de ça devrait être à peu près nul. 
