### PR TITLE
fix(previews): Add attribute for letter notifications preview

### DIFF
--- a/app/controllers/previews/notifications_controller.rb
+++ b/app/controllers/previews/notifications_controller.rb
@@ -105,6 +105,7 @@ module Previews
         sender_name: @notification.letter_sender_name,
         direction_names: @notification.direction_names,
         signature_lines: @notification.signature_lines,
+        motif_category: @notification.motif_category,
         organisation: @notification.organisation,
         display_europe_logos: @notification.display_europe_logos,
         display_department_logo: @notification.display_department_logo,

--- a/spec/features/agent_can_preview_messages_contents_spec.rb
+++ b/spec/features/agent_can_preview_messages_contents_spec.rb
@@ -2,7 +2,7 @@ describe "Agents can preview messages contents", js: true do
   include_context "with all existing categories"
 
   let!(:agent) { create(:agent) }
-  let!(:organisation) { create(:organisation) }
+  let!(:organisation) { create(:organisation, department: create(:department, number: "26")) }
   let!(:agent_role) { create(:agent_role, agent:, organisation:, access_level: "admin") }
   let!(:configuration) { create(:configuration, motif_category: category_rsa_orientation, organisation:) }
 


### PR DESCRIPTION
Dans #1267 @Michaelvilleneuve  a ajouté un nouvel attribut à passer pour la génération des courriers de convocations.
Je le rajoute pour pouvoir visualier les previews sans lever de cette erreur dans la Drôme: 
https://sentry.incubateur.net/organizations/betagouv/issues/63392/?project=16&query=is%3Aunresolved&referrer=issue-stream

L'erreur  n'était pas levée dans les tests car on utilise l'attribut `motif_category` que si on est dans la Drôme.