### PR TITLE
fix(preview): Handle non standard template previews

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -39,7 +39,7 @@ class ConfigurationsController < ApplicationController
   end
 
   def update
-    @configuration.assign_attributes(**configuration_params)
+    @configuration.assign_attributes(**formatted_configuration_params)
     if @configuration.save
       flash.now[:success] = "La configuration a été modifiée avec succès"
       redirect_to organisation_configuration_path(@organisation, @configuration)
@@ -58,6 +58,12 @@ class ConfigurationsController < ApplicationController
 
   def configuration_params
     params.require(:configuration).permit(*PERMITTED_PARAMS).to_h.deep_symbolize_keys
+  end
+
+  def formatted_configuration_params
+    configuration_params.to_h do |k, v|
+      [k, k.to_s.include?("override") ? v.presence : v]
+    end
   end
 
   def set_configuration

--- a/app/controllers/previews/base_controller.rb
+++ b/app/controllers/previews/base_controller.rb
@@ -25,10 +25,17 @@ module Previews
     end
 
     def set_and_format_contents
+      set_contents
+      format_contents
+    end
+
+    def set_contents
       set_sms_contents
       set_mail_contents
       set_letter_contents
+    end
 
+    def format_contents
       [@mail_contents, @letter_contents].each do |html_contents|
         unescape_html_contents(html_contents)
         downsize_html_headings(html_contents)

--- a/app/controllers/previews/notifications_controller.rb
+++ b/app/controllers/previews/notifications_controller.rb
@@ -126,7 +126,7 @@ module Previews
       # we sort the array because we want to highlight rdv_title_by_phone before rdv_title because it often contains it
       ::Configuration.template_override_attributes.sort_by(&:length).reverse.map do |attribute|
         @notification.send(attribute.gsub("template_", "").gsub("_override", ""))
-      end
+      end.compact
     end
   end
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,13 +1,18 @@
 class Template < ApplicationRecord
-  validates :model, :rdv_title, :rdv_title_by_phone, :rdv_purpose, :applicant_designation, :rdv_subject,
-            presence: true
+  has_many :motif_categories, dependent: :nullify
+
+  validates :model, :rdv_title, :rdv_title_by_phone, presence: true
+
+  validates :rdv_purpose, :applicant_designation, :rdv_subject, presence: true, if: :standard?
+  validates :rdv_subject, presence: true, if: :atelier?
+  validates :rdv_purpose, presence: true, if: :phone_platform?
 
   validates :display_mandatory_warning, inclusion: [true, false]
 
   enum model: { standard: 0, atelier: 1, phone_platform: 2, short: 3, atelier_enfants_ados: 4 }
 
   def mandatory_warning
-    if display_mandatory_warning && model.include?("phone_platform")
+    if display_mandatory_warning && phone_platform?
       "Cet appel est obligatoire pour le traitement de votre dossier."
     elsif display_mandatory_warning
       "Ce RDV est obligatoire."

--- a/app/views/configurations/messages_contents/_messages_content.html.erb
+++ b/app/views/configurations/messages_contents/_messages_content.html.erb
@@ -3,7 +3,7 @@
     <% Configuration.template_override_attributes.each do |attribute| %>
       <div class="col-12 col-md-6 px-5">
         <h4><%= ::Configuration.human_attribute_name(attribute) %></h4>
-        <p><%= configuration.send(attribute) || template.send(attribute.gsub("template_", "").gsub("_override", "")) %></p>
+        <p><%= configuration.send(attribute) || template.send(attribute.gsub("template_", "").gsub("_override", "")) || tag(:br) %></p>
       </div>
     <% end %>
   </div>
@@ -16,12 +16,14 @@
         <% end  %>
       <% end %>
     </div>
-    <div class="mx-1">
-      <%= link_to previews_notifications_path(configuration_id: configuration.id), data: { turbo_frame: 'remote_modal' } do %>
-        <%= button_tag class: "btn btn-blue" do %>
-          <i class="fas fa-eye"></i> Convocations
-        <% end  %>
-      <% end %>
-    </div>
+    <% if configuration.convene_applicant? %>
+      <div class="mx-1">
+        <%= link_to previews_notifications_path(configuration_id: configuration.id), data: { turbo_frame: 'remote_modal' } do %>
+          <%= button_tag class: "btn btn-blue" do %>
+            <i class="fas fa-eye"></i> Convocations
+          <% end  %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/spec/features/agent_can_preview_messages_contents_spec.rb
+++ b/spec/features/agent_can_preview_messages_contents_spec.rb
@@ -74,4 +74,31 @@ describe "Agents can preview messages contents", js: true do
     expect(page).not_to have_css("span.text-purple", text: "bénéficiaire du RSA")
     expect(page).not_to have_css("span.text-purple", text: "démarrer un parcours d'accompagnement")
   end
+
+  context "when the category does not require all the template variables and has no reminder" do
+    let!(:configuration) { create(:configuration, motif_category: category_rsa_insertion_offer, organisation:) }
+
+    it "still can preview contents" do
+      visit organisation_configuration_path(organisation, configuration)
+
+      expect(page).to have_button("Convocations")
+      expect(page).to have_button("Invitations")
+
+      click_button("Invitations")
+
+      expect(page).to have_css("span.text-purple", text: "bénéficiaire du RSA", wait: 10)
+      expect(page).to have_content("atelier")
+
+      find("button.btn-close").click
+
+      expect(page).to have_button("Convocations")
+      expect(page).to have_button("Invitations")
+
+      click_button("Convocations")
+
+      expect(page).to have_css("span.text-purple", text: "atelier", wait: 10)
+      expect(page).to have_css("span.text-purple", text: "atelier téléphonique")
+      expect(page).to have_css("span.text-purple", text: "bénéficiaire du RSA")
+    end
+  end
 end

--- a/spec/support/motif_categories_helper.rb
+++ b/spec/support/motif_categories_helper.rb
@@ -146,6 +146,8 @@ module MotifCategoriesHelper
         template: create(
           :template,
           model: "atelier",
+          rdv_title: "atelier",
+          rdv_title_by_phone: "atelier téléphonique",
           rdv_subject: "RSA",
           applicant_designation: "bénéficiaire du RSA",
           display_mandatory_warning: false
@@ -161,6 +163,7 @@ module MotifCategoriesHelper
           :template,
           model: "phone_platform",
           rdv_title: "rendez-vous d'orientation téléphonique",
+          rdv_title_by_phone: "rendez-vous d'orientation téléphonique",
           rdv_subject: "RSA",
           applicant_designation: "bénéficiaire du RSA",
           rdv_purpose: "démarrer un parcours d'accompagnement",
@@ -209,6 +212,8 @@ module MotifCategoriesHelper
         template: create(
           :template,
           model: "atelier",
+          rdv_title: "atelier",
+          rdv_title_by_phone: "atelier téléphonique",
           rdv_subject: "RSA",
           applicant_designation: "bénéficiaire du RSA",
           display_mandatory_warning: false
@@ -276,6 +281,7 @@ module MotifCategoriesHelper
           :template,
           model: "short",
           rdv_title: "rendez-vous de suivi psychologue",
+          rdv_title_by_phone: "rendez-vous téléphonique de suivi psychologue",
           display_mandatory_warning: false
         )
       )
@@ -311,6 +317,7 @@ module MotifCategoriesHelper
           :template,
           model: "atelier_enfants_ados",
           rdv_title: "atelier destiné aux jeunes de ton âge",
+          rdv_title_by_phone: "atelier téléphonique destiné aux jeunes de ton âge",
           display_mandatory_warning: false
         )
       )


### PR DESCRIPTION
Dans cette PR je corrige les erreurs soulevés lorsqu'on essaie de prévisualiser les contenus des messages pour des templates non "standard" : 

- https://sentry.incubateur.net/organizations/betagouv/issues/63425/?project=16&query=is%3Aunresolved&referrer=issue-stream
- https://sentry.incubateur.net/organizations/betagouv/issues/63438/?project=16&query=is%3Aunresolved&referrer=issue-stream

J'ai également changé les validations dans le model `template`, en fonction du model on valide la présence des attributs nécessaires.