### PR TITLE
fix(logos): allow upcase for logos

### DIFF
--- a/app/models/concerns/has_logo.rb
+++ b/app/models/concerns/has_logo.rb
@@ -2,10 +2,10 @@ module HasLogo
   delegate :path, to: :logo, prefix: true
 
   def logo
-    Logo.new(logo_name.parameterize)
+    Logo.new(logo_name)
   end
 
   def logo_name
-    respond_to?(:logo_filename) && logo_filename.present? ? logo_filename : name
+    respond_to?(:logo_filename) && logo_filename.present? ? logo_filename : name.parameterize
   end
 end


### PR DESCRIPTION
closes #1329 

Dans cette PR, je permet au système de récupérer le logo correspondant au `logo_filename` en fonction de la string tapée par l'utilisateur : quelque soit la casse ou la graphie du `logo_filename`, le système ira chercher le logo avec ce nom là, sans transformation. La tentative de jonction entre une organisation et son logo se fait malgré tout **toujours** dans un format parameterize (downcase, underscore pour les espaces) : cela reste la convention de nommage à privilégier pour les logos.