### PR TITLE
fix(cron): periodic invites cron when no invitation sent

### DIFF
--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -18,7 +18,7 @@ class SendPeriodicInvitesJob < ApplicationJob
 
   def send_invite(rdv_context)
     last_sent_invitation = rdv_context.last_sent_invitation
-    configuration = last_sent_invitation.current_configuration
+    configuration = last_sent_invitation&.current_configuration
 
     return if configuration.blank?
     return unless should_send_periodic_invite?(last_sent_invitation, configuration)

--- a/spec/jobs/send_periodic_invites_job_spec.rb
+++ b/spec/jobs/send_periodic_invites_job_spec.rb
@@ -64,5 +64,23 @@ describe SendPeriodicInvitesJob do
         subject
       end
     end
+
+    context "when no invitations have been sent" do
+      let!(:invitation) do
+        create(
+          :invitation,
+          rdv_context: rdv_context,
+          sent_at: nil,
+          valid_until: 1.day.from_now,
+          organisations: [organisation]
+        )
+      end
+
+      it "does not send periodic invites" do
+        expect(SendPeriodicInviteJob).not_to receive(:perform_async).with(invitation.id, configuration.id, "email")
+        expect(SendPeriodicInviteJob).not_to receive(:perform_async).with(invitation.id, configuration.id, "sms")
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
Permet de corriger l'erreur suivante qui empêche le job de run correctement : 
https://sentry.incubateur.net/organizations/betagouv/issues/64549/?alert_rule_id=9&alert_timestamp=1694520013213&alert_type=email&environment=production&project=16&referrer=alert_email