### PR TITLE
fix: prevent arg error when some browser send a single tag

### DIFF
--- a/app/controllers/concerns/applicants/filterable.rb
+++ b/app/controllers/concerns/applicants/filterable.rb
@@ -23,7 +23,7 @@ module Applicants::Filterable
                     .select(:applicant_id)
                     .where(tag_id: params[:tag_ids])
                     .group(:applicant_id)
-                    .having("COUNT(DISTINCT tag_id) = ?", params[:tag_ids].count)
+                    .having("COUNT(DISTINCT tag_id) = ?", [params[:tag_ids]].flatten.count)
                     .pluck(:applicant_id)
 
     @applicants = @applicants.where(id: applicant_ids)

--- a/spec/controllers/applicants_controller_spec.rb
+++ b/spec/controllers/applicants_controller_spec.rb
@@ -709,6 +709,19 @@ describe ApplicantsController do
         expect(response.body).to match(/Marie/)
         expect(response.body).not_to match(/Oliva/)
       end
+
+      context "when a single tag is given as string" do
+        let!(:index_params) do
+          { organisation_id: organisation.id, tag_ids: tags[2].id }
+        end
+
+        it "filters by this tag" do
+          get :index, params: index_params
+          expect(response.body).to match(/Oliva/)
+          expect(response.body).not_to match(/Michael/)
+          expect(response.body).not_to match(/Marie/)
+        end
+      end
     end
 
     context "when invitations dates are passed" do


### PR DESCRIPTION
Cette PR permet d'éviter de crash lorsque certains browser envoient un seul tag à filtrer. 
Par défaut les browsers envoient un tableau contenant un seul élément mais il semblerait que Edge n'envoie pas un tableau mais envoie directement l'élément inline. 

Pour régler ça on enveloppe le param dans un tableau que l'on flatten, de cette façon on obtient toujours un tableau