### PR TITLE
feat(emails): change from address for emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "rdv-insertion <contact@rdv-insertion.fr>"
+  default from: "rdv-insertion <support@rdv-insertion.fr>"
   append_view_path Rails.root.join("app/views/mailers")
   layout "mailer"
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 
@@ -247,7 +247,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 
@@ -411,7 +411,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 
@@ -603,7 +603,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 
@@ -791,7 +791,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 
@@ -925,7 +925,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 
@@ -964,7 +964,7 @@ RSpec.describe NotificationMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["someone@gmail.com"])
     end
 

--- a/spec/mailers/reply_transfer_mailer_spec.rb
+++ b/spec/mailers/reply_transfer_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["organisation@departement.fr"])
     end
 
@@ -73,7 +73,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["organisation@departement.fr"])
     end
 
@@ -109,7 +109,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the headers" do
-      expect(mail[:from].to_s).to eq("rdv-insertion <contact@rdv-insertion.fr>")
+      expect(mail[:from].to_s).to eq("rdv-insertion <support@rdv-insertion.fr>")
       expect(mail.to).to eq(["support@rdv-insertion.fr"])
     end
 


### PR DESCRIPTION
closes #1348 
Dans cette PR, je change l'adresse d'envoi par défaut dans l'app de `contact@rdv-insertion.fr` à `support@rdv-insertion.fr`

**Pourquoi fait-on ce changement ?**
Les réponses des utilisateurs sont désormais transférées, dans la mesure du possible, automatiquement aux agents/organisations concernées. Lorsque la jonction entre un mail et une organisation n'est pas possible, le mail est transféré à `support@rdv-insertion.fr`. Mais certains usagers continuent de répondre sans utiliser le champ `reply-to`, qui permet d'orienter correctement la redirection en l'enrichissant d'informations supplémentaires pour faciliter le travail du support. Ce changement d'expéditeur vise à s'assurer que ces mails parviennent tout de même a minima dans la même boite mail (ce qui n'est pas le cas pour `contact@rdv-insertion`, redirigée vers le mail perso d'@aminedhobb 