### PR TITLE
feat(stats): improve autonomous applicants rate computing

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -42,12 +42,8 @@ class Stat < ApplicationRecord
     @rdvs_non_collectifs_sample ||= Rdv.where(motif: Motif.individuel).distinct
   end
 
-  def invited_applicants_with_rdvs_non_collectifs_sample
-    @invited_applicants_with_rdvs_non_collectifs_sample ||=
-      applicants_sample.joins(:rdvs)
-                       .where(rdvs: rdvs_non_collectifs_sample)
-                       .with_sent_invitations
-                       .distinct
+  def invited_applicants_sample
+    @invited_applicants_sample ||= applicants_sample.with_sent_invitations.distinct
   end
 
   # We filter the rdv_contexts to keep those where the applicants were invited and created a rdv/participation

--- a/app/services/stats/compute_rate_of_autonomous_applicants.rb
+++ b/app/services/stats/compute_rate_of_autonomous_applicants.rb
@@ -18,7 +18,7 @@ module Stats
     end
 
     def autonomous_applicants
-      @autonomous_applicants ||= @applicants.joins(:rdvs).where(rdvs: { created_by: "user" })
+      @autonomous_applicants ||= @applicants.joins(:participations).where(participations: { created_by: "user" })
     end
   end
 end

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -58,11 +58,9 @@ module Stats
         ).value
       end
 
-      # as long as the "created_by" is not informed on the participation, we exclude from this calculation
-      # the rdvs that belong to a collectif motif and the applicants that do not have at least one non collectif rdv
       def rate_of_autonomous_applicants
         ComputeRateOfAutonomousApplicants.call(
-          applicants: @stat.invited_applicants_with_rdvs_non_collectifs_sample
+          applicants: @stat.invited_applicants_sample
         ).value
       end
 

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -65,11 +65,9 @@ module Stats
         ).value.round
       end
 
-      # as long as the "created_by" is not informed on the participation, we exclude from this calculation
-      # the rdvs that belong to a collectif motif and the applicants that do not have at least one non collectif rdv
       def rate_of_autonomous_applicants_for_focused_month
         ComputeRateOfAutonomousApplicants.call(
-          applicants: created_during_focused_month(@stat.invited_applicants_with_rdvs_non_collectifs_sample)
+          applicants: created_during_focused_month(@stat.invited_applicants_sample)
         ).value.round
       end
 

--- a/scripts/initialize_no_show_rate_for_stats.rb
+++ b/scripts/initialize_no_show_rate_for_stats.rb
@@ -1,25 +1,38 @@
-Stats::GlobalStats::UpsertStatsJob.perform_async
-
 Stat.find_each do |stat|
-  date = stat.statable.present? ? stat.statable.created_at : Time.zone.parse("15/01/2022 12:00")
-  while date < 1.month.ago
-    rate_for_invitations = stat[:rate_of_no_show_for_invitations_grouped_by_month] || {}
+  stat.rate_of_no_show_for_invitations =
+    Stats::ComputeRateOfNoShow.call(participations: stat.participations_without_notifications_sample).value
+  stat.rate_of_no_show_for_convocations =
+    Stats::ComputeRateOfNoShow.call(participations: stat.participations_with_notifications_sample).value
+
+  date = stat.statable&.created_at || Time.zone.parse("01/01/2022 12:00")
+  stat.rate_of_no_show_for_invitations_grouped_by_month = {}
+  stat.rate_of_no_show_for_convocations_grouped_by_month = {}
+
+  while date < Time.zone.parse("31/08/2023 12:00")
+    rate_for_invitations = stat.rate_of_no_show_for_invitations_grouped_by_month
     rate_for_invitations_for_date =
       Stats::ComputeRateOfNoShow.call(
         participations: stat.participations_without_notifications_sample.where(created_at: date.all_month)
       ).value.round
-    rate_for_invitations.merge!({ date.strftime("%m/%Y") => rate_for_invitations_for_date })
-    stat[:rate_of_no_show_for_invitations_grouped_by_month] = rate_for_invitations
 
-    rate_for_convocations = stat[:rate_of_no_show_for_convocations_grouped_by_month] || {}
+    if rate_for_invitations != {} || rate_for_invitations_for_date != 0
+      rate_for_invitations.merge!({ date.strftime("%m/%Y") => rate_for_invitations_for_date })
+      stat.rate_of_no_show_for_invitations_grouped_by_month = rate_for_invitations
+    end
+
+    rate_for_convocations = stat.rate_of_no_show_for_convocations_grouped_by_month
     rate_for_convocations_for_date =
       Stats::ComputeRateOfNoShow.call(
         participations: stat.participations_with_notifications_sample.where(created_at: date.all_month)
       ).value.round
-    rate_for_convocations.merge!({ date.strftime("%m/%Y") => rate_for_convocations_for_date })
-    stat[:rate_of_no_show_for_convocations_grouped_by_month] = rate_for_convocations
+
+    if rate_for_convocations != {} || rate_for_convocations_for_date != 0
+      rate_for_convocations.merge!({ date.strftime("%m/%Y") => rate_for_convocations_for_date })
+      stat.rate_of_no_show_for_convocations_grouped_by_month = rate_for_convocations
+    end
 
     date += 1.month
   end
+
   stat.save!
 end

--- a/scripts/recompute_autonomous_stats.rb
+++ b/scripts/recompute_autonomous_stats.rb
@@ -1,0 +1,25 @@
+Stat.find_each do |stat|
+  stat.rate_of_autonomous_applicants =
+    Stats::ComputeRateOfAutonomousApplicants.call(applicants: stat.invited_applicants_sample).value
+
+  date = stat.statable&.created_at || Time.zone.parse("01/01/2022 12:00")
+  stat.rate_of_autonomous_applicants_grouped_by_month = {}
+
+  while date < Time.zone.parse("31/08/2023 12:00")
+    autonomous_rate = stat.rate_of_autonomous_applicants_grouped_by_month
+    autonomous_rate_for_date =
+      Stats::ComputeRateOfAutonomousApplicants.call(
+        applicants: stat.invited_applicants_sample.where(created_at: date.all_month)
+      ).value.round
+
+    # We don't want to start the hash until we have a value
+    if autonomous_rate != {} || autonomous_rate_for_date != 0
+      autonomous_rate.merge!({ date.strftime("%m/%Y") => autonomous_rate_for_date })
+      stat.rate_of_autonomous_applicants_grouped_by_month = autonomous_rate
+    end
+
+    date += 1.month
+  end
+
+  stat.save!
+end

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -504,7 +504,7 @@ describe Stat do
         end
 
         it "includes the applicants whith no rdvs" do
-          expect(stat.invited_applicants_sample).not_to include(applicant6)
+          expect(stat.invited_applicants_sample).to include(applicant6)
         end
       end
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -233,50 +233,42 @@ describe Stat do
         end
       end
 
-      describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
+      describe "#invited_applicants_sample" do
         let!(:applicant3) do
           create(:applicant, organisations: [organisation_with_no_configuration])
         end
         let!(:applicant4) { create(:applicant, organisations: [organisation]) }
         let!(:applicant5) { create(:applicant, organisations: [organisation]) }
         let!(:applicant6) { create(:applicant, organisations: [organisation]) }
-        let!(:applicant7) { create(:applicant, organisations: [organisation]) }
         let!(:invitation3) { create(:invitation, applicant: applicant3, department: department, sent_at: date) }
         let!(:invitation5) { create(:invitation, applicant: applicant5, department: department) }
         let!(:invitation6) { create(:invitation, applicant: applicant6, department: department, sent_at: date) }
-        let!(:invitation7) { create(:invitation, applicant: applicant7, department: department, sent_at: date) }
         let!(:rdv3) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
         let!(:rdv4) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
         let!(:rdv5) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
-        let!(:rdv7) { create(:rdv, organisation: organisation, created_by: "user", motif: motif_collectif) }
         let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
         let!(:participation4) { create(:participation, rdv: rdv4, applicant: applicant4) }
         let!(:participation5) { create(:participation, rdv: rdv5, applicant: applicant5) }
-        let!(:participation7) { create(:participation, rdv: rdv7, applicant: applicant7) }
 
         it "scopes the collection to the department" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).to include(applicant1)
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant2)
+          expect(stat.invited_applicants_sample).to include(applicant1)
+          expect(stat.invited_applicants_sample).not_to include(applicant2)
         end
 
         it "does not include the applicant from irrelevant organisations" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant3)
+          expect(stat.invited_applicants_sample).not_to include(applicant3)
         end
 
         it "does not include the applicants whith no invitations" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant4)
+          expect(stat.invited_applicants_sample).not_to include(applicant4)
         end
 
         it "does not include the applicants whith no sent invitation" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant5)
+          expect(stat.invited_applicants_sample).not_to include(applicant5)
         end
 
-        it "does not include the applicants whith no rdvs" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant6)
-        end
-
-        it "does not include the applicants whith collectifs rdvs" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant7)
+        it "includes the invited applicants whith no rdvs" do
+          expect(stat.invited_applicants_sample).to include(applicant6)
         end
       end
 
@@ -477,50 +469,42 @@ describe Stat do
         end
       end
 
-      describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
+      describe "#invited_applicants_sample" do
         let!(:applicant3) do
           create(:applicant, organisations: [organisation_with_no_configuration])
         end
         let!(:applicant4) { create(:applicant, organisations: [organisation]) }
         let!(:applicant5) { create(:applicant, organisations: [organisation]) }
         let!(:applicant6) { create(:applicant, organisations: [organisation]) }
-        let!(:applicant7) { create(:applicant, organisations: [organisation]) }
         let!(:invitation3) { create(:invitation, applicant: applicant3, department: department, sent_at: date) }
         let!(:invitation5) { create(:invitation, applicant: applicant5, department: department) }
         let!(:invitation6) { create(:invitation, applicant: applicant6, department: department, sent_at: date) }
-        let!(:invitation7) { create(:invitation, applicant: applicant7, department: department, sent_at: date) }
         let!(:rdv3) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
         let!(:rdv4) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
         let!(:rdv5) { create(:rdv, organisation: organisation, created_by: "user", motif: motif) }
-        let!(:rdv7) { create(:rdv, organisation: organisation, created_by: "user", motif: motif_collectif) }
         let!(:participation3) { create(:participation, rdv: rdv3, applicant: applicant3) }
         let!(:participation4) { create(:participation, rdv: rdv4, applicant: applicant4) }
         let!(:participation5) { create(:participation, rdv: rdv5, applicant: applicant5) }
-        let!(:participation7) { create(:participation, rdv: rdv7, applicant: applicant7) }
 
         it "scopes the collection to the organisation" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).to include(applicant1)
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant2)
+          expect(stat.invited_applicants_sample).to include(applicant1)
+          expect(stat.invited_applicants_sample).not_to include(applicant2)
         end
 
         it "does not include the applicant from irrelevant organisations" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant3)
+          expect(stat.invited_applicants_sample).not_to include(applicant3)
         end
 
         it "does not include the applicants whith no invitations" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant4)
+          expect(stat.invited_applicants_sample).not_to include(applicant4)
         end
 
         it "does not include the applicants whith no sent invitation" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant5)
+          expect(stat.invited_applicants_sample).not_to include(applicant5)
         end
 
-        it "does not include the applicants whith no rdvs" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant6)
-        end
-
-        it "does not include the applicants whith collectifs rdvs" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).not_to include(applicant7)
+        it "includes the applicants whith no rdvs" do
+          expect(stat.invited_applicants_sample).not_to include(applicant6)
         end
       end
 
@@ -602,9 +586,9 @@ describe Stat do
         end
       end
 
-      describe "#invited_applicants_with_rdvs_non_collectifs_sample" do
+      describe "#invited_applicants_sample" do
         it "does not scope the collection to the department" do
-          expect(stat.invited_applicants_with_rdvs_non_collectifs_sample).to include(applicant2)
+          expect(stat.invited_applicants_sample).to include(applicant2)
         end
       end
 

--- a/spec/services/stats/compute_rate_of_autonomous_applicants_spec.rb
+++ b/spec/services/stats/compute_rate_of_autonomous_applicants_spec.rb
@@ -28,15 +28,16 @@ describe Stats::ComputeRateOfAutonomousApplicants, type: :service do
     create(:participation, rdv_context: rdv_context2, applicant: applicant2, rdv: rdv2, created_at: date)
   end
 
-  # Third applicant : created 1 month ago, has a rdv taken in autonomy
+  # Third applicant : created 1 month ago, has a participation to a rdv taken in autonomy
   let!(:applicant3) { create(:applicant, created_at: date) }
   let!(:invitation3) do
     create(:invitation, created_at: date, sent_at: date, rdv_context: rdv_context3, applicant: applicant3)
   end
   let!(:rdv_context3) { create(:rdv_context, created_at: date, applicant: applicant3) }
-  let!(:rdv3) { create(:rdv, created_at: date, created_by: "user") }
+  let!(:rdv3) { create(:rdv, created_at: date, created_by: "agent") }
   let!(:participation3) do
-    create(:participation, rdv_context: rdv_context3, applicant: applicant3, rdv: rdv3, created_at: date)
+    create(:participation, rdv_context: rdv_context3, applicant: applicant3,
+                           rdv: rdv3, created_at: date, created_by: "user")
   end
 
   # Fourth applicant : created 1 month ago, has been invited but has not take any rdv
@@ -58,7 +59,7 @@ describe Stats::ComputeRateOfAutonomousApplicants, type: :service do
     end
 
     # Applicant 1 and 3 are ok ; 2 and 5 are not ok ; 4 is not considered
-    it "computes the percentage of invited applicants with at least on rdv taken in autonomy" do
+    it "computes the percentage of invited applicants with at least on participation to rdv taken in autonomy" do
       expect(result.value).to eq(50)
     end
   end

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -36,7 +36,7 @@ describe Stats::GlobalStats::Compute, type: :service do
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
+      allow(stat).to receive(:invited_applicants_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:agents_sample)
         .and_return(Agent.where(id: [agent]))
@@ -126,7 +126,7 @@ describe Stats::GlobalStats::Compute, type: :service do
     end
 
     it "computes the percentage of invited applicants with at least on rdv taken in autonomy" do
-      expect(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
+      expect(stat).to receive(:invited_applicants_sample)
       expect(Stats::ComputeRateOfAutonomousApplicants).to receive(:call)
         .with(applicants: [applicant1, applicant2])
       subject

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -42,7 +42,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
+      allow(stat).to receive(:invited_applicants_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(Stats::ComputeRateOfNoShow).to receive(:call)
         .and_return(OpenStruct.new(success?: true, value: 50.0))
@@ -129,7 +129,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
     end
 
     it "computes the percentage of invited applicants with at least on rdv taken in autonomy" do
-      expect(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
+      expect(stat).to receive(:invited_applicants_sample)
       expect(Stats::ComputeRateOfAutonomousApplicants).to receive(:call)
         .with(applicants: [applicant1])
       subject


### PR DESCRIPTION
closes #1352 

Dans cette PR, je change la façon dont nous calculons le pourcentage de rendez-vous pris en autonomie. Notre précédente méthode de calcul était très imparfaite car les `participations` ne portaient pas encore l'information `created_by`, nécessaire pour bien calculer cette stat pour les rendez-vous collectif. Cette PR corrige ce souci.

Il faudra lancer le script `recompute_autonomous_stats` après déploiement pour recalculer cette stat.
N.B. : pas le scope de cette PR mais j'en profite pour commit un script plus propre pour `initialize_no_show_rate_for_stats` (évitant notamment de lancer le gros job de calcul de stats globales) ; je ferai ensuite une PR pour le supprimer, mais ça nous permet de garder une trace d'un script "propre" au cas où on le cherche plus tard.