### PR TITLE
feat(stats): add rate of applicants oriented stat

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -70,6 +70,10 @@ class Applicant < ApplicationRecord
     first_seen_rdv_starts_at.to_datetime.mjd - created_at.to_datetime.mjd
   end
 
+  def oriented_in_the_app?
+    participations.any? { |participation| participation.motif_category.orientation? && participation.seen? }
+  end
+
   def participation_for(rdv)
     participations.to_a.find { |participation| participation.rdv_id == rdv.id }
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -7,6 +7,7 @@ class Invitation < ApplicationRecord
   belongs_to :applicant
   belongs_to :department
   belongs_to :rdv_context
+  has_many :participations, through: :rdv_context
   has_and_belongs_to_many :organisations
   has_many :configurations, through: :organisations
 

--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -1,6 +1,22 @@
 class MotifCategory < ApplicationRecord
   include MotifCategory::Sortable
 
+  ORIENTATION_CATEGORIES_SHORT_NAMES = %w[
+    rsa_orientation
+    rsa_orientation_on_phone_platform
+    rsa_atelier_collectif_mandatory
+    rsa_spie
+    rsa_integration_information
+    rsa_orientation_coaching
+    rsa_orientation_freelance
+    rsa_orientation_france_travail
+    rsa_orientation_file_active
+    rsa_droits_devoirs
+    rsa_accompagnement
+    rsa_accompagnement_social
+    rsa_accompagnement_sociopro
+  ].freeze
+
   has_many :configurations, dependent: :restrict_with_exception
   has_many :rdv_contexts, dependent: :restrict_with_exception
   has_many :motifs, dependent: :restrict_with_exception
@@ -16,6 +32,10 @@ class MotifCategory < ApplicationRecord
   scope :participation_optional, lambda { |participation_optional = true|
     where(participation_optional: participation_optional)
   }
+
+  def orientation?
+    ORIENTATION_CATEGORIES_SHORT_NAMES.include?(short_name)
+  end
 
   def as_json(...) = super.deep_symbolize_keys.except(:rdv_solidarites_motif_category_id)
 end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -93,18 +93,25 @@ class Stat < ApplicationRecord
                                                .where.not(configurations: { invitation_formats: [] })
   end
 
-  # For the rate of applicants with rdv seen in less than 30 days
-  # we only consider specific contexts to focus on the first RSA rdv
-  def applicants_for_30_days_rdvs_seen_sample
-    # Applicants invited in an orientation or accompagnement context
-    @applicants_for_30_days_rdvs_seen_sample ||=
+  # We only consider specific contexts to focus on the first RSA rdv
+  def applicants_for_orientation_stats_sample
+    @applicants_for_orientation_stats_sample ||=
       applicants_sample.joins(:rdv_contexts)
                        .where(rdv_contexts:
                                 RdvContext.joins(:motif_category).where(
-                                  motif_category: { short_name: %w[
-                                    rsa_orientation rsa_orientation_on_phone_platform rsa_accompagnement
-                                    rsa_accompagnement_social rsa_accompagnement_sociopro
-                                  ] }
+                                  motif_category: { short_name: MotifCategory::ORIENTATION_CATEGORIES_SHORT_NAMES }
                                 ))
+  end
+
+  def invitations_on_an_orientation_category_during_a_month_sample(date)
+    @invitations_on_an_orientation_category_during_a_month_sample ||=
+      Invitation.preload(:rdv_context, :participations)
+                .where(sent_at: date.all_month)
+                .joins(:rdv_context).where(
+                  rdv_contexts:
+                    RdvContext.joins(:motif_category).where(
+                      motif_category: { short_name: MotifCategory::ORIENTATION_CATEGORIES_SHORT_NAMES }
+                    )
+                )
   end
 end

--- a/app/services/stats/compute_rate_of_applicants_oriented.rb
+++ b/app/services/stats/compute_rate_of_applicants_oriented.rb
@@ -1,0 +1,19 @@
+module Stats
+  class ComputeRateOfApplicantsOriented < BaseService
+    def initialize(applicants:)
+      @applicants = applicants
+    end
+
+    def call
+      result.value = compute_rate_of_applicants_oriented
+    end
+
+    private
+
+    def compute_rate_of_applicants_oriented
+      (@applicants.select(&:oriented_in_the_app?).count / (
+        @applicants.count.nonzero? || 1
+      ).to_f) * 100
+    end
+  end
+end

--- a/app/services/stats/compute_rate_of_applicants_oriented_on_an_invitation_sample.rb
+++ b/app/services/stats/compute_rate_of_applicants_oriented_on_an_invitation_sample.rb
@@ -1,0 +1,37 @@
+module Stats
+  class ComputeRateOfApplicantsOrientedOnAnInvitationSample < BaseService
+    def initialize(invitations:)
+      @invitations = invitations
+    end
+
+    def call
+      result.value = compute_rate_of_applicants_oriented_on_an_invitation_sample
+    end
+
+    private
+
+    def compute_rate_of_applicants_oriented_on_an_invitation_sample
+      (applicants_oriented.count / (
+        applicants.count.nonzero? || 1
+      ).to_f) * 100
+    end
+
+    def invitations_that_led_to_an_orientation
+      @invitations.select do |invitation|
+        invitation_date = invitation.created_at
+        invitation.participations.any? do |participation|
+          participation.created_at > invitation_date
+        end
+      end
+    end
+
+    def applicants_oriented
+      @applicants_oriented ||=
+        Applicant.joins(:invitations).where(invitations: invitations_that_led_to_an_orientation).distinct
+    end
+
+    def applicants
+      @applicants ||= Applicant.joins(:invitations).where(invitations: @invitations).distinct
+    end
+  end
+end

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -21,6 +21,7 @@ module Stats
           average_time_between_invitation_and_rdv_in_days: average_time_between_invitation_and_rdv_in_days,
           rate_of_applicants_with_rdv_seen_in_less_than_30_days:
             rate_of_applicants_with_rdv_seen_in_less_than_30_days,
+          rate_of_applicants_oriented: rate_of_applicants_oriented,
           rate_of_autonomous_applicants: rate_of_autonomous_applicants,
           agents_count: agents_count
         }
@@ -54,7 +55,13 @@ module Stats
 
       def rate_of_applicants_with_rdv_seen_in_less_than_30_days
         ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays.call(
-          applicants: @stat.applicants_for_30_days_rdvs_seen_sample
+          applicants: @stat.applicants_for_orientation_stats_sample
+        ).value
+      end
+
+      def rate_of_applicants_oriented
+        ComputeRateOfApplicantsOriented.call(
+          applicants: @stat.applicants_for_orientation_stats_sample
         ).value
       end
 

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -23,6 +23,7 @@ module Stats
             average_time_between_invitation_and_rdv_in_days_for_focused_month,
           rate_of_applicants_with_rdv_seen_in_less_than_30_days_by_month:
             rate_of_applicants_with_rdv_seen_in_less_than_30_days_for_focused_month,
+          rate_of_applicants_oriented_grouped_by_month: rate_of_applicants_oriented_for_focused_month,
           rate_of_autonomous_applicants_grouped_by_month:
             rate_of_autonomous_applicants_for_focused_month
         }
@@ -61,7 +62,13 @@ module Stats
       def rate_of_applicants_with_rdv_seen_in_less_than_30_days_for_focused_month
         ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays.call(
           # we compute the applicants of the previous month because we want at least 30 days old applicants
-          applicants: @stat.applicants_for_30_days_rdvs_seen_sample.where(created_at: (@date - 1.month).all_month)
+          applicants: @stat.applicants_for_orientation_stats_sample.where(created_at: (@date - 1.month).all_month)
+        ).value.round
+      end
+
+      def rate_of_applicants_oriented_for_focused_month
+        ComputeRateOfApplicantsOrientedOnAnInvitationSample.call(
+          invitations: @stat.invitations_on_an_orientation_category_during_a_month_sample(@date)
         ).value.round
       end
 

--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -49,6 +49,13 @@
         <%= line_chart @stat.rate_of_applicants_with_rdv_seen_in_less_than_30_days_by_month, title: "Taux rdv en - de 30 jours par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
+    <div class="row d-flex justify-content-center flex-wrap-reverse">
+      <div class="col-12 col-md-6 px-5 pb-5">
+        <p class="highlight-stat big margin-left"><%= @stat.rate_of_applicants_oriented.round %> %</p>
+        <p class="highlight-stat margin-left">de bénéficiaires ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
+        <%= line_chart @stat.rate_of_applicants_oriented_grouped_by_month, title: "Taux de bénéficiaires orientés via l'outil", suffix: "%", colors: ["#083b66"] %>
+      </div>
+    </div>
     <div class="row d-flex justify-content-center flex-wrap">
       <div class="col-12 col-md-6 px-5 pb-5 d-flex flex-column justify-content-center align-items-center">
         <p class="highlight-stat big margin-left"><%= @stat.agents_count %> agents</p>

--- a/db/migrate/20230913182842_add_rate_of_applicants_oriented_to_stats.rb
+++ b/db/migrate/20230913182842_add_rate_of_applicants_oriented_to_stats.rb
@@ -1,0 +1,6 @@
+class AddRateOfApplicantsOrientedToStats < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stats, :rate_of_applicants_oriented, :float
+    add_column :stats, :rate_of_applicants_oriented_grouped_by_month, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_04_144823) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_13_182842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -356,6 +356,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_04_144823) do
     t.json "rate_of_no_show_for_convocations_grouped_by_month"
     t.float "rate_of_no_show_for_invitations"
     t.json "rate_of_no_show_for_invitations_grouped_by_month"
+    t.float "rate_of_applicants_oriented"
+    t.json "rate_of_applicants_oriented_grouped_by_month"
     t.index ["statable_type", "statable_id"], name: "index_stats_on_statable"
   end
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -280,7 +280,7 @@ describe Stat do
         end
       end
 
-      describe "#applicants_for_30_days_rdvs_seen_sample" do
+      describe "#applicants_for_orientation_stats_sample" do
         let!(:applicant3) do
           create(:applicant, organisations: [organisation],
                              created_at: date)
@@ -290,12 +290,12 @@ describe Stat do
         end
 
         it "scopes the collection to the department" do
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).to include(applicant1)
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant2)
+          expect(stat.applicants_for_orientation_stats_sample).to include(applicant1)
+          expect(stat.applicants_for_orientation_stats_sample).not_to include(applicant2)
         end
 
         it "does not include the applicants with no motif category for a first rdv RSA" do
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant3)
+          expect(stat.applicants_for_orientation_stats_sample).not_to include(applicant3)
         end
       end
     end
@@ -524,7 +524,7 @@ describe Stat do
         end
       end
 
-      describe "#applicants_for_30_days_rdvs_seen_sample" do
+      describe "#applicants_for_orientation_stats_sample" do
         let!(:applicant3) do
           create(:applicant, organisations: [organisation],
                              created_at: date)
@@ -534,12 +534,12 @@ describe Stat do
         end
 
         it "scopes the collection to the organisation" do
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).to include(applicant1)
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant2)
+          expect(stat.applicants_for_orientation_stats_sample).to include(applicant1)
+          expect(stat.applicants_for_orientation_stats_sample).not_to include(applicant2)
         end
 
         it "does not include the applicants with no motif category for a first rdv RSA" do
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).not_to include(applicant3)
+          expect(stat.applicants_for_orientation_stats_sample).not_to include(applicant3)
         end
       end
     end
@@ -608,9 +608,9 @@ describe Stat do
         end
       end
 
-      describe "#applicants_for_30_days_rdvs_seen_sample" do
+      describe "#applicants_for_orientation_stats_sample" do
         it "does not scope the collection to the department" do
-          expect(stat.applicants_for_30_days_rdvs_seen_sample).to include(applicant2)
+          expect(stat.applicants_for_orientation_stats_sample).to include(applicant2)
         end
       end
     end

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -34,7 +34,7 @@ describe Stats::GlobalStats::Compute, type: :service do
         .and_return(RdvContext.where(id: [rdv_context1, rdv_context2]))
       allow(stat).to receive(:applicants_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
+      allow(stat).to receive(:applicants_for_orientation_stats_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
@@ -119,7 +119,7 @@ describe Stats::GlobalStats::Compute, type: :service do
     end
 
     it "computes the percentage of applicants with rdv seen in less than 30 days" do
-      expect(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
+      expect(stat).to receive(:applicants_for_orientation_stats_sample)
       expect(Stats::ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays).to receive(:call)
         .with(applicants: [applicant1, applicant2])
       subject

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -40,7 +40,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
         .and_return(RdvContext.where(id: [rdv_context1, rdv_context2]))
       allow(stat).to receive(:applicants_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
-      allow(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
+      allow(stat).to receive(:applicants_for_orientation_stats_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
       allow(stat).to receive(:invited_applicants_with_rdvs_non_collectifs_sample)
         .and_return(Applicant.where(id: [applicant1, applicant2]))
@@ -122,7 +122,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
     end
 
     it "computes the percentage of applicants with rdv seen in less than 30 days" do
-      expect(stat).to receive(:applicants_for_30_days_rdvs_seen_sample)
+      expect(stat).to receive(:applicants_for_orientation_stats_sample)
       expect(Stats::ComputeRateOfApplicantsWithRdvSeenInLessThanThirtyDays).to receive(:call)
         .with(applicants: [applicant2])
       subject


### PR DESCRIPTION
closes #1178 
- il manque des tests
- j'ai un problème de N+1 pour le service `ComputeRateOfApplicantsOriented` (je n'arrive pas à préloader correctement le rdv_context et la motif_category liés à chaque participation)
- il manque le script qui permettra de calculer rétroactivement mois par mois
- il y a deux services différents pour le mois par mois et le global car le mois par moi oblige à itérer sur des invitations, ce qui au global ferait des itérations encore plus énorme que d'itérer sur des applicants/rdv_contexts, et en plus on a pas besoin d'autant de précision au global