### PR TITLE
fix: dropdown css menu broken

### DIFF
--- a/app/javascript/react/components/UserBatchActions.jsx
+++ b/app/javascript/react/components/UserBatchActions.jsx
@@ -34,7 +34,7 @@ export default observer(({ users, isDepartmentLevel }) => {
 
   return (
     users.list.some((user) => user.selected) && (
-      <div style={{ marginRight: 20 }}>
+      <div style={{ marginRight: 20, position: "relative" }}>
         <button type="button" className="btn btn-primary dropdown-toggle" onClick={toggle}>
           Actions pour toute la sélection
         </button>


### PR DESCRIPTION
L'ajout d'un top: 40px sur le composant partagé de dropdown a pété cette vue car le composant parent n'était pas en relatif. Le top: 40 était donc relatif à l'écran donc le menu partait en haut de l'écran. 
