### PR TITLE
fix(upload): prevent updating before creating

### DIFF
--- a/app/javascript/lib/retrieveContactPhoneNumber.js
+++ b/app/javascript/lib/retrieveContactPhoneNumber.js
@@ -1,6 +1,6 @@
 const retrieveContactPhoneNumber = (userContactsData) => {
-  const phoneNumber = userContactsData["NUMERO TELEPHONE DOSSIER"];
-  const phoneNumber2 = userContactsData["NUMERO TELEPHONE 2 DOSSIER"];
+  const phoneNumber = userContactsData["NUMERO TELEPHONE DOSSIER"]?.replace(/\s+/g, "");
+  const phoneNumber2 = userContactsData["NUMERO TELEPHONE 2 DOSSIER"]?.replace(/\s+/g, "");
   // We want to retrieve a mobile number if possible, but if there is none, we prefer retrieving a number rather than nothing
   if (phoneNumber?.startsWith("06") || phoneNumber?.startsWith("07")) {
     return phoneNumber;

--- a/app/javascript/react/components/User.jsx
+++ b/app/javascript/react/components/User.jsx
@@ -123,7 +123,7 @@ function User({ user, isDepartmentLevel, showCarnetColumn, showReferentColumn })
 
       {/* Contact infos extra line. It appears if the user contacts data when uploading the contacts file are different from the ones in DB */}
 
-      {(user.phoneNumberNew || user.emailNew || user.rightsOpeningDateNew) && (
+      {(user.id && (user.phoneNumberNew || user.emailNew || user.rightsOpeningDateNew)) && (
         <ContactInfosExtraLine user={user} invitationsColspan={computeInvitationsColspan()} />
       )}
     </>

--- a/app/javascript/react/components/User.jsx
+++ b/app/javascript/react/components/User.jsx
@@ -123,7 +123,7 @@ function User({ user, isDepartmentLevel, showCarnetColumn, showReferentColumn })
 
       {/* Contact infos extra line. It appears if the user contacts data when uploading the contacts file are different from the ones in DB */}
 
-      {(user.id && (user.phoneNumberNew || user.emailNew || user.rightsOpeningDateNew)) && (
+      {(user.belongsToCurrentOrg() && (user.phoneNumberNew || user.emailNew || user.rightsOpeningDateNew)) && (
         <ContactInfosExtraLine user={user} invitationsColspan={computeInvitationsColspan()} />
       )}
     </>

--- a/app/javascript/react/components/user/ContactInfosExtraLine.jsx
+++ b/app/javascript/react/components/user/ContactInfosExtraLine.jsx
@@ -32,8 +32,9 @@ export default observer(({ user, invitationsColspan }) => {
     user.triggers[`${attribute}Update`] = false;
   };
 
+  // We need to add 1 to the colSpan offset because of the multiple selection checkbox
   const colSpanForContactsUpdate =
-    user.displayedAttributes().length - user.attributesFromContactsDataFile().length;
+    user.displayedAttributes().length - user.attributesFromContactsDataFile().length + 1;
 
   return (
     <tr className="table-success">

--- a/app/javascript/react/lib/parseContactsData.js
+++ b/app/javascript/react/lib/parseContactsData.js
@@ -2,7 +2,7 @@ import retrieveContactPhoneNumber from "../../lib/retrieveContactPhoneNumber";
 
 const parseContactsData = async (userContactsData) => {
   const phoneNumber = retrieveContactPhoneNumber(userContactsData);
-  const email = userContactsData["ADRESSE ELECTRONIQUE DOSSIER"];
+  const email = userContactsData["ADRESSE ELECTRONIQUE DOSSIER"]?.replace(/\s+/g, "")?.toLowerCase();
   const rightsOpeningDate = userContactsData["DATE DEBUT DROITS - DEVOIRS"];
 
   return { phoneNumber, email, rightsOpeningDate };

--- a/spec/features/agent_can_update_contacts_info_spec.rb
+++ b/spec/features/agent_can_update_contacts_info_spec.rb
@@ -126,5 +126,33 @@ describe "Agents can update contact info with caf file", js: true do
       expect(user.reload.email).to eq("hernan.crespo@hotmail.fr")
       expect(user.reload.phone_number).to eq("+33698943255")
     end
+
+    context "when user does not belong to the organisation" do
+      let!(:other_organisation) do
+        create(:organisation, agents: [agent], department: department, rdv_solidarites_organisation_id: "1123")
+      end
+
+      let!(:user) do
+        create(
+          :user,
+          first_name: "Hernan", last_name: "Crespo", email: "hernan@crespo.com", phone_number: "0620022002",
+          affiliation_number: "ISQCJQO", organisations: [other_organisation], rdv_solidarites_user_id:
+        )
+      end
+
+      it "does not show the update button" do
+        visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
+
+        attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+
+        expect(page).to have_content("hernan@crespo.com")
+        expect(page).to have_content("Ajouter à cette organisation")
+        click_button("Enrichir avec des données de contacts CNAF")
+
+        attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
+
+        expect(page).not_to have_content("Nouvelles données trouvées pour Hernan Crespo")
+      end
+    end
   end
 end


### PR DESCRIPTION
Cette PR empêche la possibilité de mettre à jour des données d'un usager alors que celui-ci n'est pas affecté à la même organisation.  
Elle permet aussi de diminuer la fréquence d'affichage du bouton de mise à jour en ne prenant pas en compte les différences de casse sur l'email

Corrige https://github.com/betagouv/rdv-insertion/issues/1342
Corrige aussi https://github.com/betagouv/rdv-insertion/issues/1204