### PR TITLE
fix(exports): remove n+1 queries in csv exports

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -159,7 +159,7 @@ class UsersController < ApplicationController
       if department_level?
         set_organisation_at_department_level
       else
-        policy_scope(Organisation).preload(configurations: [:motif_categories]).find(params[:organisation_id])
+        policy_scope(Organisation).preload(configurations: [:motif_category]).find(params[:organisation_id])
       end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -96,9 +96,7 @@ class UsersController < ApplicationController
 
   def generate_users_csv
     @generate_users_csv ||= Exporters::GenerateUsersCsv.call(
-      users: @users.preload(:invitations, :notifications, :archives, :organisations, :tags, :referents, :notifications,
-                            :participations, rdvs: [:motif, :participations, :users])
-                   .preload(rdv_contexts: [rdvs: [:motif, :participations, :users]]),
+      users: @users,
       structure: department_level? ? @department : @organisation,
       motif_category: @current_motif_category
     )

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -18,7 +18,10 @@ module Exporters
 
     def generate_csv
       csv = CSV.generate(write_headers: true, col_sep: ";", headers: headers, encoding: "utf-8") do |row|
-        @users.each do |user|
+        @users.preload(:invitations, :notifications, :archives, :organisations, :tags, :referents, :notifications,
+                       :participations, rdvs: [:motif, :participations, :users])
+              .preload(rdv_contexts: [rdvs: [:motif, :participations, :users]])
+              .each do |user|
           row << user_csv_row(user)
         end
       end

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -18,7 +18,7 @@ module Exporters
 
     def generate_csv
       csv = CSV.generate(write_headers: true, col_sep: ";", headers: headers, encoding: "utf-8") do |row|
-        @users.preload(:organisations, :rdvs, :tags, rdv_contexts: [:invitations]).each do |user|
+        @users.each do |user|
           row << user_csv_row(user)
         end
       end


### PR DESCRIPTION
La Manche a un "Application timeout" lorsqu'elle tente de charger un export csv. Il y avait en effet des n+1 au moment de la création du fichier, cette PR résout ce problème. Je bouge également le `preload` dans le controller, ce qui me paraît plus logique que dans le service.

N.B : Je pense qu'il faudrait qu'on se penche sur les ressources chargées non seulement pour la génération du csv mais également lorsque les pages index commencent à avoir de grandes collections de `users`. La Manche a par exemple à date 213 pages de users, ce qui rend le chargement de la page pas très rapide. On pourrait peut-être optimiser ça.