### PR TITLE
chore(deps): bump sidekiq version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    sidekiq (7.1.3)
+    sidekiq (7.1.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)


### PR DESCRIPTION
Les jobs n'étaient plus retried lorsqu'une erreur était levée à cause de l'option `retry_for => 0` ajoutée dans les jobs dans la version `7.1.3`. 
La version `7.1.4` que je mets à jour ici contient le fix associé (voir https://github.com/sidekiq/sidekiq/pull/6035).