### PR TITLE
fix(users): add abillity to order by invitations created_at

### DIFF
--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -19,8 +19,8 @@ module Users::Sortable
     @users = if params[:sort_by] == "invitations"
                @users
                  .includes(:invitations)
-                 .reselect("DISTINCT(users.id), users.*, invitations.created_at")
-                 .order("invitations.created_at #{sort_order_from_params}")
+                 .reselect("DISTINCT(users.id), users.*, invitations.sent_at")
+                 .order("invitations.sent_at #{sort_order_from_params}")
              else
                @users
                  .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -16,9 +16,16 @@ module Users::Sortable
   end
 
   def motif_category_order
-    @users = @users
-             .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
-             .order("rdv_contexts.created_at desc")
+    @users = if params[:sort_by] == "invitations"
+               @users
+                 .includes(:invitations)
+                 .reselect("DISTINCT(users.id), users.*, invitations.created_at")
+                 .order("invitations.created_at #{params[:sort_order] == 'asc' ? 'asc' : 'desc'}")
+             else
+               @users
+                 .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
+                 .order("rdv_contexts.created_at desc")
+             end
   end
 
   def all_users_order

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -16,8 +16,8 @@ module Users::Sortable
   end
 
   def motif_category_order
-    @users = if %w[first_invitation_sent_at last_invitation_sent_at].include?(params[:sort_by])
-               first_or_last = sort_order_from_params == "asc" ? "MIN" : "MAX"
+    @users = if %w[first_invitation_sent_at last_invitation_sent_at].include?(params[:sort_by]) && params[:sort_order]
+               first_or_last = sort_order_from_params == "up" ? "MIN" : "MAX"
 
                @users
                  .left_joins(rdv_contexts: :invitations)
@@ -58,6 +58,6 @@ module Users::Sortable
   end
 
   def sort_order_from_params
-    params[:sort_order] == "asc" ? "asc" : "desc"
+    params[:sort_order] == "up" ? "asc" : "desc"
   end
 end

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -20,7 +20,7 @@ module Users::Sortable
                first_or_last = sort_order_from_params == "asc" ? "MIN" : "MAX"
 
                @users
-                 .left_joins(:invitations)
+                 .left_joins(rdv_contexts: :invitations)
                  .reselect("DISTINCT(users.id), users.*, #{first_or_last}(invitations.sent_at) as relevant_invitation")
                  .group("users.id")
                  .order("relevant_invitation #{sort_order_from_params} NULLS LAST")

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -20,7 +20,7 @@ module Users::Sortable
                @users
                  .includes(:invitations)
                  .reselect("DISTINCT(users.id), users.*, invitations.created_at")
-                 .order("invitations.created_at #{params[:sort_order] == 'asc' ? 'asc' : 'desc'}")
+                 .order("invitations.created_at #{sort_order_from_params}")
              else
                @users
                  .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
@@ -52,5 +52,9 @@ module Users::Sortable
                    .active
                    .where(users_affected_most_recently_to_an_organisation || {})
                    .order("affected_at DESC NULLS LAST, users.id DESC")
+  end
+
+  def sort_order_from_params
+    params[:sort_order] == "asc" ? "asc" : "desc"
   end
 end

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -20,10 +20,10 @@ module Users::Sortable
                first_or_last = sort_order_from_params == "asc" ? "MIN" : "MAX"
 
                @users
-                 .joins(:invitations)
+                 .left_joins(:invitations)
                  .reselect("DISTINCT(users.id), users.*, #{first_or_last}(invitations.sent_at) as relevant_invitation")
                  .group("users.id")
-                 .order("relevant_invitation #{sort_order_from_params}")
+                 .order("relevant_invitation #{sort_order_from_params} NULLS LAST")
              else
                @users
                  .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -9,8 +9,20 @@ module UsersHelper
     configuration.invitation_formats.present?
   end
 
-  def sorting_invites_by?(order)
-    params[:sort_by] == "invitations" && params[:sort_order] == order
+  def sorting_users_by?(column)
+    params[:sort_by] == column
+  end
+
+  def sort_order_for(column)
+    return "desc" unless sorting_users_by?(column)
+
+    params[:sort_order] == "asc" ? "desc" : "asc"
+  end
+
+  def display_sorting_icon(column)
+    return unless sorting_users_by?(column)
+
+    params[:sort_order] == "asc" ? "▲" : "▼"
   end
 
   def no_search_results?(users)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -9,7 +9,7 @@ module UsersHelper
     configuration.invitation_formats.present?
   end
 
-  def sorting_by_invites?(order)
+  def sorting_invites_by?(order)
     params[:sort_by] == "invitations" && params[:sort_order] == order
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -9,6 +9,10 @@ module UsersHelper
     configuration.invitation_formats.present?
   end
 
+  def sorting_by_invites?(order)
+    params[:sort_by] == "invitations" && params[:sort_order] == order
+  end
+
   def no_search_results?(users)
     users.empty? && params[:search_query].present?
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -14,15 +14,10 @@ module UsersHelper
   end
 
   def sort_order_for(column)
-    return "desc" unless sorting_users_by?(column)
+    return "up" unless sorting_users_by?(column)
 
-    params[:sort_order] == "asc" ? "desc" : "asc"
-  end
-
-  def display_sorting_icon(column)
-    return unless sorting_users_by?(column)
-
-    params[:sort_order] == "asc" ? "▲" : "▼"
+    sortings = ["up", "down", nil]
+    sortings[(sortings.index(params[:sort_order]) + 1) % sortings.length]
   end
 
   def no_search_results?(users)

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -8,12 +8,12 @@
     <% if show_invitations?(@current_configuration) %>
       <th scope="col">
         <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :first_invitation_sent_at, sort_order: sort_order_for("first_invitation_sent_at")), class: 'text-primary' do %>
-          Première invitation <%= display_sorting_icon("first_invitation_sent_at") %>
+          Première invitation <i class="fas fa-sort fa-sort-<%= params[:sort_by] == "first_invitation_sent_at" && params[:sort_order] %>"></i>
         <% end %>
       </th>
       <th scope="col">
         <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :last_invitation_sent_at, sort_order: sort_order_for("last_invitation_sent_at")), class: 'text-primary' do %>
-          Dernière invitation <%= display_sorting_icon("last_invitation_sent_at") %>
+          Dernière invitation <i class="fas fa-sort fa-sort-<%= params[:sort_by] == "last_invitation_sent_at" && params[:sort_order] %>"></i>
         <% end %>
       </th>
     <% end %>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -8,12 +8,12 @@
     <% if show_invitations?(@current_configuration) %>
       <th scope="col">
         <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :first_invitation_sent_at, sort_order: sort_order_for("first_invitation_sent_at")), class: 'text-primary' do %>
-          Première invitation <i class="fas fa-sort fa-sort-<%= params[:sort_by] == "first_invitation_sent_at" && params[:sort_order] %>"></i>
+          Première invitation <i class="fas fa-sort fa-sort-<%= params[:sort_order] if params[:sort_by] == "first_invitation_sent_at" %>"></i>
         <% end %>
       </th>
       <th scope="col">
         <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :last_invitation_sent_at, sort_order: sort_order_for("last_invitation_sent_at")), class: 'text-primary' do %>
-          Dernière invitation <i class="fas fa-sort fa-sort-<%= params[:sort_by] == "last_invitation_sent_at" && params[:sort_order] %>"></i>
+          Dernière invitation <i class="fas fa-sort fa-sort-<%= params[:sort_order] if params[:sort_by] == "last_invitation_sent_at" %>"></i>
         <% end %>
       </th>
     <% end %>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -6,8 +6,16 @@
       <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
     <% end  %>
     <% if show_invitations?(@current_configuration) %>
-      <th scope="col">Première invitation</th>
-      <th scope="col">Dernière invitation</th>
+      <th scope="col" class="<%= sorting_by_invites?("asc") && "dropup" %>">
+        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_by_invites?("asc") ? nil : :invitations, sort_order: :asc), class: 'text-primary dropdown-toggle' do %>
+          Première invitation
+        <% end %>
+      </th>
+      <th scope="col" class="<%= sorting_by_invites?("desc") && "dropup" %>">
+        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_by_invites?("desc") ? nil : :invitations, sort_order: :desc), class: 'text-primary  dropdown-toggle' do %>
+          Dernière invitation
+        <% end %>
+      </th>
     <% end %>
     <% if show_convocation?(@current_configuration) %>
       <th scope="col">Dernière convocation envoyée le</th>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -6,13 +6,13 @@
       <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
     <% end  %>
     <% if show_invitations?(@current_configuration) %>
-      <th scope="col" class="<%= sorting_by_invites?("asc") && "dropup" %>">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_by_invites?("asc") ? nil : :invitations, sort_order: :asc), class: 'text-primary dropdown-toggle' do %>
+      <th scope="col" class="<%= "dropup" if sorting_invites_by?("asc")  %>">
+        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_invites_by?("asc") ? nil : :invitations, sort_order: :asc), class: 'text-primary dropdown-toggle' do %>
           Première invitation
         <% end %>
       </th>
-      <th scope="col" class="<%= sorting_by_invites?("desc") && "dropup" %>">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_by_invites?("desc") ? nil : :invitations, sort_order: :desc), class: 'text-primary  dropdown-toggle' do %>
+      <th scope="col" class="<%= "dropup" if sorting_invites_by?("desc")  %>">
+        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_invites_by?("desc") ? nil : :invitations, sort_order: :desc), class: 'text-primary  dropdown-toggle' do %>
           Dernière invitation
         <% end %>
       </th>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -6,14 +6,14 @@
       <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
     <% end  %>
     <% if show_invitations?(@current_configuration) %>
-      <th scope="col" class="<%= "dropup" if sorting_invites_by?("asc")  %>">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_invites_by?("asc") ? nil : :invitations, sort_order: :asc), class: 'text-primary dropdown-toggle' do %>
-          Première invitation
+      <th scope="col">
+        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :first_invitation_sent_at, sort_order: sort_order_for("first_invitation_sent_at")), class: 'text-primary' do %>
+          Première invitation <%= display_sorting_icon("first_invitation_sent_at") %>
         <% end %>
       </th>
-      <th scope="col" class="<%= "dropup" if sorting_invites_by?("desc")  %>">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: sorting_invites_by?("desc") ? nil : :invitations, sort_order: :desc), class: 'text-primary  dropdown-toggle' do %>
-          Dernière invitation
+      <th scope="col">
+        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :last_invitation_sent_at, sort_order: sort_order_for("last_invitation_sent_at")), class: 'text-primary' do %>
+          Dernière invitation <%= display_sorting_icon("last_invitation_sent_at") %>
         <% end %>
       </th>
     <% end %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -690,12 +690,12 @@ describe UsersController do
       end
 
       let!(:user2) do
-        create(:user, organisations: [organisation], first_name: "Marie",
+        create(:user, organisations: [organisation], rdv_contexts: [rdv_context1],  first_name: "Marie",
                       tag_users_attributes: [{ tag_id: tags[0].id }, { tag_id: tags[1].id }])
       end
 
       let!(:user3) do
-        create(:user, organisations: [organisation], first_name: "Oliva",
+        create(:user, organisations: [organisation], rdv_contexts: [rdv_context1], first_name: "Oliva",
                       tag_users_attributes: [{ tag_id: tags[2].id }])
       end
 
@@ -925,10 +925,11 @@ describe UsersController do
           let!(:index_params) { { department_id: department.id, motif_category_id: category_orientation.id } }
 
           before do
-            user.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 1.year.ago)
+            user.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 2.years.ago)
+            user2.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 1.year.ago)
           end
 
-          it "orders by rdv_context creation" do
+          it "orders by rdv creation" do
             get :index, params: index_params
 
             ordered_table = Nokogiri::XML(response.body).css("td").map(&:text)
@@ -947,8 +948,13 @@ describe UsersController do
               }
             end
 
-            let!(:invitation) { create(:invitation, rdv_context: user.rdv_contexts.first, sent_at: 1.year.ago) }
-            let!(:invitation2) { create(:invitation, rdv_context: user2.rdv_contexts.first, sent_at: 2.years.ago) }
+            let!(:invitation) do
+              create(:invitation, rdv_context: user.rdv_contexts.first, user: user, sent_at: 1.year.ago)
+            end
+
+            let!(:invitation2) do
+              create(:invitation, rdv_context: user2.rdv_contexts.first, user: user2, sent_at: 2.years.ago)
+            end
 
             it "orders by invitation creation" do
               get :index, params: index_params

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -944,7 +944,7 @@ describe UsersController do
                 department_id: department.id,
                 motif_category_id: category_orientation.id,
                 sort_by: "last_invitation_sent_at",
-                sort_order: "desc"
+                sort_order: "down"
               }
             end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -929,7 +929,7 @@ describe UsersController do
             user2.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 1.year.ago)
           end
 
-          it "orders by rdv creation" do
+          it "orders by rdv_context creation" do
             get :index, params: index_params
 
             ordered_table = Nokogiri::XML(response.body).css("td").map(&:text)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -950,7 +950,7 @@ describe UsersController do
             let!(:invitation) { create(:invitation, rdv_context: user.rdv_contexts.first, sent_at: 1.year.ago) }
             let!(:invitation2) { create(:invitation, rdv_context: user2.rdv_contexts.first, sent_at: 2.years.ago) }
 
-            it "orders by rdv_context creation" do
+            it "orders by invitation creation" do
               get :index, params: index_params
 
               ordered_table = Nokogiri::XML(response.body).css("td").map(&:text)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -936,6 +936,29 @@ describe UsersController do
 
             expect(ordered_first_names).to eq([user2.first_name, user.first_name])
           end
+
+          context "when sorting by invitations" do
+            let!(:index_params) do
+              {
+                department_id: department.id,
+                motif_category_id: category_orientation.id,
+                sort_by: "invitations",
+                sort_order: "desc"
+              }
+            end
+
+            let!(:invitation) { create(:invitation, rdv_context: user.rdv_contexts.first, sent_at: 1.year.ago) }
+            let!(:invitation2) { create(:invitation, rdv_context: user2.rdv_contexts.first, sent_at: 2.years.ago) }
+
+            it "orders by rdv_context creation" do
+              get :index, params: index_params
+
+              ordered_table = Nokogiri::XML(response.body).css("td").map(&:text)
+              ordered_first_names = ordered_table & [user.first_name, user2.first_name]
+
+              expect(ordered_first_names).to eq([user.first_name, user2.first_name])
+            end
+          end
         end
       end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -690,12 +690,12 @@ describe UsersController do
       end
 
       let!(:user2) do
-        create(:user, organisations: [organisation], rdv_contexts: [rdv_context1],  first_name: "Marie",
+        create(:user, organisations: [organisation], rdv_contexts: [rdv_context1], first_name: "Marie",
                       tag_users_attributes: [{ tag_id: tags[0].id }, { tag_id: tags[1].id }])
       end
 
       let!(:user3) do
-        create(:user, organisations: [organisation], rdv_contexts: [rdv_context1], first_name: "Oliva",
+        create(:user, organisations: [organisation], rdv_contexts: [rdv_context2], first_name: "Oliva",
                       tag_users_attributes: [{ tag_id: tags[2].id }])
       end
 
@@ -943,7 +943,7 @@ describe UsersController do
               {
                 department_id: department.id,
                 motif_category_id: category_orientation.id,
-                sort_by: "invitations",
+                sort_by: "last_invitation_sent_at",
                 sort_order: "desc"
               }
             end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -956,6 +956,15 @@ describe UsersController do
               create(:invitation, rdv_context: user2.rdv_contexts.first, user: user2, sent_at: 2.years.ago)
             end
 
+            # This is to make sure only the invitations of the current motif_category are taken into account
+            let!(:invitation_unused) do
+              create(:invitation, rdv_context: rdv_context_unused, user: user2, sent_at: 1.day.ago)
+            end
+
+            let(:rdv_context_unused) do
+              create(:rdv_context, motif_category: category_accompagnement, status: "rdv_seen")
+            end
+
             it "orders by invitation creation" do
               get :index, params: index_params
 


### PR DESCRIPTION
Cette PR permet de trier les usagers par date d'invitation depuis les listing de motifs catégories : 
<img width="1800" alt="Screenshot 2023-09-27 at 14 00 12" src="https://github.com/betagouv/rdv-insertion/assets/4990201/0eef4fa9-f3ac-4051-9bc8-b9963768d56a">

Corrige https://github.com/betagouv/rdv-insertion/issues/1271