### PR TITLE
fix(stats): typos after applicants naming change

### DIFF
--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -40,20 +40,20 @@
     <div class="row d-flex justify-content-center flex-wrap-reverse">
       <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_autonomous_users.round %> %</p>
-        <p class="highlight-stat margin-left">de usagers invités ayant pris au moins <strong>un rendez-vous en autonomie</strong></p>
-        <%= line_chart @stat.rate_of_autonomous_users_grouped_by_month, title: "Taux de usagers autonomes par mois", suffix: "%", colors: ["#083b66"] %>
+        <p class="highlight-stat margin-left">d'usagers invités ayant pris au moins <strong>un rendez-vous en autonomie</strong></p>
+        <%= line_chart @stat.rate_of_autonomous_users_grouped_by_month, title: "Taux d'usagers autonomes par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented_in_less_than_30_days.round %> %</p>
-        <p class="highlight-stat margin-left">de usagers <strong>ayant honoré un 1er rendez-vous RSA en - de 30 jours</strong></p>
+        <p class="highlight-stat margin-left">d'usagers <strong>ayant honoré un 1er rendez-vous RSA en - de 30 jours</strong></p>
         <%= line_chart @stat.rate_of_users_oriented_in_less_than_30_days_by_month, title: "Taux rdv en - de 30 jours par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap-reverse">
       <div class="col-12 col-md-6 px-5 pb-5">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented.round %> %</p>
-        <p class="highlight-stat margin-left">de usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
-        <%= line_chart @stat.rate_of_users_oriented_grouped_by_month, title: "Taux de usagers orientés via l'outil", suffix: "%", colors: ["#083b66"] %>
+        <p class="highlight-stat margin-left">d'usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
+        <%= line_chart @stat.rate_of_users_oriented_grouped_by_month, title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap">


### PR DESCRIPTION
Plusieurs petites typos sur la page stats `... de usagers` plutôt que `... d'usagers`, consécutives au changement de naming des bénéficiaires en usagers. Cette PR résout ce problème.