### PR TITLE
feat(notifications): Prevent sending a notification when rdv is in the past

### DIFF
--- a/app/models/concerns/rdv_participation_status.rb
+++ b/app/models/concerns/rdv_participation_status.rb
@@ -21,6 +21,10 @@ module RdvParticipationStatus
     starts_at > Time.zone.now
   end
 
+  def in_the_past?
+    starts_at < Time.zone.now
+  end
+
   def cancelled?
     status.in?(CANCELLED_STATUSES)
   end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -42,6 +42,7 @@ class Participation < ApplicationRecord
   end
 
   def notify_user
+    return if in_the_past?
     return unless event_to_notify
 
     NotifyParticipationJob.perform_async(id, "sms", "participation_#{event_to_notify}") if phone_number_is_mobile?

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -79,6 +79,7 @@ class Rdv < ApplicationRecord
   end
 
   def notify_convocable_participations
+    return if in_the_past?
     return unless event_to_notify?
     return if convocable_participations.empty?
 

--- a/app/services/notifications/notify_participation.rb
+++ b/app/services/notifications/notify_participation.rb
@@ -7,6 +7,8 @@ module Notifications
     end
 
     def call
+      return if @participation.in_the_past?
+
       Notification.transaction do
         save_record!(notification)
         send_notification

--- a/app/views/rdv_contexts/_convocations.html.erb
+++ b/app/views/rdv_contexts/_convocations.html.erb
@@ -4,7 +4,7 @@
 <% if email_convocations.any? %>
   <div>Email 📧</div>
 <% end %>
-<% if participation.pending? || participation.revoked? %>
+<% if participation.in_the_future? && participation.status.in?(["unknown", "revoked"]) %>
   <%= simple_form_for(:notification, url: participation_notifications_path(participation, format: "pdf"), html: { method: :post }) do |f| %>
     <%= f.input :format,
                 as: :hidden,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -357,24 +357,10 @@ describe UsersController do
         end
 
         context "when the rdv is passed" do
-          context "when the participation is revoked" do
-            before { participation.update! status: "revoked" }
+          it "does not show the courrier generation button" do
+            get :show, params: show_params
 
-            it "shows the courrier generation button" do
-              get :show, params: show_params
-
-              expect(response.body).to include("<i class=\"fas fa-file-pdf\"></i> Courrier")
-            end
-          end
-
-          context "when the rdv participation is seen" do
-            before { participation.update! status: "seen" }
-
-            it "does not show the courrier generation button" do
-              get :show, params: show_params
-
-              expect(response.body).not_to include("<i class=\"fas fa-file-pdf\"></i> Courrier")
-            end
+            expect(response.body).not_to include("<i class=\"fas fa-file-pdf\"></i> Courrier")
           end
         end
       end

--- a/spec/features/agent_can_generate_convocation_pdf_spec.rb
+++ b/spec/features/agent_can_generate_convocation_pdf_spec.rb
@@ -79,25 +79,25 @@ describe "Agents can generate convocation pdf", js: true do
 
       expect(page).not_to have_button "Courrier"
     end
+  end
 
-    context "when the participation is revoked" do
-      before { participation.update! status: "revoked" }
+  context "when the participation is revoked" do
+    before { participation.update! status: "revoked" }
 
-      it "can generate a revoked participation pdf" do
-        visit organisation_user_path(organisation, user)
+    it "can generate a revoked participation pdf" do
+      visit organisation_user_path(organisation, user)
 
-        expect(page).to have_button "Courrier"
+      expect(page).to have_button "Courrier"
 
-        click_button "Courrier"
+      click_button "Courrier"
 
-        wait_for_download
-        expect(downloads.length).to eq(1)
+      wait_for_download
+      expect(downloads.length).to eq(1)
 
-        pdf = download_content(format: "pdf")
-        pdf_text = extract_raw_text(pdf)
+      pdf = download_content(format: "pdf")
+      pdf_text = extract_raw_text(pdf)
 
-        expect(pdf_text).to include("a été annulé")
-      end
+      expect(pdf_text).to include("a été annulé")
     end
   end
 

--- a/spec/models/participation_spec.rb
+++ b/spec/models/participation_spec.rb
@@ -49,7 +49,7 @@ describe Participation do
     subject { participation.save }
 
     let!(:participation_id) { 333 }
-    let!(:rdv) { create(:rdv) }
+    let!(:rdv) { create(:rdv, starts_at: 2.days.from_now) }
     let!(:user) { create(:user) }
     let!(:participation) do
       build(:participation, id: participation_id, convocable: true, rdv: rdv, user: user, status: "unknown")
@@ -95,6 +95,15 @@ describe Participation do
             .with(participation_id, "email", "participation_created")
           subject
         end
+      end
+    end
+
+    context "when the rdv is in the past" do
+      before { rdv.update! starts_at: 2.days.ago }
+
+      it "doess not enqueue jobs" do
+        expect(NotifyParticipationJob).not_to receive(:perform_async)
+        subject
       end
     end
 

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -36,7 +36,9 @@ describe Rdv do
     let!(:participation) { create(:participation, convocable: true) }
 
     context "when the lieu is updated" do
-      let!(:rdv) { create(:rdv, participations: [participation], address: "some place") }
+      let!(:rdv) do
+        create(:rdv, participations: [participation], address: "some place", starts_at: 2.days.from_now)
+      end
 
       it "enqueues a job to notify rdv users" do
         rdv.address = "some other place"
@@ -74,6 +76,15 @@ describe Rdv do
           expect(NotifyParticipationsJob).not_to receive(:perform_async)
           subject
         end
+      end
+    end
+
+    context "when the rdv is in the past" do
+      let!(:rdv) { create(:rdv, participations: [participation], starts_at: 2.days.ago) }
+
+      it "does not enqueue a job to notify rdv users" do
+        expect(NotifyParticipationsJob).not_to receive(:perform_async)
+        subject
       end
     end
 

--- a/spec/services/notifications/notify_participation_spec.rb
+++ b/spec/services/notifications/notify_participation_spec.rb
@@ -7,7 +7,7 @@ describe Notifications::NotifyParticipation, type: :service do
 
   let!(:participation) { create(:participation, rdv: rdv) }
   let!(:rdv_solidarites_rdv_id) { 444 }
-  let!(:rdv) { create(:rdv, rdv_solidarites_rdv_id: rdv_solidarites_rdv_id) }
+  let!(:rdv) { create(:rdv, rdv_solidarites_rdv_id: rdv_solidarites_rdv_id, starts_at: 2.days.from_now) }
   let!(:event) { "participation_created" }
   let!(:format) { "sms" }
 
@@ -47,6 +47,17 @@ describe Notifications::NotifyParticipation, type: :service do
 
       it "fails with an error" do
         expect(subject.errors).to eq(["cannot send notification"])
+      end
+    end
+
+    context "when the rdv is in the past" do
+      before { rdv.update! starts_at: 2.days.ago }
+
+      it("is a success") { is_a_success }
+
+      it "does not send a notification" do
+        expect(Notifications::SendSms).not_to receive(:call)
+        subject
       end
     end
   end


### PR DESCRIPTION
Je me suis rendu compte qu'il n'y avait rien dans le code qui empêchait d'envoyer une notification alors que le rdv est déjà passé, je rajoute cette contrainte pour être sûr de ne pas envoyer de notif si on met à jour un vieux rdv