### PR TITLE
fix(exports): avoid timeouts for csvs

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -242,9 +242,12 @@ class UsersController < ApplicationController
 
   def set_all_users
     @users = policy_scope(User)
-             .preload(rdv_contexts: [:invitations])
              .active
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
+
+    return if request.format == "csv"
+
+    @users = @users.preload(rdv_contexts: [:invitations])
   end
 
   def set_users_for_motif_category
@@ -269,7 +272,7 @@ class UsersController < ApplicationController
   end
 
   def set_rdv_contexts
-    return if archived_scope?
+    return if archived_scope? || request.format == "csv"
 
     @rdv_contexts = RdvContext.where(
       user_id: @users.ids, motif_category: @current_motif_category


### PR DESCRIPTION
Complète et améliore ce qui a été fait dans la PR #1431 
Elle avait effectivement évitée les requêtes N+1, et si les exports les plus lourds fonctionnent dans certains cas, ils apparaissent encore de manière aléatoire.
Ici, on retire un maximum de `preload` possible à chaque requête csv, et l'on remplace un `each` par un `find_each`.
Si cela ne suffit pas, il faudra peut-être réfléchir à envoyer les csv par email (solution adoptée par rdv-s notamment) plutôt que de les streamer au client qui fait la requête.