### PR TITLE
feat(perf): Optimize csv export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,8 @@ group :development, :test do
   gem "rubocop"
   gem "rubocop-rails"
   gem "rubocop-rspec"
-  gem "bullet"
+  gem "prosopite"
+  gem "pg_query"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,9 +79,6 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    bullet (7.0.7)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.39.2)
       addressable
@@ -128,6 +125,9 @@ GEM
       raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    google-protobuf (3.24.3-arm64-darwin)
+    google-protobuf (3.24.3-x86_64-darwin)
+    google-protobuf (3.24.3-x86_64-linux)
     groupdate (6.2.0)
       activesupport (>= 5.2)
     hashdiff (1.0.1)
@@ -204,6 +204,8 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.4.6)
+    pg_query (4.2.3)
+      google-protobuf (>= 3.22.3)
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
@@ -216,6 +218,7 @@ GEM
       actionmailer (>= 3)
       net-smtp
       premailer (~> 1.7, >= 1.7.9)
+    prosopite (1.4.1)
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -390,7 +393,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -427,7 +429,6 @@ PLATFORMS
 DEPENDENCIES
   addressable
   bootsnap (>= 1.4.2)
-  bullet
   byebug
   capybara (>= 2.15)
   chartkick
@@ -442,9 +443,11 @@ DEPENDENCIES
   listen (~> 3.2)
   pdf-reader
   pg (>= 0.18, < 2.0)
+  pg_query
   pg_search
   phonelib
   premailer-rails
+  prosopite
   puma (~> 5.6)
   pundit
   rack-cors

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,15 +27,4 @@ class ApplicationController < ActionController::Base
   def department_level?
     params[:department_id].present?
   end
-
-  if Rails.env.development?
-    around_action :n_plus_one_detection
-
-    def n_plus_one_detection
-      Prosopite.scan
-      yield
-    ensure
-      Prosopite.finish
-    end
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,15 @@ class ApplicationController < ActionController::Base
   def department_level?
     params[:department_id].present?
   end
+
+  if Rails.env.development?
+    around_action :n_plus_one_detection
+
+    def n_plus_one_detection
+      Prosopite.scan
+      yield
+    ensure
+      Prosopite.finish
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -249,7 +249,7 @@ class UsersController < ApplicationController
 
   def set_users_for_motif_category
     @users = policy_scope(User)
-             .preload(rdv_contexts: [:notifications, :invitations])
+             .preload(:organisations, rdv_contexts: [:notifications, :invitations])
              .active
              .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -157,7 +157,7 @@ class UsersController < ApplicationController
       if department_level?
         set_organisation_at_department_level
       else
-        policy_scope(Organisation).preload(configurations: [:motif_category]).find(params[:organisation_id])
+        policy_scope(Organisation).find(params[:organisation_id])
       end
   end
 
@@ -183,7 +183,7 @@ class UsersController < ApplicationController
   def set_department
     @department =
       if department_level?
-        policy_scope(Department).preload(configurations: [:motif_category]).find(params[:department_id])
+        policy_scope(Department).find(params[:department_id])
       else
         @organisation.department
       end
@@ -242,9 +242,11 @@ class UsersController < ApplicationController
 
   def set_all_users
     @users = policy_scope(User)
-             .preload(rdv_contexts: [:invitations])
              .active
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
+    return if request.format == "csv"
+
+    @users = @users.preload(rdv_contexts: [:invitations])
   end
 
   def set_users_for_motif_category

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -34,7 +34,7 @@ module Exporters
 
     def generate_csv
       csv = CSV.generate(write_headers: true, col_sep: ";", headers: headers, encoding: "utf-8") do |row|
-        @users.each do |user|
+        @users.find_each do |user|
           row << user_csv_row(user)
         end
       end

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -27,7 +27,7 @@ module Exporters
         else
           @users.preload(
             :invitations, :notifications, :archives, :organisations, :tags, :referents,
-            :participations, rdvs: [:motif, :participations, :users]
+            rdvs: [:motif, :participations, :users]
           )
         end
     end
@@ -139,7 +139,7 @@ module Exporters
     end
 
     def number_of_days_before_action_required
-      @number_of_days_before_action_required ||= @structure.configurations.find do |c|
+      @number_of_days_before_action_required ||= @structure.configurations.includes(:motif_category).find do |c|
         c.motif_category == @motif_category
       end.number_of_days_before_action_required
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,8 +55,8 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   config.after_initialize do
-    Bullet.enable = true
-    Bullet.rails_logger = true
+    Prosopite.enabled = true
+    Prosopite.rails_logger = true
   end
 
   # Debug mode disables concatenation and preprocessing of assets.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,6 +54,7 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # N+1 detection
   config.after_initialize do
     Prosopite.enabled = true
     Prosopite.rails_logger = true

--- a/config/initializers/prosopite.rb
+++ b/config/initializers/prosopite.rb
@@ -1,0 +1,4 @@
+unless Rails.env.production?
+  require "prosopite/middleware/rack"
+  Rails.configuration.middleware.use(Prosopite::Middleware::Rack)
+end


### PR DESCRIPTION
Dans cette PR j'essaie d'éviter les requêtes inutiles lors de l'export csv pour essayer de générer le fichier plus rapidement.
Pour ce faire: 

* J'enlève la gem [`bullet`](https://github.com/flyerhzm/bullet) qui détecte beaucoup de faux positifs et je mets [`proposite`](https://github.com/charkost/prosopite) à la place qui me parait + fiable
* Dans le service de l'export, je fais 2 preload différents en fonction du cas où une catégorie de motif est définie ou non
* J'évite certains preload qui ne sont pas nécessaires dans le cadre d'un export csv dans le `users_controller`

