### PR TITLE
fix(stats): avoid 500 for stats

### DIFF
--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -20,38 +20,38 @@
         <%= line_chart @stat.sent_invitations_count_grouped_by_month, title: "Invitations envoyées par mois", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5">
-        <p class="highlight-stat big margin-left"><%= @stat.average_time_between_invitation_and_rdv_in_days.round %> jours</p>
+        <p class="highlight-stat big margin-left"><%= @stat.average_time_between_invitation_and_rdv_in_days&.round %> jours</p>
         <p class="highlight-stat margin-left">délai moyen entre l'invitation et la prise de rendez-vous</p>
         <%= line_chart @stat.average_time_between_invitation_and_rdv_in_days_by_month, title: "Délai moyen d'invitation par mois", ytitle: "jours", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap">
       <div class="col-12 col-md-6 px-5 pb-5">
-        <p class="highlight-stat big margin-left"><%= @stat.rate_of_no_show_for_invitations.round %> %</p>
+        <p class="highlight-stat big margin-left"><%= @stat.rate_of_no_show_for_invitations&.round %> %</p>
         <p class="highlight-stat margin-left">de rendez-vous non honorés avec rdv-insertion <strong>après invitation</strong></p>
         <%= line_chart @stat.rate_of_no_show_for_invitations_grouped_by_month, title: "Taux de rdvs non honorés après invitation par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
-        <p class="highlight-stat big margin-left"><%= @stat.rate_of_no_show_for_convocations.round %> %</p>
+        <p class="highlight-stat big margin-left"><%= @stat.rate_of_no_show_for_convocations&.round %> %</p>
         <p class="highlight-stat margin-left">de rendez-vous non honorés avec rdv-insertion <strong>après convocation</strong></p>
         <%= line_chart @stat.rate_of_no_show_for_convocations_grouped_by_month, title: "Taux de rdvs non honorés après convocation par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap-reverse">
       <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
-        <p class="highlight-stat big margin-left"><%= @stat.rate_of_autonomous_users.round %> %</p>
+        <p class="highlight-stat big margin-left"><%= @stat.rate_of_autonomous_users&.round %> %</p>
         <p class="highlight-stat margin-left">d'usagers invités ayant pris au moins <strong>un rendez-vous en autonomie</strong></p>
         <%= line_chart @stat.rate_of_autonomous_users_grouped_by_month, title: "Taux d'usagers autonomes par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5">
-        <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented_in_less_than_30_days.round %> %</p>
+        <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented_in_less_than_30_days&.round %> %</p>
         <p class="highlight-stat margin-left">d'usagers <strong>ayant honoré un 1er rendez-vous RSA en - de 30 jours</strong></p>
         <%= line_chart @stat.rate_of_users_oriented_in_less_than_30_days_by_month, title: "Taux rdv en - de 30 jours par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap-reverse">
       <div class="col-12 col-md-6 px-5 pb-5">
-        <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented.round %> %</p>
+        <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented&.round %> %</p>
         <p class="highlight-stat margin-left">d'usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
         <%= line_chart @stat.rate_of_users_oriented_grouped_by_month, title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
       </div>


### PR DESCRIPTION
Lorsque certaines valeurs étaient `nil`, les pages stats renvoyaient des 500. Cette PR règle ce problème.
Je choisis de ne pas mettre de default value pour les colonnes de stats car cela permet de mieux différencier celles qui pourraient avoir une valeur nulle de manière légitime des stats non calculées.