### PR TITLE
feat(stats): better perfs for stats jobs

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -93,7 +93,8 @@ class Stat < ApplicationRecord
   # We only consider specific contexts to focus on the first RSA rdv
   def users_with_orientation_category_sample
     @users_with_orientation_category_sample ||=
-      users_sample.joins(:rdv_contexts)
+      users_sample.preload(:rdvs)
+                  .joins(:rdv_contexts)
                   .where(rdv_contexts: RdvContext.orientation)
   end
 

--- a/app/services/stats/compute_rate_of_users_with_rdv_seen_in_less_than_thirty_days.rb
+++ b/app/services/stats/compute_rate_of_users_with_rdv_seen_in_less_than_thirty_days.rb
@@ -5,24 +5,27 @@ module Stats
     end
 
     def call
-      result.value = compute_rate_of_users_oriented_in_less_than_30_days
+      result.value = compute_rate_of_users_with_rdv_seen_in_less_than_30_days
     end
 
     private
 
     # Rate of users with rdv seen in less than 30 days
-    def compute_rate_of_users_oriented_in_less_than_30_days
-      (users_oriented_in_less_than_30_days.count / (
+    def compute_rate_of_users_with_rdv_seen_in_less_than_30_days
+      (users_with_rdv_seen_in_less_than_30_days.count / (
         users_created_more_than_30_days_ago.count.nonzero? || 1
       ).to_f) * 100
     end
 
-    def users_oriented_in_less_than_30_days
-      @users_oriented_in_less_than_30_days ||=
-        users_created_more_than_30_days_ago.select do |user|
-          user_rdv_seen_delay_in_days = user.rdv_seen_delay_in_days
-          user_rdv_seen_delay_in_days.present? && user_rdv_seen_delay_in_days < 30
+    def users_with_rdv_seen_in_less_than_30_days
+      @users_with_rdv_seen_in_less_than_30_days ||=
+        users_with_rdvs_seen_created_more_than_30_days_ago.select do |user|
+          user.rdv_seen_delay_in_days < 30
         end
+    end
+
+    def users_with_rdvs_seen_created_more_than_30_days_ago
+      @users_with_rdvs_created_more_than_30_days_ago ||= @users_created_more_than_30_days_ago.joins(:participations).where(participations: { status: "seen" }).distinct
     end
 
     def users_created_more_than_30_days_ago

--- a/app/services/stats/compute_rate_of_users_with_rdv_seen_in_less_than_thirty_days.rb
+++ b/app/services/stats/compute_rate_of_users_with_rdv_seen_in_less_than_thirty_days.rb
@@ -18,14 +18,20 @@ module Stats
     end
 
     def users_with_rdv_seen_in_less_than_30_days
-      @users_with_rdv_seen_in_less_than_30_days ||=
-        users_with_rdvs_seen_created_more_than_30_days_ago.select do |user|
-          user.rdv_seen_delay_in_days < 30
+      @users_with_rdv_seen_in_less_than_30_days ||= begin
+        users = []
+
+        users_with_rdvs_seen_created_more_than_30_days_ago.find_in_batches(batch_size: 100) do |batch|
+          users += batch.select { |user| user.rdv_seen_delay_in_days < 30 }
         end
+
+        users
+      end
     end
 
     def users_with_rdvs_seen_created_more_than_30_days_ago
-      @users_with_rdvs_created_more_than_30_days_ago ||= @users_created_more_than_30_days_ago.joins(:participations).where(participations: { status: "seen" }).distinct
+      @users_with_rdvs_seen_created_more_than_30_days_ago ||=
+        users_created_more_than_30_days_ago.joins(:participations).where(participations: { status: "seen" }).distinct
     end
 
     def users_created_more_than_30_days_ago


### PR DESCRIPTION
Les jobs de stats prennent trop de temps à être run ; celui qui regroupe les stats de toute l'app tourne même + de 24h sans parvenir à se terminer. Cette PR vise à améliorer les perfs en :
- enlevant une requête n+1 (le preload des rdvs)
- limitant le `select` dans `ComputeRateOfUsersWithRdvSeenInLessThanThirtyDays` aux seuls utilisateurs susceptibles de passer le test (ie, ceux qui ont au moins un rdv honoré)
- découpant ce `select` en batch  