### PR TITLE
refactor(mattermost): Send less notifications

### DIFF
--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -11,7 +11,7 @@ class MattermostClient
     private
 
     def send_message(url, text)
-      return unless Rails.env.production?
+      return unless ENV["SENTRY_ENVIRONMENT"] == "production"
 
       Faraday.post(
         url,

--- a/app/jobs/notify_participation_job.rb
+++ b/app/jobs/notify_participation_job.rb
@@ -9,7 +9,7 @@ class NotifyParticipationJob < ApplicationJob
     return if user.created_through_rdv_solidarites? && user.invitations.sent.empty?
 
     Notification.with_advisory_lock "notifying_particpation_#{@participation.id}" do
-      return send_already_notified_to_mattermost if already_notified?
+      return if already_notified?
 
       notify_participation!
     end
@@ -31,15 +31,6 @@ class NotifyParticipationJob < ApplicationJob
     else
       @participation.notifications.sent.find_by(event: @event, format: @format).present?
     end
-  end
-
-  def send_already_notified_to_mattermost
-    MattermostClient.send_to_notif_channel(
-      "Rdv already notified to user. Skipping notification sending.\n" \
-      "participation id: #{@participation.id}\n" \
-      "format: #{@format}\n" \
-      "event: #{@event}"
-    )
   end
 
   def notify_participation!

--- a/app/jobs/rdv_solidarites_webhooks/process_agent_role_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_agent_role_job.rb
@@ -30,7 +30,9 @@ module RdvSolidaritesWebhooks
 
     def delete_agent
       agent.destroy!
-      MattermostClient.send_to_notif_channel "agent #{agent.rdv_solidarites_agent_id} destroyed"
+      MattermostClient.send_to_notif_channel(
+        "agent removed from organisation #{organisation.name} (#{organisation.id}) and deleted"
+      )
     end
 
     def upsert_agent_and_raise

--- a/app/jobs/rdv_solidarites_webhooks/process_referent_assignation_job.rb
+++ b/app/jobs/rdv_solidarites_webhooks/process_referent_assignation_job.rb
@@ -3,8 +3,7 @@ module RdvSolidaritesWebhooks
     def perform(data, meta)
       @data = data.deep_symbolize_keys
       @meta = meta.deep_symbolize_keys
-      return if user.blank?
-      return notify_agent_not_found if agent.blank?
+      return if user.blank? || agent.blank?
 
       User.with_advisory_lock "assigning_#{rdv_solidarites_agent_id}_to_#{rdv_solidarites_user_id}" do
         attach_agent_to_user if event == "created"
@@ -32,14 +31,6 @@ module RdvSolidaritesWebhooks
 
     def agent
       @agent ||= Agent.find_by(rdv_solidarites_agent_id: rdv_solidarites_agent_id)
-    end
-
-    def notify_agent_not_found
-      MattermostClient.send_to_notif_channel(
-        "Referent not found for RDV-S referent assignation.\n" \
-        "agent id: #{rdv_solidarites_agent_id}\n" \
-        "user id: #{rdv_solidarites_user_id}"
-      )
     end
 
     def attach_agent_to_user

--- a/spec/jobs/notify_participation_job_spec.rb
+++ b/spec/jobs/notify_participation_job_spec.rb
@@ -13,7 +13,6 @@ describe NotifyParticipationJob do
     before do
       allow(Notifications::NotifyParticipation).to receive(:call)
         .and_return(OpenStruct.new(success?: true))
-      allow(MattermostClient).to receive(:send_to_notif_channel)
     end
 
     it "calls the notify user service" do
@@ -43,17 +42,6 @@ describe NotifyParticipationJob do
         subject
       end
 
-      it "sends a message to mattermost" do
-        expect(MattermostClient).to receive(:send_to_notif_channel)
-          .with(
-            "Rdv already notified to user. Skipping notification sending.\n" \
-            "participation id: #{participation.id}\n" \
-            "format: #{format}\n" \
-            "event: #{event}"
-          )
-        subject
-      end
-
       context "when the event is participation_updated" do
         let!(:event) { "participation_updated" }
 
@@ -73,17 +61,6 @@ describe NotifyParticipationJob do
 
           it "does not calls the notify user service" do
             expect(Notifications::NotifyParticipation).not_to receive(:call)
-            subject
-          end
-
-          it "sends a message to mattermost" do
-            expect(MattermostClient).to receive(:send_to_notif_channel)
-              .with(
-                "Rdv already notified to user. Skipping notification sending.\n" \
-                "participation id: #{participation.id}\n" \
-                "format: #{format}\n" \
-                "event: #{event}"
-              )
             subject
           end
         end

--- a/spec/jobs/rdv_solidarites_webhooks/process_agent_role_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_agent_role_job_spec.rb
@@ -16,7 +16,9 @@ describe RdvSolidaritesWebhooks::ProcessAgentRoleJob do
   let!(:rdv_solidarites_organisation_id) { 222 }
   let!(:rdv_solidarites_agent_id) { 455 }
 
-  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: rdv_solidarites_organisation_id) }
+  let!(:organisation) do
+    create(:organisation, rdv_solidarites_organisation_id:, id: 923, name: "Pôle Parcours")
+  end
   let!(:agent) { create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id) }
   let!(:agent_role) { create(:agent_role, organisation: organisation, agent: agent) }
   let!(:meta) do
@@ -74,7 +76,7 @@ describe RdvSolidaritesWebhooks::ProcessAgentRoleJob do
 
         it "sends a message to mattermost" do
           expect(MattermostClient).to receive(:send_to_notif_channel)
-            .with("agent 455 destroyed")
+            .with("agent removed from organisation Pôle Parcours (923) and deleted")
           subject
         end
       end

--- a/spec/jobs/rdv_solidarites_webhooks/process_referent_assignation_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_referent_assignation_job_spec.rb
@@ -48,22 +48,9 @@ describe RdvSolidaritesWebhooks::ProcessReferentAssignationJob do
         create(:agent, rdv_solidarites_agent_id: "some-orga")
       end
 
-      before do
-        allow(MattermostClient).to receive(:send_to_notif_channel)
-      end
-
       it "does not remove the agent from the user" do
         subject
         expect(user.reload.referents).to eq([agent])
-      end
-
-      it "sends a notification to mattermost" do
-        expect(MattermostClient).to receive(:send_to_notif_channel).with(
-          "Referent not found for RDV-S referent assignation.\n" \
-          "agent id: #{rdv_solidarites_agent_id}\n" \
-          "user id: #{rdv_solidarites_user_id}"
-        )
-        subject
       end
     end
 


### PR DESCRIPTION
closes #1427 

J'enlève des notifications qui n'apportaient pas d'informations utiles et qui ont surtout été utilisé pour vérifier le bon fonctionnement des features en question. 
J'en profite pour préciser l'organisation de l'agent lorsque celui-ci est supprimé ainsi que de ne plus prendre en compte les notifications venant de l'espace de demo.