### PR TITLE
Revert "fix(users): add abillity to order by invitations created_at"

### DIFF
--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -12,23 +12,13 @@ module Users::Sortable
   end
 
   def archived_order
-    @users = @users.order("archives.created_at desc")
+    @users.order("archives.created_at desc")
   end
 
   def motif_category_order
-    @users = if %w[first_invitation_sent_at last_invitation_sent_at].include?(params[:sort_by]) && params[:sort_order]
-               first_or_last = sort_order_from_params == "up" ? "MIN" : "MAX"
-
-               @users
-                 .left_joins(rdv_contexts: :invitations)
-                 .reselect("DISTINCT(users.id), users.*, #{first_or_last}(invitations.sent_at) as relevant_invitation")
-                 .group("users.id")
-                 .order("relevant_invitation #{sort_order_from_params} NULLS LAST")
-             else
-               @users
-                 .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
-                 .order("rdv_contexts.created_at #{sort_order_from_params}")
-             end
+    @users = @users
+             .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
+             .order("rdv_contexts.created_at desc")
   end
 
   def all_users_order
@@ -55,9 +45,5 @@ module Users::Sortable
                    .active
                    .where(users_affected_most_recently_to_an_organisation || {})
                    .order("affected_at DESC NULLS LAST, users.id DESC")
-  end
-
-  def sort_order_from_params
-    params[:sort_order] == "up" ? "asc" : "desc"
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -9,17 +9,6 @@ module UsersHelper
     configuration.invitation_formats.present?
   end
 
-  def sorting_users_by?(column)
-    params[:sort_by] == column
-  end
-
-  def sort_order_for(column)
-    return "up" unless sorting_users_by?(column)
-
-    sortings = ["up", "down", nil]
-    sortings[(sortings.index(params[:sort_order]) + 1) % sortings.length]
-  end
-
   def no_search_results?(users)
     users.empty? && params[:search_query].present?
   end

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -6,16 +6,8 @@
       <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
     <% end  %>
     <% if show_invitations?(@current_configuration) %>
-      <th scope="col">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :first_invitation_sent_at, sort_order: sort_order_for("first_invitation_sent_at")), class: 'text-primary' do %>
-          Première invitation <i class="fas fa-sort fa-sort-<%= params[:sort_order] if params[:sort_by] == "first_invitation_sent_at" %>"></i>
-        <% end %>
-      </th>
-      <th scope="col">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, sort_by: :last_invitation_sent_at, sort_order: sort_order_for("last_invitation_sent_at")), class: 'text-primary' do %>
-          Dernière invitation <i class="fas fa-sort fa-sort-<%= params[:sort_order] if params[:sort_by] == "last_invitation_sent_at" %>"></i>
-        <% end %>
-      </th>
+      <th scope="col">Première invitation</th>
+      <th scope="col">Dernière invitation</th>
     <% end %>
     <% if show_convocation?(@current_configuration) %>
       <th scope="col">Dernière convocation envoyée le</th>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -676,12 +676,12 @@ describe UsersController do
       end
 
       let!(:user2) do
-        create(:user, organisations: [organisation], rdv_contexts: [rdv_context1], first_name: "Marie",
+        create(:user, organisations: [organisation], first_name: "Marie",
                       tag_users_attributes: [{ tag_id: tags[0].id }, { tag_id: tags[1].id }])
       end
 
       let!(:user3) do
-        create(:user, organisations: [organisation], rdv_contexts: [rdv_context2], first_name: "Oliva",
+        create(:user, organisations: [organisation], first_name: "Oliva",
                       tag_users_attributes: [{ tag_id: tags[2].id }])
       end
 
@@ -911,8 +911,7 @@ describe UsersController do
           let!(:index_params) { { department_id: department.id, motif_category_id: category_orientation.id } }
 
           before do
-            user.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 2.years.ago)
-            user2.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 1.year.ago)
+            user.rdv_contexts.first.update!(motif_category: category_orientation, created_at: 1.year.ago)
           end
 
           it "orders by rdv_context creation" do
@@ -922,43 +921,6 @@ describe UsersController do
             ordered_first_names = ordered_table & [user.first_name, user2.first_name]
 
             expect(ordered_first_names).to eq([user2.first_name, user.first_name])
-          end
-
-          context "when sorting by invitations" do
-            let!(:index_params) do
-              {
-                department_id: department.id,
-                motif_category_id: category_orientation.id,
-                sort_by: "last_invitation_sent_at",
-                sort_order: "down"
-              }
-            end
-
-            let!(:invitation) do
-              create(:invitation, rdv_context: user.rdv_contexts.first, user: user, sent_at: 1.year.ago)
-            end
-
-            let!(:invitation2) do
-              create(:invitation, rdv_context: user2.rdv_contexts.first, user: user2, sent_at: 2.years.ago)
-            end
-
-            # This is to make sure only the invitations of the current motif_category are taken into account
-            let!(:invitation_unused) do
-              create(:invitation, rdv_context: rdv_context_unused, user: user2, sent_at: 1.day.ago)
-            end
-
-            let(:rdv_context_unused) do
-              create(:rdv_context, motif_category: category_accompagnement, status: "rdv_seen")
-            end
-
-            it "orders by invitation creation" do
-              get :index, params: index_params
-
-              ordered_table = Nokogiri::XML(response.body).css("td").map(&:text)
-              ordered_first_names = ordered_table & [user.first_name, user2.first_name]
-
-              expect(ordered_first_names).to eq([user.first_name, user2.first_name])
-            end
           end
         end
       end


### PR DESCRIPTION
Reverts betagouv/rdv-insertion#1436

J'ai l'impression que le mécanisme inhérent à la PR ne fonctionne pas comme il faudrait ou en tous cas que l'ajout apporté  est trop confusant pour les utilisateurs à l'heure actuelle: 

![image](https://github.com/betagouv/rdv-insertion/assets/7602809/74947f50-ac55-4093-8047-dc03e9472974)

Je propose qu'on revert cette PR en attendant le retour de @Michaelvilleneuve .

Ce revert fait suite à une discussion ici: https://mattermost.incubateur.net/betagouv/pl/o5f93fs85bgc8yz951oh49htrh