### PR TITLE
refactor(sorting): Use simpler queries on index page

### DIFF
--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -1,7 +1,5 @@
 module Users::Sortable
   def order_users
-    return if params[:search_query].present?
-
     if archived_scope?
       archived_order
     elsif @current_motif_category
@@ -12,38 +10,16 @@ module Users::Sortable
   end
 
   def archived_order
-    @users.order("archives.created_at desc")
+    @user = @users.order("archives.created_at desc")
   end
 
   def motif_category_order
-    @users = @users
-             .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
-             .order("rdv_contexts.created_at desc")
+    @users = @users.select("users.*, rdv_contexts.created_at")
+                   .order("rdv_contexts.created_at desc")
   end
 
   def all_users_order
-    if department_level?
-      associated_users_organisations = UsersOrganisation
-                                       .where(organisations: @organisations)
-                                       .order(created_at: :desc)
-                                       .uniq(&:user_id)
-                                       .map(&:id)
-
-      users_affected_most_recently_to_an_organisation = {
-        users_organisations: {
-          id: associated_users_organisations
-        }
-      }
-    end
-
-    @users = @users.includes(:users_organisations, :archives)
-                   .select("
-                                DISTINCT(users.id),
-                                users.*,
-                                users_organisations.created_at as affected_at
-                              ")
-                   .active
-                   .where(users_affected_most_recently_to_an_organisation || {})
-                   .order("affected_at DESC NULLS LAST, users.id DESC")
+    @users = @users.select("users.*, users_organisations.created_at")
+                   .order("users_organisations.created_at DESC NULLS LAST, users.id DESC")
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -246,18 +246,17 @@ class UsersController < ApplicationController
 
   def set_all_users
     @users = policy_scope(User)
-             .active
+             .active.distinct
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
     return if request.format == "csv"
 
-    @users = @users.preload(rdv_contexts: [:invitations])
+    @users = @users.preload(:archives, rdv_contexts: [:invitations])
   end
 
   def set_users_for_motif_category
     @users = policy_scope(User)
              .preload(:organisations, rdv_contexts: [:notifications, :invitations])
-             .active
-             .select("DISTINCT(users.id), users.*, rdv_contexts.created_at")
+             .active.distinct
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
              .where.not(id: @department.archived_users.ids)
              .joins(:rdv_contexts)


### PR DESCRIPTION
J'ai remarqué en faisant certains tests que des doublons apparaissaient lorsqu'on faisait une recherche sur la page index. 
En me plongeant un peu dans le code j'ai remarqué que certaines queries n'étaient pas nécessaires.
J'enlève ici le code qui n'est pas nécessaire, et je fais en sorte de spécifier le `select` seulement à l'endroit où on en a besoin, c'est à dire l'endroit où on fait l'ordering en fonction de ce qu'on a sélectionné.