### PR TITLE
feat(stats): add timeouts to stats jobs

### DIFF
--- a/app/jobs/stats/global_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stat_job.rb
@@ -3,13 +3,18 @@ class StatsJobError < StandardError; end
 module Stats
   module GlobalStats
     class UpsertStatJob < ApplicationJob
+      sidekiq_options retry: 1
+
       def perform(structure_type, structure_id)
-        upsert_stat_record_for_global_stats =
-          Stats::GlobalStats::UpsertStat.call(structure_type: structure_type, structure_id: structure_id)
+        # to do : add timeout as a global concern for all jobs and remove it here
+        Timeout.timeout(10.minutes) do
+          upsert_stat_record_for_global_stats =
+            Stats::GlobalStats::UpsertStat.call(structure_type: structure_type, structure_id: structure_id)
 
-        return if upsert_stat_record_for_global_stats.success?
+          return if upsert_stat_record_for_global_stats.success?
 
-        raise StatsJobError, upsert_stat_record_for_global_stats.errors.join(" - ")
+          raise StatsJobError, upsert_stat_record_for_global_stats.errors.join(" - ")
+        end
       end
     end
   end

--- a/app/jobs/stats/monthly_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stat_job.rb
@@ -3,15 +3,20 @@ class StatsJobError < StandardError; end
 module Stats
   module MonthlyStats
     class UpsertStatJob < ApplicationJob
+      sidekiq_options retry: 1
+
       def perform(structure_type, structure_id, until_date_string)
-        upsert_stat_record_for_monthly_stats =
-          Stats::MonthlyStats::UpsertStat.call(
-            structure_type: structure_type, structure_id: structure_id, until_date_string: until_date_string
-          )
+        # to do : add timeout as a global concern for all jobs and remove it here
+        Timeout.timeout(10.minutes) do
+          upsert_stat_record_for_monthly_stats =
+            Stats::MonthlyStats::UpsertStat.call(
+              structure_type: structure_type, structure_id: structure_id, until_date_string: until_date_string
+            )
 
-        return if upsert_stat_record_for_monthly_stats.success?
+          return if upsert_stat_record_for_monthly_stats.success?
 
-        raise StatsJobError, upsert_stat_record_for_monthly_stats.errors.join(" - ")
+          raise StatsJobError, upsert_stat_record_for_monthly_stats.errors.join(" - ")
+        end
       end
     end
   end


### PR DESCRIPTION
Ceci est un fix temporaire pour éviter d'avoir à tuer à la main les jobs de stats qui n'arrivent pas à se résoudre.

J'ai essayé de faire ça plus proprement en mettant en place un système de hard_timeout global pour les jobs, inspiré par ce qu'a fait rdv-s, mais j'ai rencontré diverses erreurs que je n'ai pas réussi/pas eu le temps de surmonter. Intéressé de faire du pair programming sur ce point avec l'un de vous deux en rentrant de vacances. 

Pour documenter, la solution de rdv-s ne fonctionne pas car ils utilisent `ActiveJob` et peuvent donc se servir du callback `around_perform`, ce qu'on ne peut pas faire. J'ai donc suivi deux pistes : 
- ajouter le callback dans un server middleware (en suivant [la doc de Sidekiq](https://github.com/sidekiq/sidekiq/wiki/Middleware) + j'ai trouvé ensuite [un article de Drivy](https://getaround.tech/use-sidekiq-middleware/) qui me faisait penser que c'était une bonne piste)
- réimplementer le callback `around_peform` ([inspiré par cet article](https://kevinjalbert.com/sidekiq-contained-callbacks/))