### PR TITLE
fix(upload): re-add multiple selection checkbox

### DIFF
--- a/app/javascript/react/pages/UsersUpload.jsx
+++ b/app/javascript/react/pages/UsersUpload.jsx
@@ -53,7 +53,7 @@ const UsersUpload = observer(
       users.isDepartmentLevel = isDepartmentLevel;
 
       const rows = await uploadFile(file, sheetName, columnNames)
-      
+
       rows.forEach((row) => {
         const user = new User({
           lastName: row[parameterizedColumnNames.last_name_column],
@@ -236,7 +236,21 @@ const UsersUpload = observer(
 
                       return (
                         <th {...column.attributes} key={column.name}>
-                          {column.sortable ? (
+                          {column.name === "Séléction" ? (
+                            <>
+                              {column.name}<br />
+                              <input
+                                type="checkbox"
+                                className="form-check-input"
+                                checked={users.list.every((user) => user.selected)}
+                                onChange={(event) =>
+                                  users.list.forEach((user) => {
+                                    user.selected = event.target.checked;
+                                  })
+                                }
+                              />
+                            </>
+                          ) : column.sortable ? (
                             <button type="button" onClick={() => users.sort(column.key)} >
                               {column.name} <i className={`fas fa-sort fa-sort-${users.sortBy === column.key && users.sortDirection} />`} />
                             </button>


### PR DESCRIPTION
closes #1500 

Je corrige ici un bug introduit par [cette PR](https://github.com/betagouv/rdv-insertion/pull/1454). À la suite de cette modif, les agents n'avaient plus la possibilité de sélectionner les usagers en masse lors de l'import de ceux-ci. La checkbox du `th`avait disparu. Je la remet ici - @Michaelvilleneuve on pourrait peut-être rajouter un feature test et/ou refactorer ce que j'ai fait.