### PR TITLE
fix(csv): add rdv_context status in users csv export when motif_category

### DIFF
--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -19,7 +19,24 @@ module Users::Sortable
   end
 
   def all_users_order
-    @users = @users.select("users.*, users_organisations.created_at")
-                   .order("users_organisations.created_at DESC NULLS LAST, users.id DESC")
+    if department_level?
+      associated_users_organisations = UsersOrganisation
+                                       .where(organisations: @organisations)
+                                       .order(created_at: :desc)
+                                       .uniq(&:user_id)
+                                       .map(&:id)
+
+      users_affected_most_recently_to_an_organisation = {
+        users_organisations: {
+          id: associated_users_organisations
+        }
+      }
+    end
+
+    @users = @users.includes(:users_organisations, :archives)
+                   .select("users.*, users_organisations.created_at as affected_at")
+                   .active
+                   .where(users_affected_most_recently_to_an_organisation || {})
+                   .order("affected_at DESC NULLS LAST, users.id DESC")
   end
 end

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -10,7 +10,7 @@ module Users::Sortable
   end
 
   def archived_order
-    @user = @users.order("archives.created_at desc")
+    @users = @users.order("archives.created_at desc")
   end
 
   def motif_category_order

--- a/config/locales/models/rdv.fr.yml
+++ b/config/locales/models/rdv.fr.yml
@@ -4,7 +4,7 @@ fr:
       rdv: Rendez-vous
     attributes:
       rdv:
-        status: Statut
+        status: Statut du rdv
         statuses:
           unknown: Non déterminé
           seen: Rendez-vous honoré

--- a/config/locales/models/rdv_context.fr.yml
+++ b/config/locales/models/rdv_context.fr.yml
@@ -4,7 +4,7 @@ fr:
       rdv_context: Contexte du RDV
     attributes:
       rdv_context:
-        status: Statut
+        status: Statut de la catégorie de motifs
         statuses:
           not_invited: Non invité
           invitation_pending: Invitation en attente de réponse

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -94,7 +94,8 @@ describe Exporters::GenerateUsersCsv, type: :service do
         expect(csv).to include("Rôle")
         expect(csv).to include("Archivé le")
         expect(csv).to include("Motif d'archivage")
-        expect(csv).to include("Statut")
+        expect(csv).to include("Statut du rdv")
+        expect(csv).to include("Statut de la catégorie de motifs")
         expect(csv).to include("Première invitation envoyée le")
         expect(csv).to include("Dernière invitation envoyée le")
         expect(csv).to include("Dernière convocation envoyée le")
@@ -159,9 +160,10 @@ describe Exporters::GenerateUsersCsv, type: :service do
           expect(csv).to include("RSA orientation sur site") # last rdv motif
           expect(csv).to include("individuel") # last rdv type
           expect(csv).to include("individuel;Oui") # last rdv taken in autonomy ?
-          expect(csv).to include("Non déterminé") # rdv_context status
-          expect(csv).to include("Non déterminé;Oui") # first rdv in less than 30 days ?
-          expect(csv).to include("individuel;Oui;Non déterminé;Oui;25/05/2022") # orientation date
+          expect(csv).to include("Non déterminé") # rdv status
+          expect(csv).to include("Statut du RDV à préciser") # rdv_context status
+          expect(csv).to include("Statut du RDV à préciser;Oui") # first rdv in less than 30 days ?
+          expect(csv).to include("Non déterminé;Statut du RDV à préciser;Oui;25/05/2022") # orientation date
         end
 
         it "displays the organisation infos" do
@@ -205,6 +207,11 @@ describe Exporters::GenerateUsersCsv, type: :service do
 
         it "generates the right filename" do
           expect(subject.filename).to eq("Export_beneficiaires_organisation_drome_rsa.csv")
+        end
+
+        it "generates headers" do
+          expect(csv).to start_with("\uFEFF")
+          expect(csv).not_to include("Statut de la catégorie de motifs")
         end
       end
     end


### PR DESCRIPTION
Dans cette PR, je réponds à une demande de la Manche : comme je le craignais, le fait de supprimer le statut du `rdv_context` (avec la disparition des informations "invitation en attente de réponse" et "délai dépassé") les a perturbé. Ils nous ont réclamé qu'on les remette. Plutôt que de les "forcer" à faire des croisements compliqués dans leurs tableaux Excel, je remet le statut du `rdv_context` dans une autre colonne.

N.B. : en testant la modif, j'ai eu [ce bug bizarre qu'on ne comprenait pas](https://sentry.incubateur.net/organizations/betagouv/issues/69684/?project=16&query=is%3Aunresolved&referrer=issue-stream) avec @aminedhobb. Visiblement il provient du `order_users` pour `all_users`. J'ai donc remis plus ou moins la requête de tri que l'on faisait avant de la modifier dans [cette PR](https://github.com/betagouv/rdv-insertion/pull/1490/files), il y a peut-être mieux à faire mais en attendant ça semble avoir résolu le problème tout en gardant un bon tri sur la page index. 