### PR TITLE
fix(postal): fix invitation code flow

### DIFF
--- a/app/views/invitations/invitation_code.html.erb
+++ b/app/views/invitations/invitation_code.html.erb
@@ -7,10 +7,9 @@
       <p>Vous avez reçu par courrier une invitation à prendre rendez-vous d'orientation dans le cadre de votre parcours d'insertion. En le saisissant ci-dessous, vous serez redirigé vers le site RDV-Solidarités, qui vous permettra de choisir un créneau qui vous convient.</p>
     </div>
     <div class="d-flex flex-column card-white col-8 align-items-center mt-3 rdv-insertion-form text-dark-blue h4-as-labels">
-      <%= form_with url: :redirect_invitations, method: :get, local: :true do |f| %>
+      <%= form_with url: :redirect_invitations, method: :get, local: :true, data: { turbo: false } do |f| %>
         <h4 class="text-dark-blue h4-as-labels">Code d'invitation</h4>
         <p><%= f.text_field :uuid, placeholder: "DKC92JX7" %></p>
-        <%= f.hidden_field :format, value: "postal" %>
         <div class="d-flex justify-content-center">
           <button type="submit" class="btn btn-blue">Valider</button>
         </div>


### PR DESCRIPTION
closes #1513 

## Contexte 

Lorsque nous redirigeons vers rdv-solidarites via l'action `invitations#redirect`, nous stockons le token d'invitation dans la session rdv-solidarités et faisons apparaitre l'url sans ce token d'invitation (qui permettrait, s'il était récupéré, d'accéder à tous les motifs normalement réservés aux invitations). Ce mécanisme se trouve [ici](https://github.com/betagouv/rdv-solidarites.fr/blob/60f8758d0bcb5f91e44bbaa4dec78b59807fb765/app/controllers/concerns/token_invitable.rb#L15) dans la codebase rdvs.

## Problématique

Le problème, c'est que quand nous appelons l'action `invitations#redirect` via le formulaire de la page `/invitation`, les headers de la requête n'étaient pas les mêmes que lorsque nous cliquions sur le lien dans le mail ou le sms. Notamment le header [Sec-Fetch-Mode](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode) qui était `cors` au lieu de `navigate`. Mon hypothèse est que cette différenciation de protocole faisait que le cookie avec l'id de la session rdvs  (`_lapin_session_id`) n'était pas setté lors de la première requête à rdvs, ce qui fait que lorsque nous redirigions vers l'url sans le token, l'invitation persistée en session n'était plus retrouvée.

## Résolution

À priori ajouter l'option  `data: { turbo: false } ` au formulaire permet d'avoir une navigation similaire que cliquer sur le lien sms/mail et résout ce problème.

Remarque: Les problèmes de CORS étaient déjà connus lorsqu'on redirige après soumission d'un formulaire depuis hotwire.