### PR TITLE
fix(letters): Always create a messages configuration record

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -76,8 +76,7 @@ class ConfigurationsController < ApplicationController
   end
 
   def set_messages_configuration
-    @messages_configuration = @organisation.messages_configuration ||
-                              MessagesConfiguration.new(organisation: @organisation)
+    @messages_configuration = @organisation.messages_configuration
   end
 
   def set_file_configuration

--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -95,7 +95,7 @@ u {
     display: inline-block;
 
     img {
-      max-width: 300px;
+      max-width: 275px;
     }
 
     &:last-child {

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -5,6 +5,8 @@ class Organisation < ApplicationRecord
   include Searchable
   include HasLogo
 
+  before_create { build_messages_configuration }
+
   validates :rdv_solidarites_organisation_id, uniqueness: true, allow_nil: true
   validates :name, presence: true
   validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }

--- a/db/migrate/20231109092923_add_messages_configurations_to_all_organisations.rb
+++ b/db/migrate/20231109092923_add_messages_configurations_to_all_organisations.rb
@@ -1,0 +1,8 @@
+class AddMessagesConfigurationsToAllOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    Organisation.where.missing(:messages_configuration).find_each do |organisation|
+      organisation.build_messages_configuration
+      organisation.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_22_125225) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_09_092923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
closes #1523 

Dans cette PR je fais en sorte qu'une organisation ait toujours un record de `messages_configuration` associé. 
Parce que quand on ne persistait pas on avait choisi d'instancier une nouvelle instance de `messages_configuration` avec les valeurs par défaut sur certaines colonnes qui n'étaient pas reflétées à la génération du courrier, ce qui pouvait porter à confusion.
Je fais aussi en sorte de diminuer la largeur max d'un logo car lorsqu'on affichait le logo rdvi uniquement les courriers s'affichaient sur 2 pages. 