### PR TITLE
fix(tags/drag n drop): minor changes

### DIFF
--- a/app/views/tag_assignations/_form.html.erb
+++ b/app/views/tag_assignations/_form.html.erb
@@ -2,4 +2,8 @@
   <% tags.each do |tag| %>
     <%= render "tag_assignation", tag: tag, assigned: @user.tag_ids.include?(tag.id) %>
   <% end %>
+
+  <% if tags.empty? %>
+    <p>Aucun tag disponible. Vous pouvez créer des tags depuis la configuration d'une organisation.</p>
+  <% end %>
 </div>

--- a/app/views/users/_users_list_tabs.html.erb
+++ b/app/views/users/_users_list_tabs.html.erb
@@ -8,7 +8,7 @@
       <li class="nav-item" data-id="<%= configuration.id %>">
         <%= link_to compute_index_path(@organisation, @department, motif_category_id: configuration.motif_category_id), class: "nav-link d-flex align-items-center #{configuration.id == @current_configuration&.id ? 'active' : ''}" do %>
           <%= configuration.motif_category_name %>
-          <% if @current_agent_roles.any?(&:admin?) %>
+          <% if @current_agent_roles.any?(&:admin?) && @all_configurations.size > 1 %>
             <i data-controller="tooltip" data-action="mouseover->tooltip#reOrderCategories" class="fas fa-grip-vertical"></i>
           <% end %>
         <% end %>


### PR DESCRIPTION
Juste 2 petites améliorations : 
- Pas d'icone pour drag n drop s'il y une seule tab

<img width="606" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/e5574a88-a93a-460c-82dc-1a747edd8c2e">


- Un texte explicatif lorsqu'aucun tag n'existe

<img width="544" alt="Screenshot 2023-11-09 at 10 55 19" src="https://github.com/betagouv/rdv-insertion/assets/4990201/88411282-2b8a-4a3e-a290-137b516b19fd">
