### PR TITLE
refactor(app): rename rdvs_users to participations

### DIFF
--- a/app/clients/rdv_solidarites_client.rb
+++ b/app/clients/rdv_solidarites_client.rb
@@ -178,9 +178,9 @@ class RdvSolidaritesClient
     )
   end
 
-  def update_participation(rdvs_user_id, request_body = {})
+  def update_participation(participation_id, request_body = {})
     Faraday.patch(
-      "#{@url}/api/v1/rdvs_users/#{rdvs_user_id}",
+      "#{@url}/api/v1/participations/#{participation_id}",
       request_body.to_json,
       request_headers
     )

--- a/app/models/rdv_solidarites/rdv.rb
+++ b/app/models/rdv_solidarites/rdv.rb
@@ -17,8 +17,8 @@ module RdvSolidarites
     end
 
     def participations
-      @attributes[:rdvs_users].map do |rdvs_user_attributes|
-        RdvSolidarites::Participation.new(rdvs_user_attributes.merge(rdv: @attributes))
+      @attributes[:participations].map do |participation_attributes|
+        RdvSolidarites::Participation.new(participation_attributes.merge(rdv: @attributes))
       end
     end
 

--- a/app/services/participations/update.rb
+++ b/app/services/participations/update.rb
@@ -22,7 +22,7 @@ module Participations
       @update_rdv_solidarites_participation ||= call_service!(
         RdvSolidaritesApi::UpdateParticipation,
         rdv_solidarites_session: @rdv_solidarites_session,
-        rdv_solidarites_rdvs_user_id: @participation.rdv_solidarites_participation_id,
+        rdv_solidarites_participation_id: @participation.rdv_solidarites_participation_id,
         participation_attributes: @participation_params
       )
     end

--- a/app/services/rdv_solidarites_api/update_participation.rb
+++ b/app/services/rdv_solidarites_api/update_participation.rb
@@ -1,8 +1,8 @@
 module RdvSolidaritesApi
   class UpdateParticipation < Base
-    def initialize(participation_attributes:, rdv_solidarites_session:, rdv_solidarites_rdvs_user_id:)
+    def initialize(participation_attributes:, rdv_solidarites_session:, rdv_solidarites_participation_id:)
       @rdv_solidarites_session = rdv_solidarites_session
-      @rdv_solidarites_rdvs_user_id = rdv_solidarites_rdvs_user_id
+      @rdv_solidarites_participation_id = rdv_solidarites_participation_id
       @participation_attributes = participation_attributes
     end
 
@@ -15,7 +15,7 @@ module RdvSolidaritesApi
 
     def rdv_solidarites_response
       @rdv_solidarites_response ||= rdv_solidarites_client.update_participation(
-        @rdv_solidarites_rdvs_user_id,
+        @rdv_solidarites_participation_id,
         @participation_attributes
       )
     end

--- a/spec/features/agent_can_update_a_participation_status_spec.rb
+++ b/spec/features/agent_can_update_a_participation_status_spec.rb
@@ -25,7 +25,7 @@ describe "Agents can update a participation status", js: true do
 
   before do
     setup_agent_session(agent)
-    stub_request(:patch, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/rdvs_users/#{rdvs_participation_id}")
+    stub_request(:patch, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/participations/#{rdvs_participation_id}")
       .to_return(status: 200, body: "{}")
   end
 

--- a/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
+++ b/spec/jobs/rdv_solidarites_webhooks/process_rdv_job_spec.rb
@@ -44,7 +44,7 @@ describe RdvSolidaritesWebhooks::ProcessRdvJob do
       "lieu" => lieu_attributes,
       "motif" => motif_attributes,
       "users" => users,
-      "rdvs_users" => participations_attributes,
+      "participations" => participations_attributes,
       "organisation" => { id: rdv_solidarites_organisation_id },
       "agents" => [{ id: agent.rdv_solidarites_agent_id }]
     }.deep_symbolize_keys

--- a/spec/services/participations/update_spec.rb
+++ b/spec/services/participations/update_spec.rb
@@ -16,7 +16,7 @@ describe Participations::Update, type: :service do
       {
         :participation_attributes => { :status => "seen" },
         :rdv_solidarites_session => rdv_solidarites_session,
-        :rdv_solidarites_rdvs_user_id => participation.rdv_solidarites_participation_id
+        :rdv_solidarites_participation_id => participation.rdv_solidarites_participation_id
       }
     )
   end


### PR DESCRIPTION
Suite à https://github.com/betagouv/rdv-solidarites.fr/pull/3857
Nous sommes les seuls à utiliser l'endpoint participations#update pour l'api donc je le met à jour ici avant de le renommer définitivement coté RDVSP.