### PR TITLE
feat(invitations): change atelier invitation mailer message

### DIFF
--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -40,8 +40,8 @@ module Invitations
 
     def atelier_content
       "#{user.full_name},\nVous êtes #{user_designation} et bénéficiez d'un accompagnement. " \
-        "Pour en profiter au mieux, nous vous invitons " \
-        "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le lien " \
+        "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
+        "librement, dans la limite des places disponibles, en cliquant sur le lien " \
         "suivant: #{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \

--- a/app/views/mailers/invitation_mailer/atelier_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/atelier_invitation.html.erb
@@ -1,9 +1,9 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
-<p>Vous êtes <%= @user_designation %> et bénéficiez d'un accompagnement. Pour en profiter au mieux, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
-<p><span class="font-weight-bold">Pour choisir vous-même la date et l'horaire</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant.</p>
+<p>Vous êtes <%= @user_designation %> et bénéficiez d'un accompagnement. Pour en profiter au mieux, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix, dans la limite des places disponibles.</p>
+<p><span class="font-weight-bold">Pour consulter le(s) atelier(s) proposé(s)</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
-    Choisir un créneau
+    M'inscrire
   <% end %>
 </p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>

--- a/app/views/mailers/invitation_mailer/atelier_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/atelier_invitation.html.erb
@@ -1,6 +1,5 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
-<p>Vous êtes <%= @user_designation %> et bénéficiez d'un accompagnement. Pour en profiter au mieux, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix, dans la limite des places disponibles.</p>
-<p><span class="font-weight-bold">Pour consulter le(s) atelier(s) proposé(s)</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant.</p>
+<p>Vous êtes <%= @user_designation %> et bénéficiez d'un accompagnement. En cliquant sur le bouton suivant, vous pouvez <span class="font-weight-bold">consulter le(s) atelier(s) et formation(s) proposé(s)</span> sur la plateforme RDV-Solidarités et vous y inscrire directement et librement, dans la limite des places disponibles.</p>
 <p class="btn-wrapper">
   <%= link_to redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST']), class: "btn btn-primary" do %>
     M'inscrire

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -738,9 +738,9 @@ RSpec.describe InvitationMailer do
       expect(body_string).to match("01 39 39 39 39")
       expect(body_string).to match(
         "Vous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
-        "Pour en profiter au mieux," \
-        " nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix, " \
-        "dans la limite des places disponibles."
+        "En cliquant sur le bouton suivant, vous pouvez <span class=\"font-weight-bold\">consulter le\\(s\\) " \
+        "atelier\\(s\\) et formation\\(s\\) proposé\\(s\\)</span> sur la plateforme " \
+        "RDV-Solidarités et vous y inscrire directement et librement, dans la limite des places disponibles."
       )
       expect(body_string).to match("/invitations/redirect")
       expect(body_string).to match("uuid=#{invitation.uuid}")

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -739,7 +739,8 @@ RSpec.describe InvitationMailer do
       expect(body_string).to match(
         "Vous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
         "Pour en profiter au mieux," \
-        " nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix."
+        " nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix, " \
+        "dans la limite des places disponibles."
       )
       expect(body_string).to match("/invitations/redirect")
       expect(body_string).to match("uuid=#{invitation.uuid}")

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -731,9 +731,8 @@ describe Invitations::SendSms, type: :service do
       end
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
-          "Pour en profiter au mieux, nous vous invitons " \
-          "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le " \
-          "lien suivant: " \
+          "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
+          "librement, dans la limite des places disponibles, en cliquant sur le lien suivant: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
@@ -757,9 +756,8 @@ describe Invitations::SendSms, type: :service do
       end
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
-          "Pour en profiter au mieux, nous vous invitons " \
-          "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le " \
-          "lien suivant: " \
+          "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
+          "librement, dans la limite des places disponibles, en cliquant sur le lien suivant: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
@@ -783,9 +781,8 @@ describe Invitations::SendSms, type: :service do
       end
       let!(:content) do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
-          "Pour en profiter au mieux, nous vous invitons " \
-          "à vous inscrire directement et librement aux ateliers et formations de votre choix en cliquant sur le " \
-          "lien suivant: " \
+          "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
+          "librement, dans la limite des places disponibles, en cliquant sur le lien suivant: " \
           "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end


### PR DESCRIPTION
Dans certains cas, les invitations envoyées pour des ateliers concernent un atelier unique ; les bénéficiaires n'ont donc pas le choix du créneau. De plus, les ateliers ont a priori toujours un nombre de place limité (par la taille de la salle), et même si ce n'est pas le cas, la phrase à ce sujet n'est pas gênante.
J'essaye donc de prendre en compte ces éléments avec ce changement, afin de rendre le template d'invitation aux ateliers plus générique.