### PR TITLE
fix(reminders): don't send convocation reminder if the participation is cancelled

### DIFF
--- a/app/jobs/send_convocation_reminders_job.rb
+++ b/app/jobs/send_convocation_reminders_job.rb
@@ -12,6 +12,7 @@ class SendConvocationRemindersJob < ApplicationJob
     @participations_to_send_reminders_to ||=
       Participation.joins(:rdv)
                    .where(convocable: true)
+                   .where.not(status: Participation::CANCELLED_STATUSES)
                    .where(rdvs: { starts_at: 2.days.from_now.all_day })
   end
 

--- a/app/jobs/send_convocation_reminders_job.rb
+++ b/app/jobs/send_convocation_reminders_job.rb
@@ -12,8 +12,8 @@ class SendConvocationRemindersJob < ApplicationJob
     @participations_to_send_reminders_to ||=
       Participation.joins(:rdv)
                    .where(convocable: true)
-                   .where.not(status: Participation::CANCELLED_STATUSES)
                    .where(rdvs: { starts_at: 2.days.from_now.all_day })
+                   .not_cancelled
   end
 
   def notify_on_mattermost

--- a/app/models/concerns/rdv_participation_status.rb
+++ b/app/models/concerns/rdv_participation_status.rb
@@ -9,6 +9,7 @@ module RdvParticipationStatus
     enum status: { unknown: 0, seen: 2, excused: 3, revoked: 4, noshow: 5 }
 
     scope :cancelled_by_user, -> { where(status: CANCELLED_BY_USER_STATUSES) }
+    scope :not_cancelled, -> { where.not(status: CANCELLED_STATUSES) }
     scope :status, ->(status) { where(status: status) }
     scope :resolved, -> { where(status: %w[seen excused revoked noshow]) }
   end

--- a/app/services/notifications/notify_participation.rb
+++ b/app/services/notifications/notify_participation.rb
@@ -7,7 +7,7 @@ module Notifications
     end
 
     def call
-      return if @participation.in_the_past?
+      return if @participation.in_the_past? || reminder_of_cancelled_participation?
 
       Notification.transaction do
         save_record!(notification)
@@ -40,6 +40,10 @@ module Notifications
     def update_notification_sent_at
       notification.sent_at = Time.zone.now
       save_record!(notification)
+    end
+
+    def reminder_of_cancelled_participation?
+      @event == "participation_reminder" && @participation.cancelled?
     end
   end
 end

--- a/spec/jobs/send_convocation_reminders_job_spec.rb
+++ b/spec/jobs/send_convocation_reminders_job_spec.rb
@@ -7,10 +7,12 @@ describe SendConvocationRemindersJob do
     let!(:participation1) { create(:participation, id: 239, convocable: true) }
     let!(:participation2) { create(:participation, convocable: false) }
     let!(:participation3) { create(:participation, convocable: true) }
+    let!(:participation4) { create(:participation, convocable: true, status: "revoked") }
 
     let!(:rdv1) { create(:rdv, starts_at: 2.days.from_now, participations: [participation1]) }
     let!(:rdv2) { create(:rdv, starts_at: 2.days.from_now, participations: [participation2]) }
     let!(:rdv3) { create(:rdv, starts_at: 3.days.from_now, participations: [participation3]) }
+    let!(:rdv4) { create(:rdv, starts_at: 2.days.from_now, participations: [participation4]) }
 
     before do
       allow(NotifyParticipationsJob).to receive(:perform_async)

--- a/spec/services/notifications/notify_participation_spec.rb
+++ b/spec/services/notifications/notify_participation_spec.rb
@@ -60,5 +60,18 @@ describe Notifications::NotifyParticipation, type: :service do
         subject
       end
     end
+
+    context "when it is a reminder of a cancelled participation" do
+      let!(:event) { "participation_reminder" }
+
+      before { participation.update! status: "revoked" }
+
+      it("is a success") { is_a_success }
+
+      it "does not send a notification" do
+        expect(Notifications::SendSms).not_to receive(:call)
+        subject
+      end
+    end
   end
 end


### PR DESCRIPTION
Lorsqu'un rdv de convocation était annulé, le reminder de rdv était malgré tout envoyé. Le problème avait été remonté par @Evajuliab [ici](https://mattermost.incubateur.net/betagouv/pl/b3h75rxzkpribps5jumqukixje). Cette PR résout ce problème. J'aurais peut-être pu me contenter de faire un seul des deux fixs mais je me dis que ça ne coûte pas grand chose de s'assurer qu'on ne le fait pas (dans `NotifyParticipation`, cela check aussi pour les invitations)