### PR TITLE
fix(ordering): order users correctly when all users displayed

### DIFF
--- a/app/controllers/concerns/users/filterable.rb
+++ b/app/controllers/concerns/users/filterable.rb
@@ -52,8 +52,8 @@ module Users::Filterable
   def filter_users_by_search_query
     return if params[:search_query].blank?
 
-    # with_pg_search_rank scope added to be compatible with distinct https://github.com/Casecommons/pg_search/issues/238
-    @users = @users.search_by_text(params[:search_query]).with_pg_search_rank
+    # reorder is necessary to use distinct and ordering https://github.com/Casecommons/pg_search/issues/238#issuecomment-543702501
+    @users = @users.search_by_text(params[:search_query]).reorder("")
   end
 
   def filter_users_by_page

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -14,18 +14,13 @@ module Users::Sortable
   end
 
   def motif_category_order
-    @users = @users.select(
-      "users.*," \
-      "(SELECT MAX(rdv_contexts.created_at) " \
-      "FROM rdv_contexts WHERE rdv_contexts.user_id = users.id) AS affected_at"
-    ).order("affected_at DESC, users.id DESC")
+    @users = @users.select("users.*, rdv_contexts.created_at")
+                   .order("rdv_contexts.created_at desc")
   end
 
   def all_users_order
-    @users = @users.select(
-      "users.*," \
-      "(SELECT MAX(users_organisations.created_at) " \
-      "FROM users_organisations WHERE users_organisations.user_id = users.id) AS affected_at" \
-    ).order("affected_at DESC NULLS last, users.id DESC")
+    @users = @users.select("users.*, MIN(users_organisations.created_at) AS min_created_at")
+                   .group("users.id")
+                   .order("min_created_at DESC")
   end
 end

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -14,12 +14,18 @@ module Users::Sortable
   end
 
   def motif_category_order
-    @users = @users.select("users.*, rdv_contexts.created_at")
-                   .order("rdv_contexts.created_at desc")
+    @users = @users.select(
+      "users.*," \
+      "(SELECT MAX(rdv_contexts.created_at) " \
+      "FROM rdv_contexts WHERE rdv_contexts.user_id = users.id) AS affected_at"
+    ).order("affected_at DESC, users.id DESC")
   end
 
   def all_users_order
-    @users = @users.select("users.*, users_organisations.created_at as affected_at")
-                   .order("affected_at DESC NULLS LAST, users.id DESC")
+    @users = @users.select(
+      "users.*," \
+      "(SELECT MAX(users_organisations.created_at) " \
+      "FROM users_organisations WHERE users_organisations.user_id = users.id) AS affected_at" \
+    ).order("affected_at DESC NULLS last, users.id DESC")
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -262,7 +262,7 @@ class UsersController < ApplicationController
 
   def set_all_users
     @users = policy_scope(User)
-             .active.distinct
+             .active
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
     return if request.format == "csv"
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -262,7 +262,7 @@ class UsersController < ApplicationController
 
   def set_all_users
     @users = policy_scope(User)
-             .active
+             .active.distinct
              .where(department_level? ? { organisations: @organisations } : { organisations: @organisation })
     return if request.format == "csv"
 

--- a/db/migrate/20231121133009_fill_null_users_organisations_created_at.rb
+++ b/db/migrate/20231121133009_fill_null_users_organisations_created_at.rb
@@ -1,0 +1,7 @@
+class FillNullUsersOrganisationsCreatedAt < ActiveRecord::Migration[7.0]
+  def change
+    UsersOrganisation.includes(:user).where(created_at: nil).find_each do |users_organisation|
+      users_organisation.update! created_at: users_organisation.user.created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_09_092923) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_21_133009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
On avait 2 problèmes dans la page "tous les contacts" sur une organisation: 

* Lorsqu'un usager appartenait à plusieurs organisations au niveau du département, on le sélectionnait 2 fois puisque dans la requête on sélectionnait les `users_organisations.created_at` associés et il pouvait y en avoir plusieurs. 
* Les usagers n'apparaissaient pas forcément dans l'ordre d'affectation au département quand ils appartenaient à plusieurs orgas du département

Je fais en sorte de ne plus avoir de doublons et de les avoir dans le bon ordre en modifiant la requête et en ne prenant en compte que la première date d'affectation à une organisation du département. 

J'ajoute également un fichier de migration pour ne pas avoir de date nulle en création de `users_organisations`, ce qui pouvait créer des erreurs. Pour celles qui sont nulles je prends la date de création de l'usager comme date d'affectation à l'organisation.

Je rajoute également des tests pour les cas cités.
