### PR TITLE
fix(letters): move down object line

### DIFF
--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -38,13 +38,13 @@ u {
 }
 
 .mail-object {
-  margin: 40px 0 20px;
+  margin: 60px 0 20px;
 }
 
 .main-content {
   width: 95%;
   margin-left: 40px;
-  margin-bottom: 80px;
+  margin-bottom: 60px;
   font-size: 18px;
   p {
     text-align:justify;


### PR DESCRIPTION
Le 44 avait un problème, vu avec @SalmaBennani : le mot "RSA" qui apparaissait dans l'objet de la lettre était visible dans la fenêtre de l'enveloppe envoyée au bénéficiaire. Cette PR corrige ce souci. Pour éviter que les courriers passent sur 2 pages, je récupère en sur la bottom-margin entre les signatures et les logos. 