### PR TITLE
fix(api): re-disable creneau check when async api call

### DIFF
--- a/app/jobs/invite_user_job.rb
+++ b/app/jobs/invite_user_job.rb
@@ -23,7 +23,8 @@ class InviteUserJob < ApplicationJob
       organisations: [@organisation],
       invitation_attributes: @invitation_attributes,
       motif_category_attributes: @motif_category_attributes,
-      rdv_solidarites_session:
+      rdv_solidarites_session:,
+      check_creneaux_availability: false
     )
     return if invite_user_service.success?
 

--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -1,11 +1,17 @@
 class InviteUser < BaseService
-  def initialize(user:, organisations:, invitation_attributes:, motif_category_attributes:, rdv_solidarites_session:)
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(
+    user:, organisations:, invitation_attributes:, motif_category_attributes:, rdv_solidarites_session:,
+    check_creneaux_availability: true
+  )
     @user = user
     @organisations = organisations
     @invitation_attributes = invitation_attributes
     @motif_category_attributes = motif_category_attributes
     @rdv_solidarites_session = rdv_solidarites_session
+    @check_creneaux_availability = check_creneaux_availability
   end
+  # rubocop:enable Metrics/ParameterLists
 
   def call
     set_current_configuration
@@ -84,7 +90,8 @@ class InviteUser < BaseService
     call_service!(
       Invitations::SaveAndSend,
       invitation: @invitation,
-      rdv_solidarites_session: @rdv_solidarites_session
+      rdv_solidarites_session: @rdv_solidarites_session,
+      check_creneaux_availability: @check_creneaux_availability
     )
   end
 end

--- a/spec/jobs/invite_user_job_spec.rb
+++ b/spec/jobs/invite_user_job_spec.rb
@@ -34,7 +34,7 @@ describe InviteUserJob do
       allow(InviteUser).to receive(:call)
         .with(
           user:, organisations: [organisation], invitation_attributes:, motif_category_attributes:,
-          rdv_solidarites_session:
+          rdv_solidarites_session:, check_creneaux_availability: false
         )
         .and_return(OpenStruct.new(success?: true))
     end
@@ -43,7 +43,7 @@ describe InviteUserJob do
       expect(InviteUser).to receive(:call)
         .with(
           user:, organisations: [organisation], invitation_attributes:, motif_category_attributes:,
-          rdv_solidarites_session:
+          rdv_solidarites_session:, check_creneaux_availability: false
         )
       subject
     end

--- a/spec/services/invite_user_spec.rb
+++ b/spec/services/invite_user_spec.rb
@@ -1,10 +1,12 @@
 describe InviteUser, type: :service do
   subject do
     described_class.call(
-      user:, organisations:, invitation_attributes:, motif_category_attributes:, rdv_solidarites_session:
+      user:, organisations:, invitation_attributes:, motif_category_attributes:, rdv_solidarites_session:,
+      check_creneaux_availability:
     )
   end
 
+  let!(:check_creneaux_availability) { true }
   let!(:department) { create(:department) }
   let!(:user) { create(:user, organisations: [organisation]) }
   let!(:organisation) { create(:organisation, department:, configurations: [configuration]) }
@@ -49,6 +51,7 @@ describe InviteUser, type: :service do
 
     it "saves and send the invitation" do
       expect(Invitations::SaveAndSend).to receive(:call)
+        .with(invitation:, rdv_solidarites_session:, check_creneaux_availability:)
       subject
     end
 
@@ -71,6 +74,7 @@ describe InviteUser, type: :service do
 
         it "saves and send the invitation" do
           expect(Invitations::SaveAndSend).to receive(:call)
+            .with(invitation:, rdv_solidarites_session:, check_creneaux_availability:)
           subject
         end
       end


### PR DESCRIPTION
Avec les changements au niveau de l'API et la refacto des services liées aux invitations, le fait d'enlever le check des créneaux disponible lorsqu'on fait un appel API asynchrone ne se fait plus.
Je fais en sorte de le remettre ici.