### PR TITLE
fix(session): Fix incoherence when agent session credentials invalid

### DIFF
--- a/app/controllers/concerns/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/authenticated_controller_concern.rb
@@ -11,8 +11,17 @@ module AuthenticatedControllerConcern
   def authenticate_agent!
     return if logged_in?
 
+    clear_session
     session[:agent_return_to] = request.env["PATH_INFO"]
     redirect_to sign_in_path
+  end
+
+  def clear_session
+    session.delete(:inclusion_connect_token_id)
+    session.delete(:ic_state)
+    session.delete(:agent_id)
+    session.delete(:rdv_solidarites)
+    @current_agent = nil
   end
 
   def logged_in?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,14 +27,6 @@ class SessionsController < ApplicationController
     InclusionConnectClient.logout(session[:inclusion_connect_token_id])
   end
 
-  def clear_session
-    session.delete(:inclusion_connect_token_id)
-    session.delete(:ic_state)
-    session.delete(:agent_id)
-    session.delete(:rdv_solidarites)
-    @current_agent = nil
-  end
-
   def logged_with_inclusion_connect?
     session.dig(:rdv_solidarites, "inclusion_connected") == true
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,7 +2,7 @@ class StaticPagesController < ApplicationController
   skip_before_action :authenticate_agent!
 
   def welcome
-    redirect_to(organisations_path) if logged_in?
+    redirect_to(organisations_path) if current_agent
   end
 
   def legal_notice; end


### PR DESCRIPTION
Nous avions une incohérence dans la page d'accueil lorsqu'un agent était en session mais lorsque ses identifiants de sessions sont invalides, notamment suite à [ce changement récent](https://github.com/betagouv/rdv-insertion/commit/e28f275fb842aad9a5e69976240aa17ac7739235): 

![image](https://github.com/betagouv/rdv-insertion/assets/7602809/4e90b659-ca13-4111-83dc-4a0a0658683a)


Cette PR règle ce problème.