### PR TITLE
refactor(app): Replace NotImplementedError with NoMethodError

### DIFF
--- a/app/models/rdv_solidarites_session/base.rb
+++ b/app/models/rdv_solidarites_session/base.rb
@@ -3,11 +3,11 @@ module RdvSolidaritesSession
     attr_reader :uid
 
     def valid?
-      raise NotImplementedError
+      raise NoMethodError
     end
 
     def to_h
-      raise NotImplementedError
+      raise NoMethodError
     end
 
     def rdv_solidarites_client

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -47,7 +47,7 @@ class BaseService
   attr_reader :result
 
   def call
-    raise NotImplementedError
+    raise NoMethodError
   end
 
   private

--- a/app/services/rdv_solidarites_api/base.rb
+++ b/app/services/rdv_solidarites_api/base.rb
@@ -35,7 +35,7 @@ module RdvSolidaritesApi
     end
 
     def rdv_solidarites_response
-      raise NotImplementedError
+      raise NoMethodError
     end
   end
 end


### PR DESCRIPTION
Il semblerait que nous n'utilisions pas `NotImplementedError` de la bonne façon, ce n'est pas fait pour montrer qu'une classe enfant doit implémenter cette méthode (voir par exemple dans [cette article](https://kirillshevch.medium.com/misusing-of-notimplementederror-in-ruby-531dd866f461)).