### PR TITLE
feat(sms): shorten invitation url link

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 class InvitationsController < ApplicationController
   before_action :set_organisations, :set_user, only: [:create]
   before_action :set_invitation, :verify_invitation_validity, only: [:redirect]
-  skip_before_action :authenticate_agent!, only: [:invitation_code, :redirect, :shortcut]
+  skip_before_action :authenticate_agent!, only: [:invitation_code, :redirect, :redirect_shortcut]
 
   def create
     if invite_user.success?
@@ -16,7 +16,7 @@ class InvitationsController < ApplicationController
 
   def invitation_code; end
 
-  def shortcut
+  def redirect_shortcut
     redirect_to redirect_invitations_path(params: { uuid: params[:uuid] })
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 class InvitationsController < ApplicationController
   before_action :set_organisations, :set_user, only: [:create]
   before_action :set_invitation, :verify_invitation_validity, only: [:redirect]
-  skip_before_action :authenticate_agent!, only: [:invitation_code, :redirect]
+  skip_before_action :authenticate_agent!, only: [:invitation_code, :redirect, :shortcut]
 
   def create
     if invite_user.success?
@@ -15,6 +15,10 @@ class InvitationsController < ApplicationController
   end
 
   def invitation_code; end
+
+  def shortcut
+    redirect_to redirect_invitations_path(params: { uuid: params[:uuid] })
+  end
 
   def redirect
     @invitation.clicked = true

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -14,7 +14,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user.conjugate('invité')} à prendre un #{rdv_title}." \
         " Pour choisir la date et l'horaire du RDV, " \
         "cliquez sur le lien suivant: " \
-        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "#{redirect_sms_link}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{help_phone_number}."
@@ -24,7 +24,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user_designation} et vous êtes #{user.conjugate('invité')} à" \
         " participer à un #{rdv_title}. Pour choisir la date et l'horaire du RDV, " \
         "cliquez sur le lien suivant dans les #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours: " \
-        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "#{redirect_sms_link}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{help_phone_number}."
@@ -42,7 +42,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user_designation} et bénéficiez d'un accompagnement. " \
         "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
         "librement, dans la limite des places disponibles, en cliquant sur le lien " \
-        "suivant: #{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "suivant: #{redirect_sms_link}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{help_phone_number}."
@@ -52,7 +52,7 @@ module Invitations
       "#{user},\nTu es #{user.conjugate('invité')} à participer à un atelier organisé par le département. " \
         "Nous te proposons de cliquer ci-dessous pour découvrir le programme. " \
         "Si tu es #{user.conjugate('intéressé')} pour participer, tu n’auras qu’à cliquer et t’inscrire en ligne" \
-        " avec le lien suivant: #{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        " avec le lien suivant: #{redirect_sms_link}\n" \
         "En cas de problème, tu peux contacter le #{help_phone_number}."
     end
 
@@ -63,7 +63,7 @@ module Invitations
         "vous invitant à prendre un #{rdv_title}." \
         " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "#{redirect_sms_link}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{help_phone_number}."
@@ -74,7 +74,7 @@ module Invitations
         "vous invitant à prendre RDV au créneau de votre choix afin de #{rdv_purpose}." \
         " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "#{redirect_sms_link}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{help_phone_number}."
@@ -94,7 +94,7 @@ module Invitations
         "t'invitant à participer à un #{rdv_title}." \
         " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{redirect_invitations_url(params: { uuid: @invitation.uuid }, host: ENV['HOST'])}\n" \
+        "#{redirect_sms_link}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, tu peux contacter le #{help_phone_number}."
@@ -112,6 +112,12 @@ module Invitations
       else
         ""
       end
+    end
+
+    def redirect_sms_link
+      host = ENV["HOST"].gsub("www.", "")
+      path = redirect_invitation_shortcut_path(uuid: @invitation.uuid)
+      host + path
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
   end
 
   get "invitation", to: "invitations#invitation_code", as: :invitation_landing
+  get '/r/:uuid', to: "invitations#shortcut", as: :redirect_invitation_shortcut
   resources :invitations, only: [] do
     get :redirect, on: :collection
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
   end
 
   get "invitation", to: "invitations#invitation_code", as: :invitation_landing
-  get '/r/:uuid', to: "invitations#shortcut", as: :redirect_invitation_shortcut
+  get '/r/:uuid', to: "invitations#redirect_shortcut", as: :redirect_invitation_shortcut
   resources :invitations, only: [] do
     get :redirect, on: :collection
   end

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -165,6 +165,19 @@ describe InvitationsController do
     end
   end
 
+  describe "#shortcut" do
+    subject { get :shortcut, params: { uuid: invitation.uuid } }
+
+    let!(:invitation) { create(:invitation, format: "sms") }
+
+    it "redirects to the invitation link" do
+      subject
+      expect(response).to redirect_to(
+        Rails.application.routes.url_helpers.redirect_invitations_path(params: { uuid: invitation.uuid })
+      )
+    end
+  end
+
   describe "#redirect" do
     subject { get :redirect, params: invite_params }
 

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -165,8 +165,8 @@ describe InvitationsController do
     end
   end
 
-  describe "#shortcut" do
-    subject { get :shortcut, params: { uuid: invitation.uuid } }
+  describe "#redirect_shortcut" do
+    subject { get :redirect_shortcut, params: { uuid: invitation.uuid } }
 
     let!(:invitation) { create(:invitation, format: "sms") }
 

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -42,7 +42,7 @@ describe Invitations::SendSms, type: :service do
     "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{user.conjugate('invité')} à participer" \
       " à un rendez-vous d'orientation. " \
       "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-      "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+      "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
       "Ce RDV est obligatoire. En cas de problème, contactez le 0147200001."
   end
 
@@ -99,7 +99,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
           "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
           "Le lien de prise de RDV suivant expire dans 5 jours: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. En cas de problème, contactez le 0147200001."
       end
 
@@ -129,7 +129,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes nouveau et vous êtes #{user.conjugate('invité')} à participer" \
           " à un nouveau type de rendez-vous. " \
           "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. En cas de problème, contactez le 0147200001."
       end
 
@@ -150,7 +150,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{user.conjugate('invité')} à " \
           "participer à un rendez-vous d'accompagnement." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. En l'absence d'action de votre part, " \
           "votre RSA pourra être suspendu ou réduit. " \
           "En cas de problème, contactez le 0147200001."
@@ -179,7 +179,7 @@ describe Invitations::SendSms, type: :service do
             "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
               "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
               "Le lien de prise de RDV suivant expire dans 5 jours: " \
-              "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+              "rdv-insertion.fr/r/#{invitation.uuid}\n" \
               "Ce RDV est obligatoire. En l'absence d'action de votre part, " \
               "votre RSA pourra être suspendu ou réduit. En cas de problème, contactez le " \
               "0147200001."
@@ -257,7 +257,7 @@ describe Invitations::SendSms, type: :service do
           " à un rendez-vous de signature de CER." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "3 jours: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. " \
           "En cas de problème, contactez le 0147200001."
       end
@@ -279,7 +279,7 @@ describe Invitations::SendSms, type: :service do
             "vous invitant à prendre RDV au créneau de votre choix afin de construire et signer " \
             "votre Contrat d'Engagement Réciproque. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "Ce RDV est obligatoire. En cas de problème, contactez le " \
             "0147200001."
         end
@@ -309,7 +309,7 @@ describe Invitations::SendSms, type: :service do
           " à un entretien de main tendue." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "3 jours: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. " \
           "En cas de problème, contactez le 0147200001."
       end
@@ -330,7 +330,7 @@ describe Invitations::SendSms, type: :service do
           "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
             "vous invitant à prendre RDV au créneau de votre choix afin de faire le point sur votre situation." \
             " Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "Ce RDV est obligatoire. En cas de problème, contactez le " \
             "0147200001."
         end
@@ -359,7 +359,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{user.conjugate('invité')} à participer" \
           " à un atelier collectif. Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "3 jours: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. " \
           "En cas de problème, contactez le 0147200001."
       end
@@ -380,7 +380,7 @@ describe Invitations::SendSms, type: :service do
           "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours " \
             "vous invitant à prendre RDV au créneau de votre choix afin de vous aider dans votre parcours d'insertion" \
             ". Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "Ce RDV est obligatoire. En cas de problème, contactez le " \
             "0147200001."
         end
@@ -407,7 +407,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes demandeur d'emploi et vous êtes #{user.conjugate('invité')} à participer" \
           " à un rendez-vous d'accompagnement." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. En l'absence d'action de votre part, " \
           "votre RSA pourra être suspendu ou réduit. " \
           "En cas de problème, contactez le 0147200001."
@@ -429,7 +429,7 @@ describe Invitations::SendSms, type: :service do
           "Monsieur John DOE,\nEn tant que demandeur d'emploi, vous avez reçu un message il y a 3 jours vous " \
             "invitant à prendre RDV au créneau de votre choix afin de démarrer un parcours d'accompagnement. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "Ce RDV est obligatoire. En l'absence d'action de votre part, " \
             "votre RSA pourra être suspendu ou réduit. En cas de problème, contactez le " \
             "0147200001."
@@ -459,7 +459,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
           " et vous êtes #{user.conjugate('invité')} à participer à un entretien d'embauche." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -480,7 +480,7 @@ describe Invitations::SendSms, type: :service do
             "(SIAE), vous avez reçu un message il y a 3 jours vous " \
             "invitant à prendre RDV au créneau de votre choix afin de poursuivre le processus de recrutement. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "En cas de problème, contactez le " \
             "0147200001."
         end
@@ -509,7 +509,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes candidat.e dans une Structure d’Insertion par l’Activité Economique (SIAE)" \
           " et vous êtes #{user.conjugate('invité')} à participer à un rendez-vous collectif d'information." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -530,7 +530,7 @@ describe Invitations::SendSms, type: :service do
             "(SIAE), vous avez reçu un message il y a 3 jours vous " \
             "invitant à prendre RDV au créneau de votre choix afin de découvrir cette structure. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "En cas de problème, contactez le " \
             "0147200001."
         end
@@ -559,7 +559,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes salarié.e au sein de notre structure" \
           " et vous êtes #{user.conjugate('invité')} à participer à un rendez-vous de suivi." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -580,7 +580,7 @@ describe Invitations::SendSms, type: :service do
             "vous avez reçu un message il y a 3 jours vous " \
             "invitant à prendre RDV au créneau de votre choix afin de faire un point avec votre référent. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "En cas de problème, contactez le " \
             "0147200001."
         end
@@ -606,7 +606,7 @@ describe Invitations::SendSms, type: :service do
       let!(:content) do
         "Monsieur John DOE,\nVous êtes invité à prendre un rendez-vous de suivi psychologue." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -632,7 +632,7 @@ describe Invitations::SendSms, type: :service do
           "un rendez-vous d'orientation." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "3 jours: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. " \
           "En cas de problème, contactez le 0147200001."
       end
@@ -658,7 +658,7 @@ describe Invitations::SendSms, type: :service do
         "John Doe,\nTu es invité à participer à un atelier organisé par le département. " \
           "Nous te proposons de cliquer ci-dessous pour découvrir le programme. " \
           "Si tu es intéressé pour participer, tu n’auras qu’à cliquer et t’inscrire en ligne avec le lien suivant: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, tu peux contacter le 0147200001."
       end
 
@@ -683,7 +683,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et vous êtes #{user.conjugate('invité')} à participer" \
           " à un rendez-vous d'information." \
           " Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant " \
-          "dans les 3 jours: http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "dans les 3 jours: rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "Ce RDV est obligatoire. " \
           "En cas de problème, contactez le 0147200001."
       end
@@ -704,7 +704,7 @@ describe Invitations::SendSms, type: :service do
           "Monsieur John DOE,\nEn tant que bénéficiaire du RSA, vous avez reçu un message il y a 3 jours vous " \
             "invitant à prendre RDV au créneau de votre choix afin de vous renseigner sur vos droits et vos devoirs. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "Ce RDV est obligatoire. En cas de problème, contactez le " \
             "0147200001."
         end
@@ -733,7 +733,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
           "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
           "librement, dans la limite des places disponibles, en cliquant sur le lien suivant: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -758,7 +758,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
           "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
           "librement, dans la limite des places disponibles, en cliquant sur le lien suivant: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -783,7 +783,7 @@ describe Invitations::SendSms, type: :service do
         "Monsieur John DOE,\nVous êtes bénéficiaire du RSA et bénéficiez d'un accompagnement. " \
           "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
           "librement, dans la limite des places disponibles, en cliquant sur le lien suivant: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -809,7 +809,7 @@ describe Invitations::SendSms, type: :service do
           " à un rendez-vous de suivi. " \
           "Pour choisir la date et l'horaire du RDV, cliquez sur le lien suivant dans les " \
           "3 jours: " \
-          "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+          "rdv-insertion.fr/r/#{invitation.uuid}\n" \
           "En cas de problème, contactez le 0147200001."
       end
 
@@ -830,7 +830,7 @@ describe Invitations::SendSms, type: :service do
             "vous invitant à prendre RDV au créneau de votre choix afin de faire un point avec votre référent" \
             " de parcours. " \
             "Le lien de prise de RDV suivant expire dans 5 jours: " \
-            "http://www.rdv-insertion.fr/invitations/redirect?uuid=#{invitation.uuid}\n" \
+            "rdv-insertion.fr/r/#{invitation.uuid}\n" \
             "En cas de problème, contactez le " \
             "0147200001."
         end


### PR DESCRIPTION
Cette PR permet de raccourcir l'url affichée dans les SMS pour réduire le coût de ceux-ci. 

Concrétement on passe d'une url comme celle-ci : 
`https://www.rdv-insertion.fr/invitations/redirect?uuid=AAAAAAAA`
à 
`rdv-insertion.fr/r/AAAAAAAA`

Ce qui devrait permettre d'économiser 36 caractères par SMS

fix: https://github.com/betagouv/rdv-insertion/issues/654