### PR TITLE
refactor(app): Access current structure and use it for navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
-  gem "rspec-rails", "~> 5.0.0"
+  gem "rspec-rails"
   gem "factory_bot_rails"
   gem "rubocop"
   gem "rubocop-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,14 +297,14 @@ GEM
     rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (5.0.3)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
+    rspec-rails (6.1.0)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.12)
+      rspec-expectations (~> 3.12)
+      rspec-mocks (~> 3.12)
+      rspec-support (~> 3.12)
     rspec-support (3.12.0)
     rswag (2.11.0)
       rswag-api (= 2.11.0)
@@ -476,7 +476,7 @@ DEPENDENCIES
   redis (~> 4.0)
   responders
   rexml
-  rspec-rails (~> 5.0.0)
+  rspec-rails
   rswag
   rubocop
   rubocop-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   include AuthorizationConcern
   include AuthenticatedControllerConcern
+  include CurrentStructure
+  include NavigationHelper
   include BeforeActionOverride
   include EnvironmentsHelper
 
@@ -22,9 +24,5 @@ class ApplicationController < ActionController::Base
 
   def page
     params[:page] || 1
-  end
-
-  def department_level?
-    params[:department_id].present?
   end
 end

--- a/app/controllers/concerns/authenticated_controller_concern.rb
+++ b/app/controllers/concerns/authenticated_controller_concern.rb
@@ -20,7 +20,7 @@ module AuthenticatedControllerConcern
   end
 
   def current_agent
-    @current_agent ||= Agent.find_by(id: session[:agent_id])
+    Current.agent ||= Agent.find_by(id: session[:agent_id])
   end
 
   def rdv_solidarites_session

--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -1,0 +1,73 @@
+module CurrentStructure
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_structure_type_in_session,
+                  :set_session_organisation_id, :set_session_department_id,
+                  :current_structure_attributes
+
+    helper_method :structure_type, :department_level?
+  end
+
+  def set_structure_type_in_session
+    return if params[:department_id].nil? && params[:organisation_id].nil?
+
+    session[:structure_type] = params[:organisation_id].present? ? "organisation" : "department"
+  end
+
+  def set_session_organisation_id
+    if session[:structure_type] == "organisation"
+      session[:organisation_id] = params[:organisation_id] if params[:organisation_id]
+    else
+      session[:organisation_id] = nil
+    end
+  end
+
+  def set_session_department_id
+    if session[:structure_type] == "department"
+      session[:department_id] = params[:department_id] if params[:department_id]
+    else
+      session[:department_id] = nil
+    end
+  end
+
+  def current_structure_attributes
+    Current.structure_type = session[:structure_type]
+    Current.organisation_id = session[:organisation_id]
+    Current.department_id = session[:department_id]
+  end
+
+  def structure_type
+    Current.structure_type
+  end
+
+  def department_level?
+    structure_type == "department"
+  end
+
+  def current_structure
+    Current.structure ||=
+      department_level? ? Department.find(Current.department_id) : Organisation.find(Current.organisation_id)
+  end
+
+  def current_department
+    @current_department ||=
+      department_level? ? current_structure : current_structure.department
+  end
+
+  def current_organisations_filter
+    if department_level?
+      { organisations: { department_id: Current.department_id } }
+    else
+      { organisations: [Current.organisation_id] }
+    end
+  end
+
+  def current_organisation_filter
+    if department_level?
+      { organisation: { department_id: Current.department_id } }
+    else
+      { organisation_id: Current.organisation_id }
+    end
+  end
+end

--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -2,9 +2,8 @@ module CurrentStructure
   extend ActiveSupport::Concern
 
   included do
-    before_action :set_structure_type_in_session,
-                  :set_session_organisation_id, :set_session_department_id,
-                  :current_structure_attributes
+    before_action :set_structure_type_in_session, :set_session_organisation_id, :set_session_department_id,
+                  :set_current_structure_attributes
 
     helper_method :structure_type, :department_level?
   end
@@ -31,7 +30,7 @@ module CurrentStructure
     end
   end
 
-  def current_structure_attributes
+  def set_current_structure_attributes
     Current.structure_type = session[:structure_type]
     Current.organisation_id = session[:organisation_id]
     Current.department_id = session[:department_id]

--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -5,7 +5,7 @@ module CurrentStructure
     before_action :set_structure_type_in_session, :set_session_organisation_id, :set_session_department_id,
                   :set_current_structure_attributes
 
-    helper_method :structure_type, :department_level?
+    helper_method :department_level?
   end
 
   def set_structure_type_in_session
@@ -36,12 +36,8 @@ module CurrentStructure
     Current.department_id = session[:department_id]
   end
 
-  def structure_type
-    Current.structure_type
-  end
-
   def department_level?
-    structure_type == "department"
+    Current.structure_type == "department"
   end
 
   def current_structure

--- a/app/controllers/configurations_positions_controller.rb
+++ b/app/controllers/configurations_positions_controller.rb
@@ -18,18 +18,6 @@ class ConfigurationsPositionsController < ApplicationController
   end
 
   def configurations
-    @configurations ||= department_or_organisation.configurations.includes([:motif_category]).order(position: :asc)
-  end
-
-  def department_or_organisation
-    department_level? ? department : organisation
-  end
-
-  def department
-    @department ||= policy_scope(Department).find(params[:department_id])
-  end
-
-  def organisation
-    @organisation ||= policy_scope(Organisation).find(params[:organisation_id])
+    @configurations ||= current_structure.configurations.includes([:motif_category]).order(position: :asc)
   end
 end

--- a/app/controllers/creation_dates_filterings_controller.rb
+++ b/app/controllers/creation_dates_filterings_controller.rb
@@ -1,23 +1,3 @@
 class CreationDatesFilteringsController < ApplicationController
-  before_action :set_organisation, :set_department, only: [:new]
-
   def new; end
-
-  private
-
-  def set_organisation
-    return if department_level?
-
-    @organisation =
-      policy_scope(Organisation).find(params[:organisation_id])
-  end
-
-  def set_department
-    @department =
-      if department_level?
-        policy_scope(Department).find(params[:department_id])
-      else
-        @organisation.department
-      end
-  end
 end

--- a/app/controllers/department_organisations_controller.rb
+++ b/app/controllers/department_organisations_controller.rb
@@ -1,14 +1,6 @@
 class DepartmentOrganisationsController < ApplicationController
-  before_action :set_department, only: [:index]
-
   def index
-    @organisations = policy_scope(Organisation).where(department: @department)
+    @organisations = policy_scope(Organisation).where(department_id: params[:department_id])
                                                .where(id: current_agent.admin_organisations_ids)
-  end
-
-  private
-
-  def set_department
-    @department = Department.find(params[:department_id])
   end
 end

--- a/app/controllers/invitation_dates_filterings_controller.rb
+++ b/app/controllers/invitation_dates_filterings_controller.rb
@@ -1,23 +1,3 @@
 class InvitationDatesFilteringsController < ApplicationController
-  before_action :set_organisation, :set_department, only: [:new]
-
   def new; end
-
-  private
-
-  def set_organisation
-    return if department_level?
-
-    @organisation =
-      policy_scope(Organisation).find(params[:organisation_id])
-  end
-
-  def set_department
-    @department =
-      if department_level?
-        policy_scope(Department).find(params[:department_id])
-      else
-        @organisation.department
-      end
-  end
 end

--- a/app/controllers/rdv_contexts/closings_controller.rb
+++ b/app/controllers/rdv_contexts/closings_controller.rb
@@ -1,29 +1,27 @@
 module RdvContexts
   class ClosingsController < ApplicationController
     wrap_parameters false
-    before_action :set_rdv_context, :set_user, :set_organisation, :set_department, only: [:create, :destroy]
+    before_action :set_rdv_context, only: [:create, :destroy]
 
     def create
       authorize @rdv_context, :close?
-      return reload_user_show_page if close_rdv_context.success?
-
-      display_error_modal(close_rdv_context.errors)
+      if close_rdv_context.success?
+        redirect_to structure_user_path(@rdv_context.user_id)
+      else
+        display_error_modal(@rdv_context.errors.full_messages)
+      end
     end
 
     def destroy
       authorize @rdv_context, :reopen?
-      return reload_user_show_page if @rdv_context.update(closed_at: nil)
-
-      display_error_modal(@rdv_context.errors.full_messages)
+      if @rdv_context.update(closed_at: nil)
+        redirect_to structure_user_path(@rdv_context.user_id)
+      else
+        display_error_modal(@rdv_context.errors.full_messages)
+      end
     end
 
     private
-
-    def reload_user_show_page
-      return redirect_to department_user_path(@department, @user) if department_level?
-
-      redirect_to organisation_user_path(@organisation, @user)
-    end
 
     def display_error_modal(errors)
       render turbo_stream: turbo_stream.replace(
@@ -41,22 +39,8 @@ module RdvContexts
       @rdv_context = RdvContext.find(closing_params[:rdv_context_id])
     end
 
-    def set_user
-      @user = policy_scope(User).find(closing_params[:user_id])
-    end
-
-    def set_organisation
-      return if closing_params[:organisation_id].blank?
-
-      @organisation = policy_scope(Organisation).find(closing_params[:organisation_id])
-    end
-
-    def set_department
-      @department = policy_scope(Department).find(closing_params[:department_id]) if department_level?
-    end
-
     def closing_params
-      params.permit(:rdv_context_id, :user_id, :organisation_id, :department_id)
+      params.permit(:rdv_context_id)
     end
   end
 end

--- a/app/controllers/rdv_contexts_controller.rb
+++ b/app/controllers/rdv_contexts_controller.rb
@@ -1,14 +1,14 @@
 class RdvContextsController < ApplicationController
   PERMITTED_PARAMS = [:user_id, :motif_category_id].freeze
 
-  before_action :set_user, :set_organisation, :set_department, only: [:create]
+  before_action :set_user, only: [:create]
 
   def create
     @rdv_context = RdvContext.new(**rdv_context_params)
     authorize @rdv_context
     if @rdv_context.save
       respond_to do |format|
-        format.html { redirect_to(after_save_path) } # html is used for the show page
+        format.html { redirect_to(structure_user_path(@user.id, anchor: anchor)) } # html is used for the show page
         format.turbo_stream { replace_new_button_cell_by_rdv_context_status_cell } # turbo is used for index page
       end
     else
@@ -30,26 +30,12 @@ class RdvContextsController < ApplicationController
     @user = policy_scope(User).find(rdv_context_params[:user_id])
   end
 
-  def set_organisation
-    @organisation = policy_scope(Organisation).find(params[:organisation_id]) if params[:organisation_id]
-  end
-
-  def set_department
-    @department = policy_scope(Department).find(params[:department_id]) if params[:department_id]
-  end
-
   def replace_new_button_cell_by_rdv_context_status_cell
     render turbo_stream: turbo_stream.replace(
       "user_#{@user.id}_motif_category_#{rdv_context_params[:motif_category_id]}",
       partial: "rdv_context_status_cell",
       locals: { rdv_context: @rdv_context, configuration: nil }
     )
-  end
-
-  def after_save_path
-    return department_user_path(@department, @user, anchor: anchor) if department_level?
-
-    organisation_user_path(@organisation, @user, anchor: anchor)
   end
 
   def anchor

--- a/app/controllers/rdv_contexts_controller.rb
+++ b/app/controllers/rdv_contexts_controller.rb
@@ -8,7 +8,7 @@ class RdvContextsController < ApplicationController
     authorize @rdv_context
     if @rdv_context.save
       respond_to do |format|
-        format.html { redirect_to(structure_user_path(@user.id, anchor: anchor)) } # html is used for the show page
+        format.html { redirect_to(structure_user_path(@user.id, anchor:)) } # html is used for the show page
         format.turbo_stream { replace_new_button_cell_by_rdv_context_status_cell } # turbo is used for index page
       end
     else

--- a/app/controllers/referent_assignations_controller.rb
+++ b/app/controllers/referent_assignations_controller.rb
@@ -1,5 +1,5 @@
 class ReferentAssignationsController < ApplicationController
-  before_action :set_user, :set_department, :set_agents, only: [:index, :create, :destroy]
+  before_action :set_department, :set_user, :set_agents, only: [:index, :create, :destroy]
   before_action :set_agent, only: [:create, :destroy]
 
   def index; end
@@ -52,12 +52,12 @@ class ReferentAssignationsController < ApplicationController
   end
 
   def set_department
-    @department = policy_scope(Department).find(params[:department_id])
+    @department = policy_scope(Department).find(current_department.id)
   end
 
   def set_agents
     @agents = Agent.joins(:organisations).where(
-      organisations: @user.organisations.where(department_id: params[:department_id])
+      organisations: @user.organisations.where(department: @department)
     ).distinct.order(:email)
     @agents = @agents.not_betagouv if production_env?
   end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -24,8 +24,6 @@ class TagsController < ApplicationController
   private
 
   def set_organisation
-    return if department_level?
-
     @organisation = policy_scope(Organisation).find(params[:organisation_id])
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,9 +1,9 @@
 class UploadsController < ApplicationController
-  before_action :set_organisation, :set_department, :check_if_category_is_selected,
-                :set_all_configurations, :set_current_configuration, :set_file_configuration,
+  before_action :set_all_configurations, for: [:category_selection]
+
+  before_action :set_organisation, :set_department, :check_if_category_is_selected, :set_all_configurations,
+                :set_current_configuration, :set_motif_category_name, :set_file_configuration,
                 for: [:new]
-  before_action :set_organisation, :set_department, :set_all_configurations,
-                for: [:category_selection]
 
   def new; end
 
@@ -25,29 +25,29 @@ class UploadsController < ApplicationController
 
   def set_all_configurations
     @all_configurations =
-      if department_level?
-        (
-          policy_scope(::Configuration).includes(:motif_category, :file_configuration) &
-          @department.configurations
-        ).uniq(&:motif_category_id)
-      else
-        @organisation.configurations.includes(:motif_category, :file_configuration)
-      end
+      policy_scope(::Configuration).joins(:organisation)
+                                   .where(current_organisation_filter)
+                                   .uniq(&:motif_category_id)
 
-    @all_configurations = @all_configurations.sort_by(&:position)
+    @all_configurations =
+      department_level? ? @all_configurations.sort_by(&:department_position) : @all_configurations.sort_by(&:position)
   end
 
   def set_current_configuration
     return if params[:configuration_id].blank?
 
-    @current_configuration = @all_configurations.find { |config| config.id == params[:configuration_id].to_i }
+    @current_configuration = policy_scope(::Configuration).preload(:file_configuration).find(params[:configuration_id])
 
-    if @current_configuration.nil?
-      redirect_to(category_selection_path, flash: { error: "La configuration sélectionnée n'est pas valide" })
-      return
-    end
+    return if @current_configuration
 
-    @motif_category_name = @current_configuration.motif_category_name
+    redirect_to(
+      uploads_category_selection_structure_users_path,
+      flash: { error: "La configuration sélectionnée n'est pas valide" }
+    )
+  end
+
+  def set_motif_category_name
+    @motif_category_name = @current_configuration&.motif_category_name
   end
 
   def set_file_configuration
@@ -63,15 +63,7 @@ class UploadsController < ApplicationController
   def check_if_category_is_selected
     return if category_selected?
 
-    redirect_to(category_selection_path)
-  end
-
-  def category_selection_path
-    if department_level?
-      uploads_category_selection_department_users_path(@department)
-    else
-      uploads_category_selection_organisation_users_path(@organisation)
-    end
+    redirect_to(uploads_category_selection_structure_users_path)
   end
 
   def category_selected?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,10 +49,4 @@ module ApplicationHelper
   def render_turbo_stream_flash_messages
     turbo_stream.prepend "flashes", partial: "common/flash"
   end
-
-  def compute_user_tag_assignations_path(organisation, department, user)
-    return department_user_tag_assignations_path(department, user) if department_level?
-
-    organisation_user_tag_assignations_path(organisation, user)
-  end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -36,10 +36,10 @@ module NavigationHelper
   end
 
   def structure_user_invitations_path(user_id)
-    send(:"#{structure_type}_user_invitations_path", { id: user_id })
+    send(:"#{structure_type}_user_invitations_path", { user_id: })
   end
 
   def structure_user_tag_assignations_path(user_id)
-    send(:"#{structure_type}_user_tag_assignations_path", { id: user_id })
+    send(:"#{structure_type}_user_tag_assignations_path", { user_id: })
   end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -4,38 +4,38 @@ module NavigationHelper
   end
 
   def structure_users_path(**params)
-    send(:"#{structure_type}_users_path", { **structure_id_param, **params.compact_blank })
+    send(:"#{Current.structure_type}_users_path", { **structure_id_param, **params.compact_blank })
   end
 
   def structure_configurations_positions_update_path
-    send(:"#{structure_type}_configurations_positions_update_path", structure_id_param)
+    send(:"#{Current.structure_type}_configurations_positions_update_path", structure_id_param)
   end
 
   def edit_structure_user_path(user_id)
-    send(:"edit_#{structure_type}_user_path", { id: user_id, **structure_id_param })
+    send(:"edit_#{Current.structure_type}_user_path", { id: user_id, **structure_id_param })
   end
 
   def structure_user_path(user_id, **params)
-    send(:"#{structure_type}_user_path", { id: user_id, **structure_id_param, **params })
+    send(:"#{Current.structure_type}_user_path", { id: user_id, **structure_id_param, **params })
   end
 
   def new_structure_user_path
-    send(:"new_#{structure_type}_user_path")
+    send(:"new_#{Current.structure_type}_user_path")
   end
 
   def new_structure_upload_path(**params)
-    send(:"new_#{structure_type}_upload_path", **params)
+    send(:"new_#{Current.structure_type}_upload_path", **params)
   end
 
   def uploads_category_selection_structure_users_path(**params)
-    send(:"uploads_category_selection_#{structure_type}_users_path", **params)
+    send(:"uploads_category_selection_#{Current.structure_type}_users_path", **params)
   end
 
   def structure_user_invitations_path(user_id)
-    send(:"#{structure_type}_user_invitations_path", { user_id: })
+    send(:"#{Current.structure_type}_user_invitations_path", { user_id: })
   end
 
   def structure_user_tag_assignations_path(user_id)
-    send(:"#{structure_type}_user_tag_assignations_path", { user_id: })
+    send(:"#{Current.structure_type}_user_tag_assignations_path", { user_id: })
   end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,45 @@
+module NavigationHelper
+  def structure_id_param
+    if department_level?
+      { department_id: Current.department_id }
+    else
+      { organisation_id: Current.organisation_id }
+    end
+  end
+
+  def structure_users_path(**params)
+    send(:"#{structure_type}_users_path", { **structure_id_param, **params.compact_blank })
+  end
+
+  def structure_configurations_positions_update_path
+    send(:"#{structure_type}_configurations_positions_update_path", structure_id_param)
+  end
+
+  def edit_structure_user_path(user_id)
+    send(:"edit_#{structure_type}_user_path", { id: user_id, **structure_id_param })
+  end
+
+  def structure_user_path(user_id, **params)
+    send(:"#{structure_type}_user_path", { id: user_id, **structure_id_param, **params })
+  end
+
+  def new_structure_user_path
+    send(:"new_#{structure_type}_user_path")
+  end
+
+  def new_structure_upload_path(**params)
+    send(:"new_#{structure_type}_upload_path", **params)
+  end
+
+  def uploads_category_selection_structure_users_path(**params)
+    send(:"uploads_category_selection_#{structure_type}_users_path", **params)
+  end
+
+  def structure_user_invitations_path(user_id)
+    send(:"#{structure_type}_user_invitations_path", { id: user_id })
+  end
+
+  def structure_user_tag_assignations_path(user_id)
+    send(:"#{structure_type}_user_tag_assignations_path", { id: user_id })
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,10 +1,6 @@
 module NavigationHelper
   def structure_id_param
-    if department_level?
-      { department_id: Current.department_id }
-    else
-      { organisation_id: Current.organisation_id }
-    end
+    department_level? ? { department_id: Current.department_id } : { organisation_id: Current.organisation_id }
   end
 
   def structure_users_path(**params)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -126,14 +126,6 @@ module UsersHelper
     scope == "archived"
   end
 
-  def department_level?
-    params[:department_id].present?
-  end
-
-  def navigation_level
-    department_level? ? "department" : "organisation"
-  end
-
   def rdv_solidarites_agent_searches_url(
     rdv_solidarites_organisation_id, rdv_solidarites_user_id, rdv_solidarites_motif_id, rdv_solidarites_service_id
   )
@@ -152,44 +144,6 @@ module UsersHelper
 
     rdv_context.convocable_status? ||
       rdv_context.time_to_accept_invitation_exceeded?(configuration.number_of_days_before_action_required)
-  end
-
-  def compute_index_path(organisation, department, **params)
-    if department_level?
-      department_users_path(department, **params.compact_blank)
-    else
-      organisation_users_path(organisation, **params.compact_blank)
-    end
-  end
-
-  def compute_update_position_path(organisation, department)
-    return department_configurations_positions_update_path(department) if department_level?
-
-    organisation_configurations_positions_update_path(organisation)
-  end
-
-  def compute_edit_path(user, organisation, department)
-    return edit_department_user_path(department, user) if department_level?
-
-    edit_organisation_user_path(organisation, user)
-  end
-
-  def compute_show_path(user, organisation, department)
-    return department_user_path(department, user) if department_level?
-
-    organisation_user_path(organisation, user)
-  end
-
-  def compute_new_path(organisation, department)
-    return new_department_user_path(department) if department_level?
-
-    new_organisation_user_path(organisation)
-  end
-
-  def compute_rdv_contexts_path(organisation, department)
-    return rdv_contexts_path(department_id: department.id) if department_level?
-
-    rdv_contexts_path(organisation_id: organisation.id)
   end
 end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :agent, :organisation_id, :department_id, :structure_type, :structure,
+            :organisation, :department
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :agent, :organisation_id, :department_id, :structure_type, :structure,
-            :organisation, :department
+            :department
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,3 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :agent, :organisation_id, :department_id, :structure_type, :structure,
-            :department
+  attribute :agent, :organisation_id, :department_id, :structure_type, :structure
 end

--- a/app/models/rdv_solidarites_session/with_shared_secret.rb
+++ b/app/models/rdv_solidarites_session/with_shared_secret.rb
@@ -23,19 +23,7 @@ module RdvSolidaritesSession
     end
 
     def signature_valid?
-      payload = {
-        id: agent.rdv_solidarites_agent_id,
-        first_name: agent.first_name,
-        last_name: agent.last_name,
-        email: agent.email
-      }
-
-      OpenSSL::HMAC.hexdigest("SHA256", ENV.fetch("SHARED_SECRET_FOR_AGENTS_AUTH"), payload.to_json) ==
-        @x_agent_auth_signature
-    end
-
-    def agent
-      @agent ||= Agent.find_by(email: @uid)
+      Current.agent.signature_auth_with_shared_secret == @x_agent_auth_signature
     end
   end
 end

--- a/app/views/configurations/index.html.erb
+++ b/app/views/configurations/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container text-dark-blue h4-as-labels mt-5 mb-5">
   <div class="d-flex justify-content-start mb-4">
     <div>
-      <%= link_to(@back_to_users_list_url || compute_index_path(@organisation, @department)) do %>
+      <%= link_to(@back_to_users_list_url || structure_users_path) do %>
         <button class="btn btn-blue-out">Retour</button>
       <% end %>
       <%= link_to @organisation.rdv_solidarites_url, target: "_blank" do %>

--- a/app/views/creation_dates_filterings/new.html.erb
+++ b/app/views/creation_dates_filterings/new.html.erb
@@ -1,5 +1,5 @@
 <%= render "common/remote_modal", title: "Filtrer par date de création" do %>
-  <%= form_with method: :get, local: true, url: compute_index_path(@organisation, @department), data: { "turbo-frame" => "_top" } do |form| %>
+  <%= form_with method: :get, local: true, url: structure_users_path, data: { "turbo-frame" => "_top" } do |form| %>
     <% url_params.except(:creation_date_after, :creation_date_before).each do |key, value| %>
       <%= form.hidden_field key, value: value %>
     <% end %>

--- a/app/views/invitation_dates_filterings/new.html.erb
+++ b/app/views/invitation_dates_filterings/new.html.erb
@@ -1,5 +1,5 @@
 <%= render "common/remote_modal", title: "Filtrer par date d'invitation" do %>
-  <%= form_with method: :get, local: true, url: compute_index_path(@organisation, @department), data: { "turbo-frame" => "_top" } do |form| %>
+  <%= form_with method: :get, local: true, url: structure_users_path, data: { "turbo-frame" => "_top" } do |form| %>
     <% url_params.except(:first_invitation_date_after, :first_invitation_date_before, :last_invitation_date_after, :last_invitation_date_before, :department_id, :organisation_id).each do |key, value| %>
       <%= form.hidden_field key, value: value %>
     <% end %>

--- a/app/views/invitations/_checkbox_form.html.erb
+++ b/app/views/invitations/_checkbox_form.html.erb
@@ -1,5 +1,5 @@
 <div id="user-<%= user.id %>-<%= invitation_format %>-invitation">
-  <%= form_with(url: department_level? ? department_user_invitations_path(@department, user) : organisation_user_invitations_path(@organisation, user), html: { method: :post }, data: { controller: "invitations-checkbox-form", action: "turbo:submit-start->invitations-checkbox-form#submitStart", user_id: user.id, department_id: @department.id, organisation_id: @organisation&.id, invitation_format: invitation_format, rdv_context: rdv_context }) do |f| %>
+  <%= form_with(url: structure_user_invitations_path(user.id), html: { method: :post }, data: { controller: "invitations-checkbox-form", action: "turbo:submit-start->invitations-checkbox-form#submitStart", user_id: user.id, department_id: @department.id, organisation_id: @organisation&.id, invitation_format: invitation_format, rdv_context: rdv_context }) do |f| %>
     <div class="form-group">
       <%= f.hidden_field :motif_category_id, value: motif_category.id %>
       <%= f.hidden_field :help_phone_number, value: department_level? ? user.organisations.first.phone_number : @organisation.phone_number %>

--- a/app/views/rdv_contexts/_close_rdv_context_button.html.erb
+++ b/app/views/rdv_contexts/_close_rdv_context_button.html.erb
@@ -1,4 +1,4 @@
-<%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: organisation.id, department_id: department_level? ? department.id : nil, user_id: user.id), method: :post do %>
+<%= link_to rdv_context_closings_path(rdv_context.id), method: :post do %>
   <button class="btn btn-blue" data-controller="tooltip" data-action="mouseover->tooltip#closeRdvContextButton">
     Clôturer "<%= rdv_context.motif_category.name %>"
   </button>

--- a/app/views/rdv_contexts/_new_button.html.erb
+++ b/app/views/rdv_contexts/_new_button.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(:rdv_context, url: compute_rdv_contexts_path(organisation, department), html: { method: :post }, data: { turbo: turbo }) do |f| %>
+<%= simple_form_for(:rdv_context, url: rdv_contexts_path, html: { method: :post }, data: { turbo: turbo }) do |f| %>
   <%= f.hidden_field :user_id, value: user.id %>
   <%= f.hidden_field :motif_category_id, value: configuration.motif_category_id %>
   <button type= "submit" class="btn btn-blue-out mx-2"><%= button_text %></button>

--- a/app/views/rdv_contexts/_rdv_context.html.erb
+++ b/app/views/rdv_contexts/_rdv_context.html.erb
@@ -95,9 +95,9 @@
       <% end %>
       <div class="m-2 p-2 text-center">
         <% if rdv_context.status == "closed" %>
-          <%= render "rdv_contexts/reopen_rdv_context_button", rdv_context: rdv_context, user: @user, organisation: @organisation, department: @department %>
+          <%= render "rdv_contexts/reopen_rdv_context_button", rdv_context: rdv_context %>
         <% else %>
-          <%= render "rdv_contexts/close_rdv_context_button", rdv_context: rdv_context, user: @user, organisation: @organisation, department: @department %>
+          <%= render "rdv_contexts/close_rdv_context_button", rdv_context: rdv_context %>
         <% end %>
       </div>
     </div>

--- a/app/views/rdv_contexts/_reopen_rdv_context_button.html.erb
+++ b/app/views/rdv_contexts/_reopen_rdv_context_button.html.erb
@@ -1,4 +1,4 @@
-<%= link_to rdv_context_closings_path(rdv_context.id, organisation_id: organisation.id, department_id: department_level? ? department.id : nil, user_id: user.id), method: :delete do %>
+<%= link_to rdv_context_closings_path(rdv_context.id), method: :delete do %>
   <button class="btn btn-blue"  data-controller="tooltip" data-action="mouseover->tooltip#reopenRdvContextButton">
     Rouvrir "<%= rdv_context.motif_category.name %>"
   </button>

--- a/app/views/referent_assignations/_referent_assignation.html.erb
+++ b/app/views/referent_assignations/_referent_assignation.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id(agent, :referent) %>" class="d-flex justify-content-between my-4">
   <div><p><%= "#{agent.first_name} #{agent.last_name} (#{agent.email})" %></p></div>
   <div>
-    <%= simple_form_for(:referent_assignation, url: department_referent_assignations_path(department), html: { method: assigned ? :delete : :post }) do |f| %>
+    <%= simple_form_for(:referent_assignation, url: referent_assignations_path, html: { method: assigned ? :delete : :post }) do |f| %>
       <%= f.input :user_id,
                   as: :hidden,
                   input_html: { class: "form-control", value: user.id }

--- a/app/views/referent_assignations/create.turbo_stream.erb
+++ b/app/views/referent_assignations/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "referents_list" do %>
-  <%= render "common/attribute_display", record: @user, attribute: :referents, as: :list, id: "referents_list" %>
+  <%= render partial: "users/user_referents_list", locals: { user: @user.reload } %>
 <% end %>
 
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/referent_assignations/destroy.turbo_stream.erb
+++ b/app/views/referent_assignations/destroy.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.replace "referents_list" do %>
-  <%= render "common/attribute_display", record: @user, attribute: :referents, as: :list, id: "referents_list" %>
+  <%= render partial: "users/user_referents_list", locals: { user: @user.reload } %>
 <% end %>
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/referent_assignations/index.html.erb
+++ b/app/views/referent_assignations/index.html.erb
@@ -1,6 +1,6 @@
 <%= render "common/remote_modal", title: "Choisissez un agent référent" do %>
   <% @agents.each do |agent| %>
-    <%= render "referent_assignation", department: @department, agent: agent, user: @user, assigned: @user.referent_ids.include?(agent.id) %>
+    <%= render "referent_assignation", agent: agent, user: @user, assigned: @user.referent_ids.include?(agent.id) %>
   <% end %>
 <% end %>
 

--- a/app/views/tag_assignations/_tag_assignation.html.erb
+++ b/app/views/tag_assignations/_tag_assignation.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id(tag) %>" class="d-flex justify-content-between my-4">
   <div><p><%= "#{tag.value}" %></p></div>
   <div>
-    <%= simple_form_for(:tag_assignation, url: compute_user_tag_assignations_path(@organisation, @department, @user), html: { method: assigned ? :delete : :post }) do |f| %>
+    <%= simple_form_for(:tag_assignation, url: structure_user_tag_assignations_path(@user.id), html: { method: assigned ? :delete : :post }) do |f| %>
       <%= f.input :user_id,
                   as: :hidden,
                   input_html: { class: "form-control", value: @user.id }

--- a/app/views/uploads/category_selection.html.erb
+++ b/app/views/uploads/category_selection.html.erb
@@ -7,7 +7,7 @@
   <div class="row justify-content-center mt-5">
     <div class="col-8 d-flex justify-content-between">
       <div>
-        <%= link_to(department_level? ? new_department_upload_path(@department, category: "none") : new_organisation_upload_path(@organisation, category: "none"), class: "btn btn-blue-out") do %>
+        <%= link_to(new_structure_upload_path(category: "none"), class: "btn btn-blue-out") do %>
           Aucune catégorie de suivi
           <i
             class="fas fa-question-circle"
@@ -19,7 +19,7 @@
       </div>
       <% @all_configurations.each do |configuration| %>
         <div>
-          <%= link_to(department_level? ? new_department_upload_path(@department, configuration_id: configuration.id) : new_organisation_upload_path(@organisation, configuration_id: configuration.id), class: "btn btn-blue-out") do %>
+          <%= link_to(new_structure_upload_path(configuration_id: configuration.id), class: "btn btn-blue-out") do %>
             <%= configuration.motif_category_name %>
           <% end %>
         </div>

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -28,7 +28,7 @@
           <% end %>
         <% end %>
         <td class="padding-left-15">
-          <%= link_to compute_show_path(user, @organisation, @department) do %>
+          <%= link_to structure_user_path(user.id) do %>
             <button class="btn btn-blue">Gérer</button>
           <% end %>
         </td>

--- a/app/views/users/_archived_users_table.html.erb
+++ b/app/views/users/_archived_users_table.html.erb
@@ -20,7 +20,7 @@
         <td><%= display_attribute format_date(user.archive_for(@department.id).created_at) %></td>
         <td><%= display_attribute user.archive_for(@department.id).archiving_reason %></td>
         <td class="padding-left-15">
-          <%= link_to compute_show_path(user, @organisation, @department) do %>
+          <%= link_to structure_user_path(user.id) do %>
             <button class="btn btn-blue">Gérer</button>
           <% end %>
         </td>

--- a/app/views/users/_archiving_button.html.erb
+++ b/app/views/users/_archiving_button.html.erb
@@ -12,7 +12,7 @@
           user_id: @user.id,
           organisation_id: @organisation.id,
           department_id: @department.id,
-          navigation_level: structure_type
+          navigation_level: Current.structure_type
         }
       )
     %>
@@ -30,7 +30,7 @@
         user_id: @user.id,
         organisation_id: @organisation.id,
         department_id: @department.id,
-        navigation_level: structure_type
+        navigation_level: Current.structure_type
       }
     )
   %>

--- a/app/views/users/_archiving_button.html.erb
+++ b/app/views/users/_archiving_button.html.erb
@@ -12,7 +12,7 @@
           user_id: @user.id,
           organisation_id: @organisation.id,
           department_id: @department.id,
-          navigation_level: navigation_level
+          navigation_level: structure_type
         }
       )
     %>
@@ -30,7 +30,7 @@
         user_id: @user.id,
         organisation_id: @organisation.id,
         department_id: @department.id,
-        navigation_level: navigation_level
+        navigation_level: structure_type
       }
     )
   %>

--- a/app/views/users/_filter_by_creation_dates_button.html.erb
+++ b/app/views/users/_filter_by_creation_dates_button.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-1">
   <div class="w-100">
-    <%= link_to(new_creation_dates_filtering_path(url_params.merge(department_level? ? { department_id: @department.id } : {organisation_id: @organisation.id })), data: { turbo_frame: 'remote_modal' }) do %>
+    <%= link_to(new_creation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
       <button class="btn btn-grey w-100">Filtrer par date de création</button>
     <% end %>
   </div>

--- a/app/views/users/_filter_by_invitations_dates_button.html.erb
+++ b/app/views/users/_filter_by_invitations_dates_button.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-1">
   <div class="w-100">
-    <%= link_to(new_invitation_dates_filtering_path(url_params.merge(department_level? ? { department_id: @department.id } : {organisation_id: @organisation.id })), data: { turbo_frame: 'remote_modal' }) do %>
+    <%= link_to(new_invitation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
       <button class="btn btn-grey w-100">Filtrer par date d'invitation</button>
     <% end %>
   </div>

--- a/app/views/users/_user_organisations_list.html.erb
+++ b/app/views/users/_user_organisations_list.html.erb
@@ -1,0 +1,5 @@
+<%= render "common/attribute_display", record: user, attribute: :organisations, as: :list, id: "organisations_list" do %>
+  <%= link_to(users_organisations_path(user_id: user.id), data: { turbo_frame: 'remote_modal' }) do %>
+    <button class="btn btn-blue"><i class="fas fa-pen"></i> Ajouter ou retirer une organisation </button>
+  <% end %>
+<% end %>

--- a/app/views/users/_user_referents_list.html.erb
+++ b/app/views/users/_user_referents_list.html.erb
@@ -1,0 +1,5 @@
+<%= render "common/attribute_display", record: user, attribute: :referents, as: :list, id: "referents_list" do %>
+  <%= link_to(referent_assignations_path(user_id: user.id), data: { turbo_frame: 'remote_modal' }) do %>
+    <button class="btn btn-blue mb-3"><i class="fas fa-user-plus"></i> Assigner le.s référent.s</button>
+  <% end %>
+<% end %>

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -13,7 +13,7 @@
     </div>
     <%= render "filter_by_creation_dates_button" if @current_configuration.nil? %>
     <%= render "filter_by_invitations_dates_button" if @current_configuration.present? || archived_scope?(@users_scope) %>
-    <%= render 'search_form', url: compute_index_path(@organisation, @department) %>
+    <%= render 'search_form', url: structure_users_path %>
 
     <div class="d-flex justify-content-between mt-1" data-controller="index-filters">
       <div class="text-left mt-2">
@@ -50,7 +50,7 @@
       </div>
       <% if display_back_to_list_button? %>
         <div>
-          <%= link_to compute_index_path(@organisation, @department, motif_category_id: @current_motif_category&.id, users_scope: @users_scope), class: "btn btn-blue-out" do %>
+          <%= link_to structure_users_path(motif_category_id: @current_motif_category&.id, users_scope: @users_scope), class: "btn btn-blue-out" do %>
             Retour à la liste
           <% end %>
         </div>
@@ -98,12 +98,12 @@
     </a>
     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
       <li>
-        <%= link_to(compute_new_path(@organisation, @department), class: "dropdown-item") do %>
+        <%= link_to(new_structure_user_path, class: "dropdown-item") do %>
           Créer un usager
         <% end %>
       </li>
       <li>
-        <%= link_to(department_level? ? new_department_upload_path(@department) : new_organisation_upload_path(@organisation), class: "dropdown-item") do %>
+        <%= link_to(new_structure_upload_path, class: "dropdown-item") do %>
           Charger fichier usagers
         <% end %>
       </li>
@@ -117,7 +117,7 @@
         Configurer l'organisation
       <% end %>
     <% end %>
-    <%= link_to(compute_index_path(@organisation, @department, **params.to_unsafe_h.merge(format: "csv")), class: "btn btn-blue-out mt-2", data: { controller: "tooltip", action: "mouseover->tooltip#csvExport"}, target: "_blank") do %>
+    <%= link_to(structure_users_path(**params.to_unsafe_h.merge(format: "csv")), class: "btn btn-blue-out mt-2", data: { controller: "tooltip", action: "mouseover->tooltip#csvExport"}, target: "_blank") do %>
       <i class="fas fa-download"></i> Exporter au format CSV
     <% end %>
   </div>

--- a/app/views/users/_users_list_tabs.html.erb
+++ b/app/views/users/_users_list_tabs.html.erb
@@ -1,12 +1,12 @@
 <ul class="nav nav-tabs">
   <li class="nav-item">
-    <%= link_to "Tous les contacts", compute_index_path(@organisation, @department), class: "nav-link #{@current_configuration.present? || archived_scope?(@users_scope) ? '' : 'active'}" %>
+    <%= link_to "Tous les contacts", structure_users_path, class: "nav-link #{@current_configuration.present? || archived_scope?(@users_scope) ? '' : 'active'}" %>
   </li>
   <li>
-    <ul data-controller="drag" data-drag-url="<%= compute_update_position_path(@organisation, @department) %>" class="<%= "draggable" if @current_agent_roles.any?(&:admin?) %> nav">
+    <ul data-controller="drag" data-drag-url="<%= structure_configurations_positions_update_path %>" class="<%= "draggable" if @current_agent_roles.any?(&:admin?) %> nav">
     <% @all_configurations.each do |configuration| %>
       <li class="nav-item" data-id="<%= configuration.id %>">
-        <%= link_to compute_index_path(@organisation, @department, motif_category_id: configuration.motif_category_id), class: "nav-link d-flex align-items-center #{configuration.id == @current_configuration&.id ? 'active' : ''}" do %>
+        <%= link_to structure_users_path(motif_category_id: configuration.motif_category_id), class: "nav-link d-flex align-items-center #{configuration.id == @current_configuration&.id ? 'active' : ''}" do %>
           <%= configuration.motif_category_name %>
           <% if @current_agent_roles.any?(&:admin?) && @all_configurations.size > 1 %>
             <i data-controller="tooltip" data-action="mouseover->tooltip#reOrderCategories" class="fas fa-grip-vertical"></i>
@@ -17,6 +17,6 @@
     </ul>
   </li>
   <li class="nav-item">
-    <%= link_to "Archivés", compute_index_path(@organisation, @department, users_scope: "archived"), class: "nav-link #{archived_scope?(@users_scope) ? 'active' : ''}" %>
+    <%= link_to "Archivés", structure_users_path(users_scope: "archived"), class: "nav-link #{archived_scope?(@users_scope) ? 'active' : ''}" %>
   </li>
 </ul>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -52,7 +52,7 @@
           <%= display_context_status(rdv_context, @current_configuration.number_of_days_before_action_required) %>
         </td>
         <td class="padding-left-15">
-          <%= link_to compute_show_path(user, @organisation, @department) do %>
+          <%= link_to structure_user_path(user.id) do %>
             <button class="btn btn-blue">Gérer</button>
           <% end %>
         </td>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render 'archive_banner' if @user.archived_in?(@department) %>
-<%= simple_form_for(@user, url: compute_show_path(@user, @organisation, @department), html: { method: :patch }) do |f| %>
-  <%= render 'user_form', f: f, title: "Modifier usager", return_path: compute_show_path(@user, @organisation, @department) %>
+<%= simple_form_for(@user, url: structure_user_path(@user.id), html: { method: :patch }) do |f| %>
+  <%= render 'user_form', f: f, title: "Modifier usager", return_path: structure_user_path(@user.id) %>
 <% end %>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(@user, url: department_level? ? department_users_path(@department, @user) : organisation_users_path(@organisation, @user), html: { method: :post }) do |f| %>
-  <%= render 'user_form', f: f, title: "Créer un usager", return_path: compute_index_path(@organisation, @department) %>
+<%= simple_form_for(@user, url: structure_users_path, html: { method: :post }) do |f| %>
+  <%= render 'user_form', f: f, title: "Créer un usager", return_path: structure_users_path %>
 <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
 <div class="container text-dark-blue h4-as-labels mt-4">
   <div class="d-flex justify-content-between mb-4">
     <div>
-      <%= link_to(@back_to_users_list_url || compute_index_path(@organisation, @department)) do %>
+      <%= link_to(@back_to_users_list_url || structure_users_path) do %>
         <button class="btn btn-blue-out">Retour</button>
       <% end %>
       <%= link_to rdv_solidarites_user_url(@organisation, @user), target: "_blank" do %>
@@ -22,7 +22,7 @@
     </div>
     <div>
       <%= render "archiving_button" %>
-      <%= link_to compute_edit_path(@user, @organisation, @department) do %>
+      <%= link_to edit_structure_user_path(@user.id) do %>
         <button class="btn btn-blue">Modifier</button>
       <% end %>
     </div>
@@ -54,22 +54,13 @@
         <h4> Tags </h4>
         <%= render "user_tags", tags: @tags %>
 
-        <%= link_to(compute_user_tag_assignations_path(@organisation, @department, @user), data: { turbo_frame: 'remote_modal' }) do %>
+        <%= link_to(structure_user_tag_assignations_path(@user.id), data: { turbo_frame: 'remote_modal' }) do %>
           <button class="btn btn-blue mb-3"><i class="fas fa-pen"></i> Ajouter ou retirer un tag </button>
         <% end %>
       </div>
 
-      <%= render "common/attribute_display", record: @user, attribute: :organisations, as: :list, id: "organisations_list" do %>
-        <%= link_to(department_user_users_organisations_path(@department, @user, current_organisation_id: department_level? ? nil : @organisation.id), data: { turbo_frame: 'remote_modal' }) do %>
-          <button class="btn btn-blue"><i class="fas fa-pen"></i> Ajouter ou retirer une organisation </button>
-        <% end %>
-      <% end %>
-
-      <%= render "common/attribute_display", record: @user, attribute: :referents, as: :list, id: "referents_list" do %>
-        <%= link_to(department_user_referent_assignations_path(@department, @user), data: { turbo_frame: 'remote_modal' }) do %>
-          <button class="btn btn-blue mb-3"><i class="fas fa-user-plus"></i> Assigner le.s référent.s</button>
-        <% end %>
-      <% end %>
+      <%= render "users/user_organisations_list", user: @user %>
+      <%= render "users/user_referents_list", user: @user %>
     </div>
   </div>
   <% @all_configurations.each do |configuration| %>

--- a/app/views/users_organisations/_users_organisation.html.erb
+++ b/app/views/users_organisations/_users_organisation.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id(organisation, :users_organisation) %>" class="d-flex justify-content-between my-4">
   <div class="col-5"><p><%= organisation.name %></p></div>
   <div class="col-7">
-    <%= simple_form_for(:users_organisation, url: department_users_organisations_path(department, current_organisation_id: @current_organisation&.id), html: { method: belongs_to_org ? :delete : :post }) do |f| %>
+    <%= simple_form_for(:users_organisation, url: users_organisations_path, html: { method: belongs_to_org ? :delete : :post }) do |f| %>
       <%= f.input :user_id,
                   as: :hidden,
                   input_html: { class: "form-control", value: user.id }

--- a/app/views/users_organisations/create.turbo_stream.erb
+++ b/app/views/users_organisations/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "organisations_list" do %>
-  <%= render "common/attribute_display", record: @user, attribute: :organisations, as: :list, id: "organisations_list" %>
+  <%= render partial: "users/user_organisations_list", locals: { user: @user.reload, department: @department } %>
 <% end %>
 
 <%= render_turbo_stream_flash_messages %>

--- a/app/views/users_organisations/destroy.turbo_stream.erb
+++ b/app/views/users_organisations/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.replace "organisations_list" do %>
-  <%= render "common/attribute_display", record: @user, attribute: :organisations, as: :list, id: "organisations_list" %>
+  <%= render partial: "users/user_organisations_list", locals: { user: @user.reload, department: @department } %>
 <% end %>
 
 <%= render_turbo_stream_flash_messages %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,10 +92,6 @@ Rails.application.routes.draw do
     resources :carnets, only: [:create]
   end
 
-  resources :users, only: [] do
-    resource :parcours
-  end
-
   resources :users_organisations, only: [:index, :create]
   resource :users_organisations, only: [:destroy]
   resources :referent_assignations, only: [:index, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,15 @@ Rails.application.routes.draw do
     resources :carnets, only: [:create]
   end
 
+  resources :users, only: [] do
+    resource :parcours
+  end
+
+  resources :users_organisations, only: [:index, :create]
+  resource :users_organisations, only: [:destroy]
+  resources :referent_assignations, only: [:index, :create]
+  resource :referent_assignations, only: [:destroy]
+
   resources :departments, only: [] do
     patch "configurations_positions/update", to: "configurations_positions#update"
     resources :department_organisations, only: [:index], as: :organisations, path: "/organisations"
@@ -102,18 +111,13 @@ Rails.application.routes.draw do
         get :default_list
       end
       resources :invitations, only: [:create]
-      resources :users_organisations, only: [:index]
-      resources :referent_assignations, only: [:index]
       resources :tag_assignations, only: [:index, :create] do
         delete :destroy, on: :collection
       end
     end
-    resource :users_organisations, only: [:create, :destroy]
-    resource :referent_assignations, only: [:create, :destroy]
     resource :stats, only: [:show]
   end
   resources :invitation_dates_filterings, :creation_dates_filterings, only: [:new]
-  resources :tags_filterings, :tags_filterings, only: [:new]
 
   namespace :api do
     namespace :v1 do

--- a/spec/controllers/rdv_contexts/closings_controller_spec.rb
+++ b/spec/controllers/rdv_contexts/closings_controller_spec.rb
@@ -19,8 +19,7 @@ describe RdvContexts::ClosingsController do
     end
 
     let(:create_params) do
-      { rdv_context_id: rdv_context.id, user_id: user.id,
-        organisation_id: organisation.id, department_id: department.id }
+      { rdv_context_id: rdv_context.id, user_id: user.id, department_id: department.id }
     end
 
     it "calls the close rdv_context service" do
@@ -39,7 +38,7 @@ describe RdvContexts::ClosingsController do
     context "when not department_level" do
       let(:create_params) do
         { rdv_context_id: rdv_context.id, user_id: user.id,
-          organisation_id: organisation.id, department_id: nil }
+          organisation_id: organisation.id }
       end
 
       context "when the rdv_context is closed successfully" do
@@ -54,7 +53,7 @@ describe RdvContexts::ClosingsController do
   describe "#destroy" do
     let(:destroy_params) do
       { rdv_context_id: rdv_context.id, user_id: user.id,
-        organisation_id: organisation.id, department_id: department.id }
+        department_id: department.id }
     end
     let!(:rdv_context) do
       create(:rdv_context, user: user, motif_category: motif_category,
@@ -76,7 +75,7 @@ describe RdvContexts::ClosingsController do
     context "when not department_level" do
       let(:destroy_params) do
         { rdv_context_id: rdv_context.id, user_id: user.id,
-          organisation_id: organisation.id, department_id: nil }
+          organisation_id: organisation.id }
       end
 
       context "when the rdv_context is closed successfully" do

--- a/spec/models/rdv_solidarites_session/with_shared_secret_spec.rb
+++ b/spec/models/rdv_solidarites_session/with_shared_secret_spec.rb
@@ -19,6 +19,8 @@ describe RdvSolidaritesSession::WithSharedSecret do
   end
 
   describe "#valid?" do
+    before { allow(Current).to receive(:agent).and_return(agent) }
+
     context "when required attributes are present and signature is valid" do
       it "session is valid" do
         expect(subject).to be_valid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,10 @@ RSpec.configure do |config|
     clear_downloads
   end
 
+  config.before do
+    ActiveSupport::CurrentAttributes.reset_all
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
## Contexte

En commençant à travailler sur le parcours, je me suis rendu compte que lorsque je suis sur l'onglet parcours et que je veux revenir aux infos de l'usager, je dois savoir si je me trouve dans une vue de l'organisation ou une vue du département. 
C'est un problème qu'on a à plusieurs endroits de l'application, et qui fait qu'on passe souvent des `organisation_id` et des `department_id` sur des actions qui ne dépendent pas de ces paramètres, mais seulement pour pouvoir rediriger sur la bonne page après cette action. 
Dans les vues on se retrouve aussi à avoir une multitude de méthode `compute...path` auxquelles on passe des instances vides d'organisation ou de département pour pouvoir retrouver la bonne URL. 
J'avais déjà exprimé ce problème dans #1114 .

## Implémentation

L'idée est qu'à chaque requête on store en session dans quelle type de structure on est (si c'est un département ou une organisation) en fonction des paramètres dans l'url. 
On va également storer l'id de cette structure.
Cette logique se trouve dans le concern `CurrentStructure`.

### Utilisation de `ActiveSupport::CurrentAttributes`

En plus de storer le type et l'id de la structure en session, j'introduis un model `Current` qui descend des [`ActiveSupport::CurrentAttributes`](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) dans lequel je store ces attributs. Ça permet de pouvoir accéder à ces variables dans toute l'application et pas seulement dans les controllers.
Remarque: J'en profite pour rendre accessible le `current_agent` via `Current.agent`.

### `NavigationHelper`

Du coup on définit un helper dans lequel on définit les méthodes permettant de retrouver le path d'une action en fonction de la structure dans laquelle on se trouve. L'assignement du bon path et de l'id de la structure se fait dynamiquement en fonction de ce qui aura été définit dans l'objet `Current`.
On est donc plus obligé de passer des ids à chaque fois et on n'a plus à implémenter une logique de redirection en fonction de l'où on est dans chaque controller.

## Développements annexes

* J'en profite pour régler le bug #1420 . 

## Perspectives

* J'ai utilisé cette nouvelle logique dans les endroits qui me paraissaient évident mais il reste probablement des endroits que l'on peut simplifier, notamment dans le `users_controller`
* On pourrait assigner de nouveaux attributs au model `Current`, notamment la `rdv_solidarites_session`: Ça nous permettra de ne plus avoir à faire passer cette instance dans tous nos services ! 

