### PR TITLE
feat(csv): add prescripteur info

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_prescripteur_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_prescripteur_job.rb
@@ -1,0 +1,42 @@
+module InboundWebhooks
+  module RdvSolidarites
+    class ProcessPrescripteurJob < ApplicationJob
+      def perform(data, meta)
+        @data = data.deep_symbolize_keys
+        @meta = meta.deep_symbolize_keys
+        return if participation.blank?
+
+        upsert_or_delete_prescripteur
+      end
+
+      private
+
+      def event
+        @meta[:event]
+      end
+
+      def rdv_solidarites_prescripteur_id
+        @data[:id]
+      end
+
+      def participation
+        @participation ||= Participation.find_by(rdv_solidarites_participation_id: @data[:participation_id])
+      end
+
+      def upsert_or_delete_prescripteur
+        return delete_prescripteur if event == "destroyed"
+
+        UpsertRecordJob.perform_async(
+          "Prescripteur",
+          @data,
+          { last_webhook_update_received_at: @meta[:timestamp], participation_id: participation.id }
+        )
+      end
+
+      def delete_prescripteur
+        prescripteur = Prescripteur.find_by(rdv_solidarites_prescripteur_id: rdv_solidarites_prescripteur_id)
+        prescripteur.destroy!
+      end
+    end
+  end
+end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -10,6 +10,7 @@ class Participation < ApplicationRecord
   has_many :notifications, dependent: :nullify
   has_many :rdv_context_invitations, through: :rdv_context, source: :invitations
 
+  has_one :prescripteur, dependent: :destroy
   has_one :organisation, through: :rdv
   has_many :configurations, through: :organisation
 

--- a/app/models/prescripteur.rb
+++ b/app/models/prescripteur.rb
@@ -1,0 +1,10 @@
+class Prescripteur < ApplicationRecord
+  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:first_name, :last_name, :email].freeze
+
+  belongs_to :participation
+  has_one :rdv, through: :participation
+  has_one :user, through: :participation
+
+  validates :participation_id, uniqueness: true
+  validates :first_name, :last_name, :email, presence: true
+end

--- a/db/migrate/20231204154228_create_prescripteurs.rb
+++ b/db/migrate/20231204154228_create_prescripteurs.rb
@@ -1,0 +1,14 @@
+class CreatePrescripteurs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :prescripteurs do |t|
+      t.string :first_name
+      t.string :last_name
+      t.string :email
+      t.references :participation, null: false, foreign_key: true
+      t.bigint :rdv_solidarites_prescripteur_id
+      t.datetime :last_webhook_update_received_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_21_133009) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_04_154228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -265,6 +265,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_133009) do
     t.index ["user_id", "rdv_id"], name: "index_participations_on_user_id_and_rdv_id", unique: true
   end
 
+  create_table "prescripteurs", force: :cascade do |t|
+    t.string "first_name"
+    t.string "last_name"
+    t.string "email"
+    t.bigint "participation_id", null: false
+    t.bigint "rdv_solidarites_prescripteur_id"
+    t.datetime "last_webhook_update_received_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["participation_id"], name: "index_prescripteurs_on_participation_id"
+  end
+
   create_table "rdv_contexts", force: :cascade do |t|
     t.integer "status"
     t.bigint "user_id", null: false
@@ -451,6 +463,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_133009) do
   add_foreign_key "notifications", "participations"
   add_foreign_key "organisations", "departments"
   add_foreign_key "participations", "rdv_contexts"
+  add_foreign_key "prescripteurs", "participations"
   add_foreign_key "rdv_contexts", "motif_categories"
   add_foreign_key "rdv_contexts", "users"
   add_foreign_key "rdvs", "lieux"

--- a/spec/factories/prescripteurs.rb
+++ b/spec/factories/prescripteurs.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :prescripteur do
+    first_name { "MyString" }
+    last_name { "MyString" }
+    email { "MyString" }
+    participation { nil }
+  end
+end

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_prescripteur_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_prescripteur_job_spec.rb
@@ -1,0 +1,55 @@
+describe InboundWebhooks::RdvSolidarites::ProcessPrescripteurJob do
+  subject do
+    described_class.new.perform(data, meta)
+  end
+
+  let!(:data) do
+    {
+      "id" => rdv_solidarites_prescripteur_id,
+      "participation_id" => rdv_solidarites_participation_id,
+      "email" => "linus@linux.com",
+      "first_name" => "Linus",
+      "last_name" => "Linux"
+    }.deep_symbolize_keys
+  end
+
+  let!(:meta) do
+    {
+      "model" => "Prescripteur",
+      "event" => "created",
+      "timestamp" => "2022-05-30 14:44:22 +0200"
+    }.deep_symbolize_keys
+  end
+
+  let!(:participation) { create(:participation, rdv_solidarites_participation_id:) }
+  let!(:rdv_solidarites_prescripteur_id) { 123 }
+  let!(:rdv_solidarites_participation_id) { 123 }
+
+  describe "#perform" do
+    it "upserts the prescripteur" do
+      expect(UpsertRecordJob).to receive(:perform_async)
+        .with("Prescripteur", data, {
+                last_webhook_update_received_at: "2022-05-30 14:44:22 +0200",
+                participation_id: participation.id
+              })
+      subject
+    end
+
+    context "when it is a destroyed event" do
+      let!(:prescripteur) { create(:prescripteur, rdv_solidarites_prescripteur_id:, participation:) }
+
+      let!(:meta) do
+        {
+          "model" => "Prescripteur",
+          "event" => "destroyed",
+          "timestamp" => "2022-05-30 14:44:22 +0200"
+        }.deep_symbolize_keys
+      end
+
+      it "deletes the prescripteur" do
+        expect(UpsertRecordJob).not_to receive(:perform_async)
+        expect { subject }.to change(Prescripteur, :count).by(-1)
+      end
+    end
+  end
+end

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -39,6 +39,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
                  participations: [participation_rdv])
   end
   let!(:participation_rdv) { create(:participation, user: user1, status: "seen") }
+  let!(:prescripteur) { create(:prescripteur, participation: participation_rdv, first_name: "Michaël") }
 
   let!(:first_invitation) do
     create(:invitation, user: user1, format: "email", sent_at: Time.zone.parse("2022-05-21"))
@@ -109,6 +110,10 @@ describe Exporters::GenerateUsersCsv, type: :service do
         expect(csv).to include("Référent(s)")
         expect(csv).to include("Nombre d'organisations")
         expect(csv).to include("Nom des organisations")
+        expect(csv).to include("Rendez-vous prescrit")
+        expect(csv).to include("Prénom du prescripteur")
+        expect(csv).to include("Nom du prescripteur")
+        expect(csv).to include("Email du prescripteur")
       end
 
       context "it exports all the concerned users" do
@@ -164,6 +169,11 @@ describe Exporters::GenerateUsersCsv, type: :service do
           expect(csv).to include("Statut du RDV à préciser") # rdv_context status
           expect(csv).to include("Statut du RDV à préciser;Oui") # first rdv in less than 30 days ?
           expect(csv).to include("Non déterminé;Statut du RDV à préciser;Oui;25/05/2022") # orientation date
+        end
+
+        it "displays the prescripteur infos" do
+          expect(csv).to include(prescripteur.first_name)
+          expect(csv).to include(prescripteur.last_name)
         end
 
         it "displays the organisation infos" do


### PR DESCRIPTION
Cette PR permet d'enregistrer les prescripteurs grâce à la modification du webhook côté RDVs

Une fois enregistrés, les prescripteurs sont désormais affichés dans l'export CSV des users

fix #1544 