### PR TITLE
fix(mailers): set_user correctly if reply comes from another email

### DIFF
--- a/app/mailers/reply_transfer_mailer.rb
+++ b/app/mailers/reply_transfer_mailer.rb
@@ -37,9 +37,9 @@ class ReplyTransferMailer < ApplicationMailer
   end
 
   def set_user_page_url
-    @user_page_url = if @organisation.present?
+    @user_page_url = if @organisation && @user
                        organisation_user_url(@organisation, @user, host: ENV["HOST"])
-                     elsif @department.present?
+                     elsif @department && @user
                        department_user_url(@department, @user, host: ENV["HOST"])
                      end
   end

--- a/app/mailers/reply_transfer_mailer.rb
+++ b/app/mailers/reply_transfer_mailer.rb
@@ -57,7 +57,11 @@ class ReplyTransferMailer < ApplicationMailer
   end
 
   def set_user
-    @user = User.find_by(email: @source_mail.from.first)
+    @user = if @rdv.present? && @rdv.users.one?
+              @rdv.users.first
+            else
+              @invitation&.user || User.find_by(email: @source_mail.from.first)
+            end
   end
 
   def set_reply_subject


### PR DESCRIPTION
Traite [cette erreur Sentry].
Lorsqu'un usager répondait à un email depuis une boîte mail autre que celle utilisée pour prendre le rendez-vous, le job de transfert de réponse automatique ne fonctionnait pas. Cette PR résout ce problème, en priorisant l'utilisateur lié au rendez-vous ou à l'invitation ; l'email n'est utilisé pour `set_user` que lorsque cette priorité n'est pas réalisable.