### PR TITLE
fix(jobs): set current agent in jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,5 @@
 class ApplicationJob
   include Sidekiq::Worker
   include EnvironmentsHelper
+  include JobSessionConcern
 end

--- a/app/jobs/concerns/job_session_concern.rb
+++ b/app/jobs/concerns/job_session_concern.rb
@@ -1,0 +1,11 @@
+module JobSessionConcern
+  extend ActiveSupport::Concern
+
+  def rdv_solidarites_session(credentials)
+    @rdv_solidarites_session ||= RdvSolidaritesSessionFactory.create_with(**credentials)
+  end
+
+  def current_agent(credentials)
+    @current_agent ||= Agent.find_by(email: credentials[:uid])
+  end
+end

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -11,6 +11,7 @@ class CreateAndInviteUserJob < ApplicationJob
     @invitation_attributes = invitation_attributes.deep_symbolize_keys
     @motif_category_attributes = motif_category_attributes.deep_symbolize_keys
     @rdv_solidarites_session_credentials = rdv_solidarites_session_credentials.deep_symbolize_keys
+    Current.agent = current_agent(@rdv_solidarites_session_credentials)
 
     upsert_user!
     invite_user
@@ -22,7 +23,7 @@ class CreateAndInviteUserJob < ApplicationJob
     upsert_user = Users::Upsert.call(
       user_attributes: @user_attributes,
       organisation: @organisation,
-      rdv_solidarites_session:
+      rdv_solidarites_session: rdv_solidarites_session(@rdv_solidarites_session_credentials)
     )
     @user = upsert_user.user
     return if upsert_user.success?
@@ -54,9 +55,5 @@ class CreateAndInviteUserJob < ApplicationJob
       @motif_category_attributes,
       @rdv_solidarites_session_credentials
     )
-  end
-
-  def rdv_solidarites_session
-    @rdv_solidarites_session ||= RdvSolidaritesSessionFactory.create_with(**@rdv_solidarites_session_credentials)
   end
 end

--- a/app/jobs/invite_user_job.rb
+++ b/app/jobs/invite_user_job.rb
@@ -8,7 +8,8 @@ class InviteUserJob < ApplicationJob
     @organisation = Organisation.find(organisation_id)
     @invitation_attributes = invitation_attributes.deep_symbolize_keys
     @motif_category_attributes = motif_category_attributes
-    @rdv_solidarites_session_credentials = rdv_solidarites_session_credentials
+    @rdv_solidarites_session_credentials = rdv_solidarites_session_credentials.deep_symbolize_keys
+    Current.agent = current_agent(@rdv_solidarites_session_credentials)
 
     Invitation.with_advisory_lock "invite_user_job_#{@user.id}" do
       invite_user!
@@ -23,7 +24,7 @@ class InviteUserJob < ApplicationJob
       organisations: [@organisation],
       invitation_attributes: @invitation_attributes,
       motif_category_attributes: @motif_category_attributes,
-      rdv_solidarites_session:,
+      rdv_solidarites_session: rdv_solidarites_session(@rdv_solidarites_session_credentials),
       check_creneaux_availability: false
     )
     return if invite_user_service.success?
@@ -33,9 +34,5 @@ class InviteUserJob < ApplicationJob
       "Could not send invitation to user #{@user.id} in InviteUserJob: " \
       "#{invite_user_service.errors}"
     )
-  end
-
-  def rdv_solidarites_session
-    @rdv_solidarites_session ||= RdvSolidaritesSessionFactory.create_with(**@rdv_solidarites_session_credentials)
   end
 end

--- a/app/jobs/trigger_rdv_solidarites_webhooks_job.rb
+++ b/app/jobs/trigger_rdv_solidarites_webhooks_job.rb
@@ -5,6 +5,7 @@ class TriggerRdvSolidaritesWebhooksJob < ApplicationJob
     @rdv_solidarites_webhook_endpoint_id = rdv_solidarites_webhook_endpoint_id
     @rdv_solidarites_organisation_id = rdv_solidarites_organisation_id
     @rdv_solidarites_session_credentials = rdv_solidarites_session_credentials.deep_symbolize_keys
+    Current.agent = current_agent(@rdv_solidarites_session_credentials)
 
     return if trigger_webhook_endpoint.success?
 
@@ -17,12 +18,8 @@ class TriggerRdvSolidaritesWebhooksJob < ApplicationJob
     @trigger_webhook_endpoint ||= RdvSolidaritesApi::UpdateWebhookEndpoint.call(
       rdv_solidarites_webhook_endpoint_id: @rdv_solidarites_webhook_endpoint_id,
       rdv_solidarites_organisation_id: @rdv_solidarites_organisation_id,
-      rdv_solidarites_session: rdv_solidarites_session,
+      rdv_solidarites_session: rdv_solidarites_session(@rdv_solidarites_session_credentials),
       trigger: true
     )
-  end
-
-  def rdv_solidarites_session
-    @rdv_solidarites_session ||= RdvSolidaritesSessionFactory.create_with(**@rdv_solidarites_session_credentials)
   end
 end

--- a/spec/jobs/create_and_invite_user_job_spec.rb
+++ b/spec/jobs/create_and_invite_user_job_spec.rb
@@ -24,8 +24,9 @@ describe CreateAndInviteUserJob do
   let!(:email_invitation_attributes) { invitation_attributes.merge(format: "email", help_phone_number: "0146292929") }
   let!(:sms_invitation_attributes) { invitation_attributes.merge(format: "sms", help_phone_number: "0146292929") }
 
+  let!(:agent) { create(:agent, email: "janedoe@gouv.fr") }
   let!(:rdv_solidarites_session_credentials) do
-    { "client" => "someclient", "uid" => "janedoe@gouv.fr", "access_token" => "sometoken" }.symbolize_keys
+    { "client" => "someclient", "uid" => agent.email.to_s, "access_token" => "sometoken" }.symbolize_keys
   end
 
   before do
@@ -36,6 +37,11 @@ describe CreateAndInviteUserJob do
     allow(Users::Upsert).to receive(:call)
       .with(organisation:, user_attributes:, rdv_solidarites_session:)
       .and_return(OpenStruct.new(success?: true, user: user))
+  end
+
+  it "sets the current agent" do
+    subject
+    expect(Current.agent).to eq(agent)
   end
 
   it "upserts the user" do

--- a/spec/jobs/invite_user_job_spec.rb
+++ b/spec/jobs/invite_user_job_spec.rb
@@ -12,8 +12,9 @@ describe InviteUserJob do
   let!(:organisation) do
     create(:organisation, id: organisation_id, department: department)
   end
+  let!(:agent) { create(:agent, email: "janedoe@gouv.fr") }
   let!(:rdv_solidarites_session_credentials) do
-    { "client" => "someclient", "uid" => "janedoe@gouv.fr", "access_token" => "sometoken" }.symbolize_keys
+    { "client" => "someclient", "uid" => agent.email.to_s, "access_token" => "sometoken" }.symbolize_keys
   end
   let!(:invitation_format) { "sms" }
   let!(:invitation_attributes) do
@@ -38,6 +39,11 @@ describe InviteUserJob do
         )
         .and_return(OpenStruct.new(success?: true))
     end
+
+  it "sets the current agent" do
+    subject
+    expect(Current.agent).to eq(agent)
+  end
 
     it "invites the user" do
       expect(InviteUser).to receive(:call)

--- a/spec/jobs/invite_user_job_spec.rb
+++ b/spec/jobs/invite_user_job_spec.rb
@@ -40,10 +40,10 @@ describe InviteUserJob do
         .and_return(OpenStruct.new(success?: true))
     end
 
-  it "sets the current agent" do
-    subject
-    expect(Current.agent).to eq(agent)
-  end
+    it "sets the current agent" do
+      subject
+      expect(Current.agent).to eq(agent)
+    end
 
     it "invites the user" do
       expect(InviteUser).to receive(:call)

--- a/spec/jobs/trigger_rdv_solidarites_webhooks_job_spec.rb
+++ b/spec/jobs/trigger_rdv_solidarites_webhooks_job_spec.rb
@@ -7,8 +7,9 @@ describe TriggerRdvSolidaritesWebhooksJob do
 
   let!(:rdv_solidarites_webhook_endpoint_id) { 17 }
   let!(:rdv_solidarites_organisation_id) { 1717 }
+  let!(:agent) { create(:agent, email: "janedoe@gouv.fr") }
   let!(:rdv_solidarites_session_credentials) do
-    { "client" => "someclient", "uid" => "janedoe@gouv.fr", "access_token" => "sometoken" }.symbolize_keys
+    { "client" => "someclient", "uid" => agent.email.to_s, "access_token" => "sometoken" }.symbolize_keys
   end
   let!(:rdv_solidarites_session) { instance_double(RdvSolidaritesSession::Base) }
 
@@ -25,6 +26,11 @@ describe TriggerRdvSolidaritesWebhooksJob do
           trigger: true
         )
         .and_return(OpenStruct.new(success?: true))
+    end
+
+    it "sets the current agent" do
+      subject
+      expect(Current.agent).to eq(agent)
     end
 
     it "calls the update webhook service with the trigger option on" do


### PR DESCRIPTION
fix [ce bug Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/78219/?alert_rule_id=9&alert_timestamp=1702886472245&alert_type=email&environment=production&project=16&referrer=alert_email)

Les jobs étant executés en asychrone, le `Current.agent` n'y était pas défini. Je résous ce problème (avec une petite refacto de l'endroit où l'on crée la session pour être plus DRY