### PR TITLE
fix(stats): allow stats to run by removing in memory handling of conditions

### DIFF
--- a/app/jobs/stats/global_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stat_job.rb
@@ -7,7 +7,7 @@ module Stats
 
       def perform(structure_type, structure_id)
         # to do : add timeout as a global concern for all jobs and remove it here
-        Timeout.timeout(10.minutes) do
+        Timeout.timeout(30.minutes) do
           upsert_stat_record_for_global_stats =
             Stats::GlobalStats::UpsertStat.call(structure_type: structure_type, structure_id: structure_id)
 

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -23,7 +23,10 @@ class Stat < ApplicationRecord
 
   # We filter the participations to only keep the participations of the users in the scope
   def participations_sample
-    participations = all_participations.where.not(user_id: archived_user_ids)
+    participations = all_participations
+                     .where.not(user_id: archived_user_ids)
+                     .left_outer_joins(:user)
+                     .where(users: { deleted_at: nil })
 
     if statable.present?
       participations = participations.left_outer_joins(user: :organisations)

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -25,11 +25,11 @@ class Stat < ApplicationRecord
   def participations_sample
     participations = all_participations
                      .where.not(user_id: archived_user_ids)
-                     .left_outer_joins(:user)
+                     .joins(:user)
                      .where(users: { deleted_at: nil })
 
     if statable.present?
-      participations = participations.left_outer_joins(user: :organisations)
+      participations = participations.joins(user: :organisations)
                                      .where(users: { organisations: all_organisations })
     end
 

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -19,8 +19,7 @@ module Stats
           rate_of_no_show_for_invitations: rate_of_no_show_for_invitations,
           rate_of_no_show_for_convocations: rate_of_no_show_for_convocations,
           average_time_between_invitation_and_rdv_in_days: average_time_between_invitation_and_rdv_in_days,
-          rate_of_users_oriented_in_less_than_30_days:
-            rate_of_users_oriented_in_less_than_30_days,
+          rate_of_users_oriented_in_less_than_30_days: rate_of_users_oriented_in_less_than_30_days,
           rate_of_users_oriented: rate_of_users_oriented,
           rate_of_autonomous_users: rate_of_autonomous_users,
           agents_count: agents_count

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -49,6 +49,10 @@ describe Stat do
           expect(stat.all_organisations).to include(organisation)
           expect(stat.all_organisations).not_to include(other_organisation)
         end
+
+        it "does not scope the collection to the department" do
+          expect(stat.all_organisations).to include(other_organisation)
+        end
       end
 
       describe "#all_participations" do
@@ -113,18 +117,6 @@ describe Stat do
             expect(stat.participations_with_notifications_sample).not_to include(participation4)
             expect(stat.participations_with_notifications_sample).to include(participation5)
           end
-        end
-      end
-
-      describe "#all_organisations" do
-        let!(:organisation_with_no_invitations_formats) { create(:organisation, department: department) }
-        let!(:configuration_with_no_invitations_formats) do
-          create(:configuration, organisation: organisation_with_no_invitations_formats, invitation_formats: [])
-        end
-
-        it "scopes the collection to the department" do
-          expect(stat.all_organisations).to include(organisation)
-          expect(stat.all_organisations).not_to include(other_organisation)
         end
       end
 
@@ -539,12 +531,6 @@ describe Stat do
       describe "#participations_sample" do
         it "does not scope the collection to the department" do
           expect(stat.participations_sample).to include(participation2)
-        end
-      end
-
-      describe "#all_organisations" do
-        it "does not scope the collection to the department" do
-          expect(stat.all_organisations).to include(other_organisation)
         end
       end
 

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -49,10 +49,6 @@ describe Stat do
           expect(stat.all_organisations).to include(organisation)
           expect(stat.all_organisations).not_to include(other_organisation)
         end
-
-        it "does not scope the collection to the department" do
-          expect(stat.all_organisations).to include(other_organisation)
-        end
       end
 
       describe "#all_participations" do

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -116,20 +116,15 @@ describe Stat do
         end
       end
 
-      describe "#organisations_sample" do
+      describe "#all_organisations" do
         let!(:organisation_with_no_invitations_formats) { create(:organisation, department: department) }
         let!(:configuration_with_no_invitations_formats) do
           create(:configuration, organisation: organisation_with_no_invitations_formats, invitation_formats: [])
         end
 
         it "scopes the collection to the department" do
-          expect(stat.organisations_sample).to include(organisation)
-          expect(stat.organisations_sample).not_to include(other_organisation)
-        end
-
-        it "scopes the collection to the ones with an active configuration" do
-          expect(stat.organisations_sample).not_to include(organisation_with_no_invitations_formats)
-          expect(stat.organisations_sample).not_to include(organisation_with_no_configuration)
+          expect(stat.all_organisations).to include(organisation)
+          expect(stat.all_organisations).not_to include(other_organisation)
         end
       end
 
@@ -156,10 +151,6 @@ describe Stat do
 
         it "does not include the archived users" do
           expect(stat.users_sample).not_to include(user4)
-        end
-
-        it "does not include the user from irrelevant organisations" do
-          expect(stat.users_sample).not_to include(user5)
         end
       end
 
@@ -218,10 +209,6 @@ describe Stat do
         it "does not include rdv_contexts with no rdvs" do
           expect(stat.rdv_contexts_with_invitations_and_participations_sample).not_to include(rdv_context5)
         end
-
-        it "does not include the rdv_contexts of users from irrelevant organisations" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_sample).not_to include(rdv_context6)
-        end
       end
 
       describe "#rdvs_non_collectifs_sample" do
@@ -258,16 +245,8 @@ describe Stat do
           expect(stat.invited_users_sample).not_to include(user2)
         end
 
-        it "does not include the user from irrelevant organisations" do
-          expect(stat.invited_users_sample).not_to include(user3)
-        end
-
         it "does not include the users whith no invitations" do
           expect(stat.invited_users_sample).not_to include(user4)
-        end
-
-        it "does not include the users whith no sent invitation" do
-          expect(stat.invited_users_sample).not_to include(user5)
         end
 
         it "includes the invited users whith no rdvs" do
@@ -352,23 +331,6 @@ describe Stat do
         it "scopes the collection to the organisation" do
           expect(stat.participations_sample).to include(participation1)
           expect(stat.participations_sample).not_to include(participation2)
-        end
-      end
-
-      describe "#organisations_sample" do
-        let!(:organisation_with_no_invitations_formats) { create(:organisation, department: department) }
-        let!(:configuration_with_no_invitations_formats) do
-          create(:configuration, organisation: organisation_with_no_invitations_formats, invitation_formats: [])
-        end
-
-        it "scopes the collection to the organisation" do
-          expect(stat.organisations_sample).to include(organisation)
-          expect(stat.organisations_sample).not_to include(other_organisation)
-        end
-
-        it "scopes the collection to the ones with an active configuration" do
-          expect(stat.organisations_sample).not_to include(organisation_with_no_invitations_formats)
-          expect(stat.organisations_sample).not_to include(organisation_with_no_configuration)
         end
       end
 
@@ -580,9 +542,9 @@ describe Stat do
         end
       end
 
-      describe "#organisations_sample" do
+      describe "#all_organisations" do
         it "does not scope the collection to the department" do
-          expect(stat.organisations_sample).to include(other_organisation)
+          expect(stat.all_organisations).to include(other_organisation)
         end
       end
 


### PR DESCRIPTION
Du coup dans cette PR j'ai augmenté le délai de timeout pour éviter qu'il s'arrête à 10 minutes (en local avec un jeu de donnée de production je dépasse ce temps). 

Sinon niveau code l'amélioration magique a consisté à enlever un `where(user_id: user_sample)` qui générait un WHERE IN, ce qui était très couteux VS le left outer joins. J'ai également gardé en mémoire certaines chose comme les id de users archivés. 

Malgré ces améliorations, le temps de traitement du job ne va malgré tout faire qu'augmenter. 
En effet, il reste des choses que l'on calcule avec des gros `.find_each` et qui sont voués à ne plus fonctionner dans les semaines / mois à venir. 

Par exemple, ce code : 
```ruby
@rdv_contexts.find_each do |rdv_context|
        cumulated_invitation_delays += rdv_context.time_between_invitation_and_rdv_in_days
      end
``` 

Qui sert à calculer le délai moyen, ne pourra pas fonctionne indéfiniment. Il est déjà extrémement long et va être proportionnel à la quantité de RdvContext. 
S'il prend environ 10 minutes aujourd'hui, il en prendra 20 dans quelques mois.

C'est pour ce genre de chose qu'il va devenir indispensable de soit, faire ce calcul autrement sans itérer, soit différer ce calcul à un autre moment comme proposé dans l'autre PR

cc @aminedhobb @qblanc 