### PR TITLE
fix(csv): show participation status instead of rdv status

### DIFF
--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -100,7 +100,7 @@ module Exporters
        last_rdv_motif(user),
        last_rdv_type(user),
        rdv_taken_in_autonomy?(user),
-       human_rdv_status(user),
+       human_last_participation_status(user),
        *(human_rdv_context_status(user) if @motif_category),
        rdv_seen_in_less_than_30_days?(user),
        display_date(user.first_seen_rdv_starts_at),
@@ -122,10 +122,10 @@ module Exporters
       end
     end
 
-    def human_rdv_status(user)
-      return I18n.t("activerecord.attributes.rdv.statuses.#{last_rdv(user).status}") if last_rdv(user).present?
+    def human_last_participation_status(user)
+      return "" if last_participation(user).blank?
 
-      ""
+      I18n.t("activerecord.attributes.rdv.statuses.#{last_participation(user).status}")
     end
 
     def human_rdv_context_status(user)

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -160,10 +160,10 @@ describe Exporters::GenerateUsersCsv, type: :service do
           expect(csv).to include("RSA orientation sur site") # last rdv motif
           expect(csv).to include("individuel") # last rdv type
           expect(csv).to include("individuel;Oui") # last rdv taken in autonomy ?
-          expect(csv).to include("Non déterminé") # rdv status
+          expect(csv).to include("Rendez-vous honoré") # rdv status
           expect(csv).to include("Statut du RDV à préciser") # rdv_context status
           expect(csv).to include("Statut du RDV à préciser;Oui") # first rdv in less than 30 days ?
-          expect(csv).to include("Non déterminé;Statut du RDV à préciser;Oui;25/05/2022") # orientation date
+          expect(csv).to include("Rendez-vous honoré;Statut du RDV à préciser;Oui;25/05/2022") # orientation date
         end
 
         it "displays the organisation infos" do


### PR DESCRIPTION
Cette PR permet d'afficher le statut de la participation du user au RDV plutôt que le statut du RDV en lui même (qui peut changer en fonction des autres users). 

closes #1528 