### PR TITLE
feat(ops): Enable number of puma workers configuration

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
Je fais en sorte ici de pouvoir ajuster le nombre de worker puma sur notre appli via la variable d'env `WEB_CONCURRENCY`.