### PR TITLE
feat(ops): Try to improve performance

### DIFF
--- a/app/controllers/concerns/users/filterable.rb
+++ b/app/controllers/concerns/users/filterable.rb
@@ -132,7 +132,7 @@ module Users::Filterable
     if rdv_contexts.blank?
       invitations
     else
-      invitations.select { |i| rdv_contexts.include?(i.rdv_context) }
+      invitations.select { |i| rdv_contexts.map(&:id).include?(i.rdv_context_id) }
     end
   end
 end

--- a/app/services/invitations/assign_link_and_token.rb
+++ b/app/services/invitations/assign_link_and_token.rb
@@ -1,5 +1,5 @@
 module Invitations
-  class AssignAttributes < BaseService
+  class AssignLinkAndToken < BaseService
     def initialize(invitation:, rdv_solidarites_session:)
       @invitation = invitation
       @rdv_solidarites_session = rdv_solidarites_session

--- a/app/services/invitations/assign_link_and_token.rb
+++ b/app/services/invitations/assign_link_and_token.rb
@@ -17,11 +17,13 @@ module Invitations
     end
 
     def retrieve_rdv_solidarites_token
-      @retrieve_rdv_solidarites_token ||= call_service!(
-        RdvSolidaritesApi::CreateOrRetrieveInvitationToken,
-        rdv_solidarites_user_id: @invitation.user.rdv_solidarites_user_id,
-        rdv_solidarites_session: @rdv_solidarites_session
-      )
+      Invitation.with_advisory_lock "retrieving_token_for_user_#{@invitation.user_id}" do
+        @retrieve_rdv_solidarites_token ||= call_service!(
+          RdvSolidaritesApi::CreateOrRetrieveInvitationToken,
+          rdv_solidarites_user_id: @invitation.user.rdv_solidarites_user_id,
+          rdv_solidarites_session: @rdv_solidarites_session
+        )
+      end
     end
 
     def compute_invitation_link

--- a/app/services/invitations/save_and_send.rb
+++ b/app/services/invitations/save_and_send.rb
@@ -7,15 +7,13 @@ module Invitations
     end
 
     def call
-      Invitation.with_advisory_lock "invite_user_#{user.id}" do
-        Invitation.transaction do
-          assign_link_and_token
-          validate_invitation
-          verify_creneaux_are_available if @check_creneaux_availability
-          save_record!(@invitation)
-          send_invitation
-          assign_invitation_sent_at
-        end
+      Invitation.transaction do
+        assign_link_and_token
+        validate_invitation
+        verify_creneaux_are_available if @check_creneaux_availability
+        save_record!(@invitation)
+        send_invitation
+        assign_invitation_sent_at
       end
       result.invitation = @invitation
     end
@@ -61,7 +59,7 @@ module Invitations
       return if @invitation.link? && @invitation.rdv_solidarites_token?
 
       call_service!(
-        Invitations::AssignAttributes,
+        Invitations::AssignLinkAndToken,
         invitation: @invitation,
         rdv_solidarites_session: @rdv_solidarites_session
       )

--- a/spec/services/invitations/assign_link_and_token_spec.rb
+++ b/spec/services/invitations/assign_link_and_token_spec.rb
@@ -1,4 +1,4 @@
-describe Invitations::AssignAttributes, type: :service do
+describe Invitations::AssignLinkAndToken, type: :service do
   subject do
     described_class.call(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
   end

--- a/spec/services/invitations/save_and_send_spec.rb
+++ b/spec/services/invitations/save_and_send_spec.rb
@@ -13,7 +13,7 @@ describe Invitations::SaveAndSend, type: :service do
 
   describe "#call" do
     before do
-      allow(Invitations::AssignAttributes).to receive(:call)
+      allow(Invitations::AssignLinkAndToken).to receive(:call)
         .with(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
         .and_return(OpenStruct.new(success?: true))
       allow(Invitations::Validate).to receive(:call)
@@ -37,7 +37,7 @@ describe Invitations::SaveAndSend, type: :service do
     end
 
     it "saves an invitation" do
-      expect(Invitations::AssignAttributes).to receive(:call)
+      expect(Invitations::AssignLinkAndToken).to receive(:call)
         .with(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
       subject
     end
@@ -54,7 +54,7 @@ describe Invitations::SaveAndSend, type: :service do
 
     context "when it fails to assign attributes" do
       before do
-        allow(Invitations::AssignAttributes).to receive(:call)
+        allow(Invitations::AssignLinkAndToken).to receive(:call)
           .with(invitation: invitation, rdv_solidarites_session: rdv_solidarites_session)
           .and_return(OpenStruct.new(success?: false, errors: ["cannot assign token"]))
       end
@@ -113,7 +113,7 @@ describe Invitations::SaveAndSend, type: :service do
       it("is a success") { is_a_success }
 
       it "does not call the assign link and token service" do
-        expect(Invitations::AssignAttributes).not_to receive(:call)
+        expect(Invitations::AssignLinkAndToken).not_to receive(:call)
         subject
       end
     end


### PR DESCRIPTION
Dans cette PR j'essaie d'améliorer le temps de réponse de deux requêtes: 

* Celle qui invite un usager. Jusqu'à présent à chaque invitation on lockait l'envoi d'invitations pour l'usager en question. On l'avait fait parce qu'il y avait un risque de race condition lors de l'assignation d'un token rdv-solidarités, où on pouvait se retrouver avec des invitations envoyés avec un token invalidé.  Mais depuis #1214 , l'endpoint appelé sur rdv-solidarités est idempotent et n'a plus d'influence sur la validité de l'invitation. J'enlève donc ce lock.

* Celle qui permet de filtrer les usagers par date d'invitations. J'ai eu un timeout en testant en prod. J'ai remarqué qu'il y avait un N+1 qui se déclenchait lors de ces filtres, je l'enlève ici voir si ça résout le problème

J'en profite pour renommer le service `Invitations::AssignAttributes` en `Invitations::AssignLinkAndToken`.