### PR TITLE
fix(app): Use secure_compare for hash verifications

### DIFF
--- a/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
+++ b/app/controllers/concerns/filter_rdv_solidarites_webhooks_concern.rb
@@ -27,7 +27,9 @@ module FilterRdvSolidaritesWebhooksConcern
   end
 
   def webhook_correctly_signed?
-    OpenSSL::HMAC.hexdigest("SHA256", ENV["RDV_SOLIDARITES_SECRET"], request.body.read) ==
+    ActiveSupport::SecurityUtils.secure_compare(
+      OpenSSL::HMAC.hexdigest("SHA256", ENV["RDV_SOLIDARITES_SECRET"], request.body.read),
       request.headers["X-Lapin-Signature"]
+    )
   end
 end

--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -37,7 +37,7 @@ class InclusionConnectController < ApplicationController
   end
 
   def valid_state?
-    params[:state] == session[:ic_state]
+    ActiveSupport::SecurityUtils.secure_compare(params[:state], session[:ic_state])
   end
 
   def set_session_credentials

--- a/app/models/rdv_solidarites_session/with_shared_secret.rb
+++ b/app/models/rdv_solidarites_session/with_shared_secret.rb
@@ -23,7 +23,9 @@ module RdvSolidaritesSession
     end
 
     def signature_valid?
-      Current.agent.signature_auth_with_shared_secret == @x_agent_auth_signature
+      ActiveSupport::SecurityUtils.secure_compare(
+        Current.agent.signature_auth_with_shared_secret, @x_agent_auth_signature
+      )
     end
   end
 end


### PR DESCRIPTION
Il est recommandé d'utiliser `secure_compare` plutôt qu'une simple vérification d'égalité, notamment pour se prémunir des "timing attacks". 
Je l'utilise à chaque fois que l'on fait des vérifications sur des hash cryptographiques.