### PR TITLE
fix(routes): re-enable deleted routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,11 +119,13 @@ Rails.application.routes.draw do
         resources :rdv_contexts, only: [:index]
       end
       resources :invitations, only: [:create]
+      resources :referent_assignations, only: [:create]
       resources :tag_assignations, only: [:index, :create] do
         delete :destroy, on: :collection
       end
     end
     resource :stats, only: [:show]
+    resources :referent_assignations, only: [:create]
   end
   resources :invitation_dates_filterings, :creation_dates_filterings, only: [:new]
 


### PR DESCRIPTION
Ceci est un fix temporaire du bug empêchant l'assignation d'un référent en production. 
Je n'ai pas encore trouvé la source du problème mais j'imagine que la partie React n'a pas encore été adaptée à la structure des routes. 

J'ouvrirai une autre PR pour corriger ça une fois compris le pourquoi du problème

Fix: https://github.com/betagouv/rdv-insertion/issues/1622