### PR TITLE
fix(referents): assignations routing using incorrect param

### DIFF
--- a/app/controllers/referent_assignations_controller.rb
+++ b/app/controllers/referent_assignations_controller.rb
@@ -59,7 +59,7 @@ class ReferentAssignationsController < ApplicationController
   end
 
   def set_department
-    @department = policy_scope(Department).find(current_department_id)
+    @department = policy_scope(Department).find(params[:department_id])
   end
 
   def set_agents

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,11 +119,13 @@ Rails.application.routes.draw do
         resources :rdv_contexts, only: [:index]
       end
       resources :invitations, only: [:create]
+      resources :referent_assignations, only: [:create]
       resources :tag_assignations, only: [:index, :create] do
         delete :destroy, on: :collection
       end
     end
     resource :stats, only: [:show]
+    resources :referent_assignations, only: [:create]
   end
   resources :invitation_dates_filterings, :creation_dates_filterings, only: [:new]
 


### PR DESCRIPTION
After re-enabling the deleted route, requests are now successful locally, but requests that were already failing in production are now failing because the Agent seems to be missing. 
Error went from "The resource could not be found" to "L'agent n'a pas été trouvé"

I suspect that the Current structure is in some cases not properly updated when using session coming from the React App. 
This may be causing the allowed agents not to resolve properly due to trying to find agent on a nil department. 