### PR TITLE
fix(status update): clearer error feedback when participation update call fails

### DIFF
--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -2,13 +2,14 @@ class ParticipationsController < ApplicationController
   before_action :set_participation, only: [:update]
 
   def update
-    @success = Participations::Update.call(
+    participation_update = Participations::Update.call(
       participation: @participation,
       rdv_solidarites_session: rdv_solidarites_session,
       participation_params: participation_params
-    ).success?
+    )
 
-    flash.now[:error] = "Impossible de changer le statut de ce rendez-vous." unless @success
+    @success = participation_update.success?
+    flash.now[:error] = participation_update.errors.join(" ") unless @success
   end
 
   private


### PR DESCRIPTION
Cette PR affiche désormais le message d'erreur complet du service plutôt qu'un message d'erreur générique. 
Cela permettra d'éviter les confusions comme celle-ci https://github.com/betagouv/rdv-insertion/issues/1621 où l'erreur était en fait une erreur pouvant être corrigée par l'agent `Erreur RDV-Solidarités: lieu doit être un lieu ouvert de l’organisation, ou un lieu ponctuel.`

Fix #1621 