### PR TITLE
feat(configurations): add ability to set a custom phone number

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -65,7 +65,7 @@ module Api
       def call_invite_user_service_by(format)
         InviteUser.call(
           user: @user, organisations: [@organisation], motif_category_attributes:, rdv_solidarites_session:,
-          invitation_attributes: invitation_attributes.merge(format:, help_phone_number: @organisation.phone_number)
+          invitation_attributes: invitation_attributes.merge(format:)
         )
       end
 

--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -4,7 +4,7 @@ class ConfigurationsController < ApplicationController
     :invite_to_user_organisations_only, :number_of_days_before_action_required,
     :day_of_the_month_periodic_invites, :number_of_days_between_periodic_invites, :motif_category_id,
     :template_rdv_title_override, :template_rdv_title_by_phone_override, :template_rdv_purpose_override,
-    :template_user_designation_override
+    :template_user_designation_override, :phone_number
   ].freeze
 
   include BackToListConcern

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -30,7 +30,7 @@ class InvitationsController < ApplicationController
 
   def invitation_params
     params.require(:invitation).permit(
-      :format, :help_phone_number, :rdv_solidarites_lieu_id, { motif_category: [:id] }
+      :format, :rdv_solidarites_lieu_id, { motif_category: [:id] }
     ).to_h.deep_symbolize_keys
   end
 

--- a/app/controllers/previews/invitations_controller.rb
+++ b/app/controllers/previews/invitations_controller.rb
@@ -17,7 +17,7 @@ module Previews
         user: @user, organisations: [@organisation],
         rdv_context: RdvContext.new(motif_category: @motif_category),
         valid_until: @configuration.number_of_days_before_action_required.days.from_now,
-        help_phone_number: @organisation.phone_number,
+        help_phone_number: @configuration.phone_number,
         department: @department,
         uuid: SecureRandom.send(:choose, [*"A".."Z", *"0".."9"], 8)
       )

--- a/app/javascript/controllers/invitations_checkbox_form_controller.js
+++ b/app/javascript/controllers/invitations_checkbox_form_controller.js
@@ -40,7 +40,6 @@ export default class extends Controller {
       organisationId,
       isDepartmentLevel,
       body.motif_category_id,
-      body.help_phone_number,
       body.invitation_format
     );
 

--- a/app/javascript/react/actions/inviteUser.js
+++ b/app/javascript/react/actions/inviteUser.js
@@ -6,7 +6,6 @@ const inviteUser = async (
   organisationId,
   isDepartmentLevel,
   invitationFormat,
-  helpPhoneNumber,
   motifCategoryId,
   types = "application/json"
 ) => {
@@ -22,7 +21,6 @@ const inviteUser = async (
     {
       invitation: {
         format: invitationFormat,
-        help_phone_number: helpPhoneNumber,
         motif_category: { id: motifCategoryId },
       },
     },

--- a/app/javascript/react/components/InvitationBlock.jsx
+++ b/app/javascript/react/components/InvitationBlock.jsx
@@ -62,7 +62,6 @@ export default function InvitationBlock({
       organisation.id,
       isDepartmentLevel,
       motifCategory.id,
-      organisation.phone_number,
     ];
     let newInvitationDate;
 

--- a/app/javascript/react/lib/createInvitationLetter.js
+++ b/app/javascript/react/lib/createInvitationLetter.js
@@ -6,8 +6,7 @@ const createInvitationLetter = async (
   departmentId,
   organisationId,
   isDepartmentLevel,
-  motifCategoryId,
-  helpPhoneNumber
+  motifCategoryId
 ) => {
   const response = await inviteUser(
     userId,
@@ -15,7 +14,6 @@ const createInvitationLetter = async (
     organisationId,
     isDepartmentLevel,
     "postal",
-    helpPhoneNumber,
     motifCategoryId,
     "application/pdf"
   );

--- a/app/javascript/react/lib/handleUserInvitation.js
+++ b/app/javascript/react/lib/handleUserInvitation.js
@@ -8,7 +8,6 @@ const handleUserInvitation = async (
   organisationId,
   isDepartmentLevel,
   motifCategoryId,
-  helpPhoneNumber,
   invitationFormat,
   options = { raiseError: true }
 ) => {
@@ -18,8 +17,7 @@ const handleUserInvitation = async (
       departmentId,
       organisationId,
       isDepartmentLevel,
-      motifCategoryId,
-      helpPhoneNumber
+      motifCategoryId
     );
   }
   const result = await inviteUser(
@@ -28,7 +26,6 @@ const handleUserInvitation = async (
     organisationId,
     isDepartmentLevel,
     invitationFormat,
-    helpPhoneNumber,
     motifCategoryId
   );
   if (!result.success && options.raiseError) {

--- a/app/javascript/react/models/User.js
+++ b/app/javascript/react/models/User.js
@@ -159,7 +159,6 @@ export default class User {
       this.currentOrganisation.id,
       this.list.isDepartmentLevel,
       this.currentConfiguration.motif_category_id,
-      this.currentOrganisation.phone_number,
     ];
     const result = await handleUserInvitation(...invitationParams, format, {
       raiseError: options.raiseError,

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -48,10 +48,7 @@ class CreateAndInviteUserJob < ApplicationJob
     InviteUserJob.perform_async(
       @user.id,
       @organisation.id,
-      @invitation_attributes.merge(
-        format: invitation_format,
-        help_phone_number: @organisation.phone_number
-      ),
+      @invitation_attributes.merge(format: invitation_format),
       @motif_category_attributes,
       @rdv_solidarites_session_credentials
     )

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,4 +1,6 @@
 class Configuration < ApplicationRecord
+  include PhoneNumberValidation
+
   belongs_to :motif_category
   belongs_to :file_configuration
   belongs_to :organisation
@@ -22,6 +24,10 @@ class Configuration < ApplicationRecord
 
   def periodic_invites_activated?
     day_of_the_month_periodic_invites.present? || number_of_days_between_periodic_invites.present?
+  end
+
+  def phone_number
+    attributes["phone_number"].presence || organisation.phone_number
   end
 
   private

--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -35,6 +35,7 @@ class InviteUser < BaseService
       # the validity of an invitation is equal to the number of days before an action is required,
       # then the organisation usually convene the user
       valid_until: @current_configuration.number_of_days_before_action_required.days.from_now,
+      help_phone_number: @current_configuration.phone_number,
       rdv_with_referents: @current_configuration.rdv_with_referents,
       **@invitation_attributes
     )

--- a/app/views/configurations/_configuration_form.html.erb
+++ b/app/views/configurations/_configuration_form.html.erb
@@ -33,6 +33,7 @@
       <%= render "common/attribute_input", f:f, attribute: :number_of_days_before_action_required, mandatory: true %>
       <%= render "common/attribute_input", f:f, attribute: :rdv_with_referents, as: :boolean, mandatory: true %>
       <%= render "common/attribute_input", f:f, attribute: :invite_to_user_organisations_only, as: :boolean, mandatory: true %>
+      <%= render "common/attribute_input", f:f, attribute: :phone_number, mandatory: false %>
     </div>
 
     <div class="row my-4">

--- a/app/views/configurations/show.html.erb
+++ b/app/views/configurations/show.html.erb
@@ -23,6 +23,7 @@
     <%= render "common/attribute_display", record: @configuration, attribute: :rdv_with_referents %>
     <%= render "common/attribute_display", record: @configuration.motif_category, attribute: :participation_optional %>
     <%= render "common/attribute_display", record: @configuration, attribute: :invite_to_user_organisations_only %>
+    <%= render "common/attribute_display", record: @configuration, attribute: :phone_number %>
   </div>
 
   <h3>Invitations périodiques</h3>

--- a/app/views/invitations/_checkbox_form.html.erb
+++ b/app/views/invitations/_checkbox_form.html.erb
@@ -2,7 +2,6 @@
   <%= form_with(url: structure_user_invitations_path(user.id), html: { method: :post }, data: { controller: "invitations-checkbox-form", action: "turbo:submit-start->invitations-checkbox-form#submitStart", user_id: user.id, department_id: @department.id, organisation_id: @organisation&.id, invitation_format: invitation_format, rdv_context_id: rdv_context.id }) do |f| %>
     <div class="form-group">
       <%= f.hidden_field :motif_category_id, value: motif_category.id %>
-      <%= f.hidden_field :help_phone_number, value: department_level? ? user.organisations.first.phone_number : @organisation.phone_number %>
       <%= f.hidden_field :invitation_format, value: invitation_format %>
       <div>
         <%= f.check_box "#{invitation_format}_invite", { checked: checked, disabled: disabled, data: { controller: "invitations-checkbox-form", action: "change->invitations-checkbox-form#submit" } }, checked %>

--- a/config/locales/models/configuration.fr.yml
+++ b/config/locales/models/configuration.fr.yml
@@ -10,6 +10,7 @@ fr:
         day_of_the_month_periodic_invites: Jour du mois auquel envoyer les invitations récurrentes
         invite_to_user_organisations_only: Invitation limitée aux organisations du bénéficiaire
         rdv_with_referents: RDV avec référent
+        phone_number: Numéro de téléphone (si différent de celui de l'organisation)
         invitation_formats: Formats d'invitations
         motif_category: Catégorie de motifs
         file_configuration: Fichier d'import

--- a/db/migrate/20240104105413_add_phone_number_to_configuration.rb
+++ b/db/migrate/20240104105413_add_phone_number_to_configuration.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToConfiguration < ActiveRecord::Migration[7.0]
+  def change
+    add_column :configurations, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_12_173606) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_04_105413) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_173606) do
     t.integer "day_of_the_month_periodic_invites"
     t.integer "position", default: 0
     t.integer "department_position", default: 0
+    t.string "phone_number"
     t.index ["file_configuration_id"], name: "index_configurations_on_file_configuration_id"
     t.index ["motif_category_id"], name: "index_configurations_on_motif_category_id"
     t.index ["organisation_id"], name: "index_configurations_on_organisation_id"

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -2,7 +2,6 @@ describe InvitationsController do
   describe "#create" do
     let!(:user_id) { "24" }
     let!(:organisation_id) { "22" }
-    let!(:help_phone_number) { "0101010101" }
     let!(:department) { create(:department) }
     let!(:organisation) { create(:organisation, id: organisation_id, department: department) }
     let!(:other_org) { create(:organisation, department: department) }
@@ -24,7 +23,6 @@ describe InvitationsController do
         user_id: user_id,
         invitation: {
           format: "sms",
-          help_phone_number: help_phone_number,
           motif_category: motif_category_attributes
         },
         format: "json"
@@ -32,7 +30,7 @@ describe InvitationsController do
     end
 
     let!(:invitation_attributes) do
-      { help_phone_number: help_phone_number, format: "sms" }
+      { format: "sms" }
     end
 
     let!(:motif_category_attributes) { { id: motif_category.id.to_s } }
@@ -62,7 +60,6 @@ describe InvitationsController do
           user_id: user_id,
           invitation: {
             format: "email",
-            help_phone_number: help_phone_number,
             motif_category: motif_category_attributes,
             rdv_solidarites_lieu_id: "3929"
           },
@@ -70,7 +67,7 @@ describe InvitationsController do
         }
       end
       let!(:invitation_attributes) do
-        { help_phone_number: help_phone_number, format: "email", rdv_solidarites_lieu_id: "3929" }
+        { format: "email", rdv_solidarites_lieu_id: "3929" }
       end
 
       it "calls the service" do
@@ -102,7 +99,6 @@ describe InvitationsController do
             user_id: user_id,
             invitation: {
               format: "postal",
-              help_phone_number: help_phone_number,
               motif_category: motif_category_attributes
             },
             format: "pdf"
@@ -110,7 +106,7 @@ describe InvitationsController do
         end
 
         let!(:invitation_attributes) do
-          { help_phone_number: help_phone_number, format: "postal" }
+          { format: "postal" }
         end
 
         before do

--- a/spec/factories/configuration.rb
+++ b/spec/factories/configuration.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     association :motif_category
     association :file_configuration
     invitation_formats { %w[sms email postal] }
+    phone_number { "0101010101" }
   end
 end

--- a/spec/jobs/create_and_invite_user_job_spec.rb
+++ b/spec/jobs/create_and_invite_user_job_spec.rb
@@ -21,8 +21,8 @@ describe CreateAndInviteUserJob do
   end
   let!(:invitation_attributes) { { rdv_solidarites_lieu_id: 888 } }
   let!(:motif_category_attributes) { { short_name: "rsa_orientation" } }
-  let!(:email_invitation_attributes) { invitation_attributes.merge(format: "email", help_phone_number: "0146292929") }
-  let!(:sms_invitation_attributes) { invitation_attributes.merge(format: "sms", help_phone_number: "0146292929") }
+  let!(:email_invitation_attributes) { invitation_attributes.merge(format: "email") }
+  let!(:sms_invitation_attributes) { invitation_attributes.merge(format: "sms") }
 
   let!(:agent) { create(:agent, email: "janedoe@gouv.fr") }
   let!(:rdv_solidarites_session_credentials) do

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -199,12 +199,11 @@ describe "Users API", swagger_doc: "v1/api.json" do
           nir: generate_random_nir
         }
       end
-      let!(:help_phone_number) { "0134499424" }
       let!(:email_attributes) do
-        { help_phone_number:, format: "email" }
+        { format: "email" }
       end
       let!(:sms_attributes) do
-        { help_phone_number:, format: "sms" }
+        { format: "sms" }
       end
 
       let!(:motif_category_attributes) { { name: "RSA orientation" } }

--- a/spec/services/invite_user_spec.rb
+++ b/spec/services/invite_user_spec.rb
@@ -128,6 +128,22 @@ describe InviteUser, type: :service do
           end
         end
 
+        context "when the configuration has a custom phone number" do
+          let(:phone_number) { "0102030405" }
+
+          before { configuration.update!(phone_number:) }
+
+          it "invites with the proper phone number" do
+            expect(Invitation).to receive(:new)
+              .with(
+                organisations: [organisation], user:, department:, rdv_context:, valid_until: 5.days.from_now,
+                rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2,
+                help_phone_number: phone_number
+              )
+            subject
+          end
+        end
+
         context "when the invitation is not restricted to the user organisations" do
           before { configuration.update! invite_to_user_organisations_only: false }
 

--- a/spec/services/invite_user_spec.rb
+++ b/spec/services/invite_user_spec.rb
@@ -44,7 +44,8 @@ describe InviteUser, type: :service do
       expect(Invitation).to receive(:new)
         .with(
           organisations: [organisation], user:, department:, rdv_context:, valid_until: 5.days.from_now,
-          rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2
+          rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2,
+          help_phone_number: organisation.phone_number
         )
       subject
     end
@@ -67,7 +68,8 @@ describe InviteUser, type: :service do
           expect(Invitation).to receive(:new)
             .with(
               organisations: [organisation], user:, department:, rdv_context:, valid_until: 5.days.from_now,
-              rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2
+              rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2,
+              help_phone_number: organisation.phone_number
             )
           subject
         end
@@ -114,7 +116,8 @@ describe InviteUser, type: :service do
             expect(Invitation).to receive(:new)
               .with(
                 organisations: [organisation], user:, department:, rdv_context:, valid_until: 5.days.from_now,
-                rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2
+                rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2,
+                help_phone_number: organisation.phone_number
               )
             subject
           end
@@ -136,7 +139,8 @@ describe InviteUser, type: :service do
             expect(Invitation).to receive(:new)
               .with(
                 organisations:, user:, department:, rdv_context:, valid_until: 5.days.from_now,
-                rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2
+                rdv_with_referents: true, format: "sms", rdv_solidarites_lieu_id: 2,
+                help_phone_number: organisation.phone_number
               )
             subject
           end


### PR DESCRIPTION
Cette PR permet d'ajouter un numéro de téléphone par configuration. 
Une fois ajoutée, celle-ci est automatiquement envoyée comme le help_phone_number des invitations. 

Si ce nouveau champ n'est pas rempli, un fallback est automatiquement fait vers le numéro de téléphone de l'organisation.

<img width="1543" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/c094dd46-aeae-4a0b-8c1b-b732d83e6a7d">


Fix https://github.com/betagouv/rdv-insertion/issues/1585