### PR TITLE
fix(flaky): participation status update

### DIFF
--- a/spec/features/agent_can_update_a_participation_status_spec.rb
+++ b/spec/features/agent_can_update_a_participation_status_spec.rb
@@ -40,7 +40,7 @@ describe "Agents can update a participation status", js: true do
         find("a[data-value=revoked]").click
 
         expect(page).to have_content("Annulé (par le service)")
-        expect(user.rdv_contexts.pluck(:status)).to include("rdv_revoked")
+        Timeout.timeout(2) { loop until user.rdv_contexts.where(status: :rdv_revoked).any? }
       end
     end
 

--- a/spec/features/agent_can_update_a_participation_status_spec.rb
+++ b/spec/features/agent_can_update_a_participation_status_spec.rb
@@ -18,7 +18,7 @@ describe "Agents can update a participation status", js: true do
   end
 
   let(:participation) do
-    create(:participation, rdv_context: rdv_context, user: user, rdv: rdv)
+    create(:participation, rdv_context: rdv_context, user: user, rdv: rdv, status: "seen")
   end
 
   let(:rdvs_participation_id) { participation.rdv_solidarites_participation_id }
@@ -40,7 +40,7 @@ describe "Agents can update a participation status", js: true do
         find("a[data-value=revoked]").click
 
         expect(page).to have_content("Annulé (par le service)")
-        Timeout.timeout(2) { loop until user.rdv_contexts.where(status: :rdv_revoked).any? }
+        expect(participation.reload.status).to eq("revoked")
       end
     end
 


### PR DESCRIPTION
Cette PR vérifie le status de la participation plutôt que du rdv_contexte