### PR TITLE
fix(stats): set a similar timeout between all stats jobs

### DIFF
--- a/app/jobs/stats/monthly_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stat_job.rb
@@ -7,7 +7,7 @@ module Stats
 
       def perform(structure_type, structure_id, until_date_string)
         # to do : add timeout as a global concern for all jobs and remove it here
-        Timeout.timeout(10.minutes) do
+        Timeout.timeout(30.minutes) do
           upsert_stat_record_for_monthly_stats =
             Stats::MonthlyStats::UpsertStat.call(
               structure_type: structure_type, structure_id: structure_id, until_date_string: until_date_string


### PR DESCRIPTION
C'est moche mais en l'état j'applique désormais juste le même timeout pour les jobs monthly que pour les jobs globaux. 
Cela fixera temporairement le job de stats