### PR TITLE
fix(archive): Use correct CTA when user archived

### DIFF
--- a/app/views/users/_archiving_button.html.erb
+++ b/app/views/users/_archiving_button.html.erb
@@ -1,16 +1,16 @@
-<% if @archive.blank? %>
+<% if archive.blank? %>
   <!-- We must set a wrapper to trigger a tooltip on a disabled element -->
   <span class="tooltip-wrapper" data-controller="tooltip" data-action="mouseover->tooltip#archivingDisabled">
     <%=
       button_tag(
         "Archiver le dossier",
         class: "btn btn-blue", id: "archive-button",
-        disabled: !policy(Archive.new(department: @department, user: @user)).create?,
+        disabled: !policy(Archive.new(department: department, user: user)).create?,
         data: {
           controller: "archives",
           action: "click->archives#create",
-          user_id: @user.id,
-          department_id: @department.id,
+          user_id: user.id,
+          department_id: department.id,
         }
       )
     %>
@@ -20,13 +20,13 @@
     button_tag(
       "Rouvrir le dossier",
       class: "btn btn-blue", id: "unarchive-button",
-      disabled: !policy(@archive).destroy?,
+      disabled: !policy(archive).destroy?,
       data: {
         controller: "archives",
         action: "click->archives#destroy",
-        archive_id: @archive.id,
-        user_id: @user.id,
-        department_id: @department.id,
+        archive_id: archive.id,
+        user_id: user.id,
+        department_id: department.id,
       }
     )
   %>

--- a/app/views/users/_user_page_header.html.erb
+++ b/app/views/users/_user_page_header.html.erb
@@ -18,7 +18,7 @@
     <%= render "users/user_icon", user: @user %> <%= @user.to_s %>
   </h4>
   <div class="col-sm-4 text-end">
-    <%= render "users/archiving_button" %>
+    <%= render "users/archiving_button", user: @user, department: @department, archive: @user.archive_for(@department.id) %>
   </div>
 </div>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,4 @@
-<%= render 'archive_banner' if @archive.present? %>
-
 <div class="container text-dark-blue h4-as-labels mt-4">
-  <%= render "user_page_header" %>
   <%= turbo_frame_tag "user_page_body" do %>
     <%= simple_form_for(@user, url: structure_user_path(@user.id), html: { method: :patch }) do |f| %>
       <%= render 'user_form', f: f, title: "Modifier usager", return_path: structure_user_path(@user.id) %>


### PR DESCRIPTION
Lié à #1631
On avait un problème sur les actions `rdv_contexts#index` et `parcours#show`, vu qu'on n'instanciait pas de variable `@archive` dans ces controllers.
Plutôt que de l'instancier dans ces controllers (où l'archive ne sert qu'à changer les CTA dans la vue) j'utilise plutôt la méthode `@user.archive_for(@department.id)` pour assigner la locale envoyée dans la partial `archiving_button`.
