### PR TITLE
feat(parcours): Change new parcours wording

### DIFF
--- a/app/views/orientations/_orientation.html.erb
+++ b/app/views/orientations/_orientation.html.erb
@@ -10,7 +10,7 @@
     Orientation <strong><%= I18n.t("activerecord.attributes.orientation.orientation_types.#{orientation.orientation_type}") %></strong>
   </div>
   <div class="w-100">Structure <strong><%= orientation.organisation.name %></strong></div>
-  <div class="w-100">Référent <strong><%= orientation.agent.to_s %></strong></div>
+  <div class="w-100">Référent unique <strong><%= orientation.agent.to_s %></strong></div>
   <div class="w-100 text-end">
     <%= link_to edit_user_orientation_path(id: orientation.id, user_id: orientation.user_id), data: { turbo_frame: 'remote_modal' } do %>
       <i class="fas fa-pencil-alt text-dark-blue"></i>

--- a/app/views/orientations/_orientation_form.html.erb
+++ b/app/views/orientations/_orientation_form.html.erb
@@ -24,8 +24,7 @@
         placeholder: "au",
         data: {
           controller: "flatpickr",
-          flatpickr_min_date: "2012/04/01",
-          flatpickr_max_date: Date.today
+          flatpickr_min_date: "2012/04/01"
         }
       )
     %>

--- a/app/views/users/_user_tabs.html.erb
+++ b/app/views/users/_user_tabs.html.erb
@@ -6,7 +6,7 @@
   </li>
   <li class="nav-item">
     <%= link_to structure_user_rdv_contexts_path(user.id), class: "nav-link d-flex align-items-center #{tab == "rdvs" ? 'active' : ''}" do %>
-      Suivi
+      Rendez-vous
     <% end %>
   </li>
   <% if show_parcours?(@department) %>

--- a/config/locales/models/orientation.fr.yml
+++ b/config/locales/models/orientation.fr.yml
@@ -7,7 +7,7 @@ fr:
         starts_at: Date de début
         ends_at: Date de fin
         organisation: Structure référente
-        agent: Agent réferent
+        agent: Réferent unique
         orientation_type: Type d'orientation
         orientation_types:
           social: Sociale

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -51,7 +51,7 @@ describe "Agents can add user orientation", js: true do
       expect(page).to have_selector("select#orientation_agent_id[disabled]")
 
       page.select "CD 26", from: "orientation_organisation_id"
-      expect(page).to have_select("orientation_agent_id", with_options: organisation_agents)
+      expect(page).to have_select("orientation_agent_id", with_options: organisation_agents.map(&:to_s))
 
       page.select "Kad Merad", from: "orientation_agent_id"
 
@@ -61,7 +61,7 @@ describe "Agents can add user orientation", js: true do
       expect(page).to have_content("Du 03/07/2023 à aujourd'hui")
       expect(page).to have_content("Orientation Sociale")
       expect(page).to have_content("Structure CD 26")
-      expect(page).to have_content("Référent Kad Merad")
+      expect(page).to have_content("Référent unique Kad Merad")
 
       click_button("Ajouter une orientation")
 
@@ -72,7 +72,7 @@ describe "Agents can add user orientation", js: true do
       expect(page).to have_selector("select#orientation_agent_id[disabled]")
 
       page.select "Asso 26", from: "orientation_organisation_id"
-      expect(page).to have_select("orientation_agent_id", with_options: other_organisation_agents)
+      expect(page).to have_select("orientation_agent_id", with_options: other_organisation_agents.map(&:to_s))
 
       page.select "Jean-Paul Rouve", from: "orientation_agent_id"
 
@@ -81,12 +81,12 @@ describe "Agents can add user orientation", js: true do
       expect(page).to have_content("Du 03/07/2023 au 03/10/2023")
       expect(page).to have_content("Orientation Sociale")
       expect(page).to have_content("Structure CD 26")
-      expect(page).to have_content("Référent Kad Merad")
+      expect(page).to have_content("Référent unique Kad Merad")
 
       expect(page).to have_content("Du 03/10/2023 à aujourd'hui")
       expect(page).to have_content("Orientation Professionnelle")
       expect(page).to have_content("Structure Asso 26")
-      expect(page).to have_content("Référent Jean-Paul Rouve")
+      expect(page).to have_content("Référent unique Jean-Paul Rouve")
     end
   end
 end


### PR DESCRIPTION
Je fais quelques changements ici suite à #1607 :  

* Je renomme l'onglet "Suivi" en "Rendez-vous"
* Je parle de "Référent unique" et non plus d'"Agent référent"
* Je laisse la possibilité de renseigner une date de fin postérieure à la date du jour