### PR TITLE
feat(config): Add vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@
 yarn-debug.log*
 .yarn-integrity
 dump.rdb
+
+.vscode/


### PR DESCRIPTION
Depuis que je suis passé sur vscode, j'ai une configuration spécifique qui se trouve dans le dossier `.vscode/`.
J'ajoute ce dossier dans le gitignore pour éviter d'avoir à le supprimer à chaque fois que je veux que la branche soit clean pour déployer