### PR TITLE
fix(flaky): participation update status

### DIFF
--- a/spec/features/agent_can_update_a_participation_status_spec.rb
+++ b/spec/features/agent_can_update_a_participation_status_spec.rb
@@ -34,8 +34,8 @@ describe "Agents can update a participation status", js: true do
       it "can edit a participation status" do
         visit organisation_user_rdv_contexts_path(organisation_id: organisation.id, user_id: user.id)
         page.execute_script("window.scrollBy(0, 500)")
-        expect(page).to have_content("RDV honoré")
         status_update_button = find_by_id("toggle-rdv-status")
+        expect(status_update_button).to have_content("RDV honoré")
 
         status_update_button.click
         find("a[data-value=revoked]").click

--- a/spec/features/agent_can_update_a_participation_status_spec.rb
+++ b/spec/features/agent_can_update_a_participation_status_spec.rb
@@ -35,11 +35,12 @@ describe "Agents can update a participation status", js: true do
         visit organisation_user_rdv_contexts_path(organisation_id: organisation.id, user_id: user.id)
         page.execute_script("window.scrollBy(0, 500)")
         expect(page).to have_content("RDV honoré")
+        status_update_button = find_by_id("toggle-rdv-status")
 
-        find_by_id("toggle-rdv-status").click
+        status_update_button.click
         find("a[data-value=revoked]").click
 
-        expect(page).to have_content("Annulé (par le service)")
+        expect(status_update_button).to have_content("Annulé (par le service)")
         expect(participation.reload.status).to eq("revoked")
       end
     end

--- a/spec/features/agent_can_update_a_participation_status_spec.rb
+++ b/spec/features/agent_can_update_a_participation_status_spec.rb
@@ -35,7 +35,7 @@ describe "Agents can update a participation status", js: true do
         visit organisation_user_rdv_contexts_path(organisation_id: organisation.id, user_id: user.id)
         page.execute_script("window.scrollBy(0, 500)")
         status_update_button = find_by_id("toggle-rdv-status")
-        expect(status_update_button).to have_content("RDV honoré")
+        expect(status_update_button).to have_content("Rendez-vous honoré")
 
         status_update_button.click
         find("a[data-value=revoked]").click


### PR DESCRIPTION
Afin d'éviter de checker la page entière qui contenait la string attendue de toute façon, je check désormais le contenu du bouton d'update qui lui se doit de contenir réellement la string associé au statut mis à jour.