### PR TITLE
fix(jobs): Assign rdv_solidarites_agent_role_id for agent roles

### DIFF
--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
@@ -55,7 +55,7 @@ module InboundWebhooks
       end
 
       def assign_rdv_solidarites_agent_role_id
-        agent_role.update!(rdv_solidarites_agent_role_id: @data[:id])
+        agent_role.update!(rdv_solidarites_agent_role_id: @data[:id]) if agent_role.rdv_solidarites_agent_role_id.nil?
       end
 
       def event

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job.rb
@@ -6,6 +6,9 @@ module InboundWebhooks
         @meta = meta.deep_symbolize_keys
         return if organisation.blank? || @data[:access_level] == "intervenant"
 
+        # This is necessary when the agent role has been created through rdv-i without the rdv-s record
+        # when importing an organisation
+        assign_rdv_solidarites_agent_role_id if agent_role
         event == "destroyed" ? remove_agent_from_org : upsert_agent_role
       end
 
@@ -49,6 +52,10 @@ module InboundWebhooks
           rdv_solidarites_attributes: @data[:agent],
           additional_attributes: { last_webhook_update_received_at: @meta[:timestamp] }
         )
+      end
+
+      def assign_rdv_solidarites_agent_role_id
+        agent_role.update!(rdv_solidarites_agent_role_id: @data[:id])
       end
 
       def event

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
@@ -23,7 +23,9 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
     create(:organisation, rdv_solidarites_organisation_id:, id: 923, name: "Pôle Parcours")
   end
   let!(:agent) { create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id) }
-  let!(:agent_role) { create(:agent_role, organisation: organisation, agent: agent) }
+  let!(:agent_role) do
+    create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
+  end
   let!(:meta) do
     {
       "model" => "AgentRole",
@@ -41,6 +43,11 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
             last_webhook_update_received_at: "2023-02-09 11:17:22 +0200" }
         )
       subject
+    end
+
+    it "assigns the rdv solidarites agent role id" do
+      subject
+      expect(agent_role.reload.rdv_solidarites_agent_role_id).to eq(rdv_solidarites_agent_role_id)
     end
 
     context "for destroyed event" do
@@ -105,11 +112,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
         expect(UpsertRecordJob).not_to receive(:perform_async)
         subject
       end
-    end
-
-    it "assigns the rdv solidarites agent role id" do
-      subject
-      expect(agent_role.reload.rdv_solidarites_agent_role_id).to eq(rdv_solidarites_agent_role_id)
     end
 
     context "when the agent cannot be found" do

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
@@ -33,10 +33,6 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
   end
 
   describe "#perform" do
-    before do
-      allow_any_instance_of(described_class).to receive(:sleep)
-    end
-
     it "upserts an agent_role record" do
       expect(UpsertRecordJob).to receive(:perform_async)
         .with(
@@ -111,6 +107,11 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
       end
     end
 
+    it "assigns the rdv solidarites agent role id" do
+      subject
+      expect(agent_role.reload.rdv_solidarites_agent_role_id).to eq(rdv_solidarites_agent_role_id)
+    end
+
     context "when the agent cannot be found" do
       let!(:meta) do
         {
@@ -121,7 +122,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
       end
 
       before do
-        allow(Agent).to receive(:find_by).and_return(nil, agent)
+        allow(Agent).to receive(:find_by).and_return(nil, nil, agent)
         allow(UpsertRecord).to receive(:call).and_return(OpenStruct.new(success?: true))
       end
 


### PR DESCRIPTION
Dans #1618 j'ai enlevé l'assignation du `rdv_solidarites_agent_role_id` pensant qu'elle n'était plus utilisée.
Or elle est toujours utilisée pour assigner l'id RDVS lorsqu'on crée le record d'`AgentRole` depuis rdv-i [ici](https://github.com/betagouv/rdv-insertion/blob/321fa75f9c5373669e5e55d3e574689c29983661/app/services/organisations/create.rb#L39) lorsqu'on rappatrie une orga rdv-s.
Si on ne le met pas on se retrouve avec ces erreurs: https://sentry.incubateur.net/organizations/betagouv/issues/80310/?project=16&query=is%3Aunresolved&referrer=issue-stream

