### PR TITLE
fix(ic): Handle invalid state correctly

### DIFF
--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -37,7 +37,8 @@ class InclusionConnectController < ApplicationController
   end
 
   def valid_state?
-    ActiveSupport::SecurityUtils.secure_compare(params[:state], session[:ic_state])
+    params[:state].present? && session[:ic_state].present? &&
+      ActiveSupport::SecurityUtils.secure_compare(params[:state], session[:ic_state])
   end
 
   def set_session_credentials


### PR DESCRIPTION
Depuis #1617 on a cette erreur sur sentry qui est présente quand le `state` n'est pas présent lors de l'authentification via inclusion connect: https://sentry.incubateur.net/organizations/betagouv/issues/80107/?project=16&query=&referrer=issue-stream&statsPeriod=14d.
@Holist je fais un petit fix ici pour ne plus avoir cette erreur (et que le message affiché à l'usager soit compréhensible), tu me diras si c'est bon.