### PR TITLE
fix(stats): minor issues

### DIFF
--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -11,4 +11,8 @@ module StatsHelper
               .map { |o| [o.name.to_s, o.id] }
               .unshift(["Toutes les organisations", "0"])
   end
+
+  def exclude_current_month(stat)
+    stat.delete_if { |key, _value| key == Time.zone.now.strftime("%m/%Y") }
+  end
 end

--- a/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
+++ b/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
@@ -15,6 +15,9 @@ module Stats
       invitation_delays = []
 
       @rdv_contexts.find_each do |rdv_context|
+        # Some rdv_contexts might have negative values when users have had
+        # rdvs on Rdv-Solidarités prior to being imported in the app.
+        # We don't want to take those values into account.
         next if rdv_context.time_between_invitation_and_rdv_in_days.negative?
 
         invitation_delays << rdv_context.time_between_invitation_and_rdv_in_days

--- a/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
+++ b/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
@@ -12,11 +12,14 @@ module Stats
 
     # Delays between the first invitation and the first rdv
     def compute_average_time_between_invitation_and_rdv_in_days
-      cumulated_invitation_delays = 0
+      invitation_delays = []
+
       @rdv_contexts.find_each do |rdv_context|
-        cumulated_invitation_delays += rdv_context.time_between_invitation_and_rdv_in_days
+        next if rdv_context.time_between_invitation_and_rdv_in_days.negative?
+
+        invitation_delays << rdv_context.time_between_invitation_and_rdv_in_days
       end
-      cumulated_invitation_delays / (@rdv_contexts.count.nonzero? || 1).to_f
+      invitation_delays.sum / invitation_delays.size.to_f
     end
   end
 end

--- a/app/services/stats/monthly_stats/upsert_stat.rb
+++ b/app/services/stats/monthly_stats/upsert_stat.rb
@@ -39,12 +39,7 @@ module Stats
           # We don't want to start the hash until we have a value
           next if stat_attribute == {} && stat_value.zero?
 
-          if stat_name == :rate_of_users_oriented_in_less_than_30_days_by_month
-            # this stat is computed with 1 month lag
-            stat_attribute.merge!({ (@date - 1.month).strftime("%m/%Y") => stat_value })
-          else
-            stat_attribute.merge!({ @date.strftime("%m/%Y") => stat_value })
-          end
+          stat_attribute.merge!({ (@date - 1.month).strftime("%m/%Y") => stat_value })
           stat[stat_name] = stat_attribute
         end
       end

--- a/app/services/stats/monthly_stats/upsert_stat.rb
+++ b/app/services/stats/monthly_stats/upsert_stat.rb
@@ -39,8 +39,12 @@ module Stats
           # We don't want to start the hash until we have a value
           next if stat_attribute == {} && stat_value.zero?
 
-          stat_attribute.merge!({ (@date - 1.month).strftime("%m/%Y") => stat_value })
-          stat[stat_name] = stat_attribute
+          if stat_name == :rate_of_users_oriented_in_less_than_30_days_by_month
+            # this stat is computed with 1 month lag
+            stat_attribute.merge!({ (@date - 1.month).strftime("%m/%Y") => stat_value })
+          else
+            stat_attribute.merge!({ @date.strftime("%m/%Y") => stat_value })
+          end
         end
       end
 

--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -4,12 +4,12 @@
     <div class="col-12 col-md-6 px-5 pb-5">
       <p class="highlight-stat big margin-left"><%= @stat.users_count %></p>
       <p class="highlight-stat margin-left">usagers gérés dans rdv-insertion</p>
-      <%= line_chart @stat.users_count_grouped_by_month, title: "Nouveaux usagers par mois", colors: ["#083b66"] %>
+      <%= line_chart exclude_current_month(@stat.users_count_grouped_by_month), title: "Nouveaux usagers par mois", colors: ["#083b66"] %>
     </div>
     <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
       <p class="highlight-stat big margin-left"><%= @stat.rdvs_count %></p>
       <p class="highlight-stat margin-left">rendez-vous pris</p>
-      <%= line_chart @stat.rdvs_count_grouped_by_month, title: "Nouveaux rdvs par mois", colors: ["#083b66"] %>
+      <%= line_chart exclude_current_month(@stat.rdvs_count_grouped_by_month), title: "Nouveaux rdvs par mois", colors: ["#083b66"] %>
     </div>
   </div>
   <% if current_page?(action: 'index') || @display_all_stats %>
@@ -17,7 +17,7 @@
       <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
         <p class="highlight-stat big margin-left"><%= @stat.sent_invitations_count %></p>
         <p class="highlight-stat margin-left">invitations envoyées par mail, SMS, et courrier</p>
-        <%= line_chart @stat.sent_invitations_count_grouped_by_month, title: "Invitations envoyées par mois", colors: ["#083b66"] %>
+        <%= line_chart exclude_current_month(@stat.sent_invitations_count_grouped_by_month), title: "Invitations envoyées par mois", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5">
         <p class="highlight-stat big margin-left"><%= @stat.average_time_between_invitation_and_rdv_in_days&.round %> jours</p>
@@ -29,19 +29,19 @@
       <div class="col-12 col-md-6 px-5 pb-5">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_no_show_for_invitations&.round %> %</p>
         <p class="highlight-stat margin-left">de rendez-vous non honorés avec rdv-insertion <strong>après invitation</strong></p>
-        <%= line_chart @stat.rate_of_no_show_for_invitations_grouped_by_month, title: "Taux de rdvs non honorés après invitation par mois", suffix: "%", colors: ["#083b66"] %>
+        <%= line_chart exclude_current_month(@stat.rate_of_no_show_for_invitations_grouped_by_month), title: "Taux de rdvs non honorés après invitation par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_no_show_for_convocations&.round %> %</p>
         <p class="highlight-stat margin-left">de rendez-vous non honorés avec rdv-insertion <strong>après convocation</strong></p>
-        <%= line_chart @stat.rate_of_no_show_for_convocations_grouped_by_month, title: "Taux de rdvs non honorés après convocation par mois", suffix: "%", colors: ["#083b66"] %>
+        <%= line_chart exclude_current_month(@stat.rate_of_no_show_for_convocations_grouped_by_month), title: "Taux de rdvs non honorés après convocation par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap-reverse">
       <div class="col-12 col-md-6 px-5 pb-5 background-blue-light">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_autonomous_users&.round %> %</p>
         <p class="highlight-stat margin-left">d'usagers invités ayant pris au moins <strong>un rendez-vous en autonomie</strong></p>
-        <%= line_chart @stat.rate_of_autonomous_users_grouped_by_month, title: "Taux d'usagers autonomes par mois", suffix: "%", colors: ["#083b66"] %>
+        <%= line_chart exclude_current_month(@stat.rate_of_autonomous_users_grouped_by_month), title: "Taux d'usagers autonomes par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
       <div class="col-12 col-md-6 px-5 pb-5">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented_in_less_than_30_days&.round %> %</p>
@@ -53,7 +53,7 @@
       <div class="col-12 col-md-6 px-5 pb-5">
         <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented&.round %> %</p>
         <p class="highlight-stat margin-left">d'usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
-        <%= line_chart @stat.rate_of_users_oriented_grouped_by_month, title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
+        <%= line_chart exclude_current_month(@stat.rate_of_users_oriented_grouped_by_month), title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap">

--- a/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
+++ b/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
@@ -35,5 +35,21 @@ describe Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays, type: :service 
     it "computes the average time between first invitation and first rdv in days" do
       expect(result.value).to eq(3)
     end
+
+    context "negative values" do
+      let!(:participation1) do
+        create(:participation, rdv_context: rdv_context1, created_at: (date - 2.days), status: "seen")
+      end
+      let!(:rdv1) { create(:rdv, created_at: (date - 2.days), participations: [participation1]) }
+
+      let!(:participation2) do
+        create(:participation, rdv_context: rdv_context2, created_at: (date + 4.days), status: "seen")
+      end
+      let!(:rdv2) { create(:rdv, created_at: (date + 4.days), participations: [participation2]) }
+
+      it "doesn't take into account negative values" do
+        expect(result.value).to eq(4)
+      end
+    end
   end
 end

--- a/spec/services/stats/monthly_stats/upsert_stat_spec.rb
+++ b/spec/services/stats/monthly_stats/upsert_stat_spec.rb
@@ -64,28 +64,28 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
     it "computes the monthly stats" do
       subject
       expect(stat.reload[:users_count_grouped_by_month]).to eq(
-        { "01/2022" => 1, "02/2022" => 1, "03/2022" => 1, "04/2022" => 1 }
+        { "12/2021" => 1, "01/2022" => 1, "02/2022" => 1, "03/2022" => 1 }
       )
       expect(stat.reload[:rdvs_count_grouped_by_month]).to eq(
-        { "01/2022" => 2, "02/2022" => 2, "03/2022" => 2, "04/2022" => 2 }
+        { "12/2021" => 2, "01/2022" => 2, "02/2022" => 2, "03/2022" => 2 }
       )
       expect(stat.reload[:sent_invitations_count_grouped_by_month]).to eq(
-        { "01/2022" => 3, "02/2022" => 3, "03/2022" => 3, "04/2022" => 3 }
+        { "12/2021" => 3, "01/2022" => 3, "02/2022" => 3, "03/2022" => 3 }
       )
       expect(stat.reload[:rate_of_no_show_for_invitations_grouped_by_month]).to eq(
-        { "01/2022" => 4, "02/2022" => 4, "03/2022" => 4, "04/2022" => 4 }
+        { "12/2021" => 4, "01/2022" => 4, "02/2022" => 4, "03/2022" => 4 }
       )
       expect(stat.reload[:rate_of_no_show_for_convocations_grouped_by_month]).to eq(
-        { "01/2022" => 9, "02/2022" => 9, "03/2022" => 9, "04/2022" => 9 }
+        { "12/2021" => 9, "01/2022" => 9, "02/2022" => 9, "03/2022" => 9 }
       )
       expect(stat.reload[:average_time_between_invitation_and_rdv_in_days_by_month]).to eq(
-        { "01/2022" => 5, "02/2022" => 5, "03/2022" => 5, "04/2022" => 5 }
+        { "12/2021" => 5, "01/2022" => 5, "02/2022" => 5, "03/2022" => 5 }
       )
       expect(stat.reload[:rate_of_users_oriented_in_less_than_30_days_by_month]).to eq(
         { "12/2021" => 7, "01/2022" => 7, "02/2022" => 7, "03/2022" => 7 }
       )
       expect(stat.reload[:rate_of_autonomous_users_grouped_by_month]).to eq(
-        { "01/2022" => 8, "02/2022" => 8, "03/2022" => 8, "04/2022" => 8 }
+        { "12/2021" => 8, "01/2022" => 8, "02/2022" => 8, "03/2022" => 8 }
       )
     end
 

--- a/spec/services/stats/monthly_stats/upsert_stat_spec.rb
+++ b/spec/services/stats/monthly_stats/upsert_stat_spec.rb
@@ -64,28 +64,28 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
     it "computes the monthly stats" do
       subject
       expect(stat.reload[:users_count_grouped_by_month]).to eq(
-        { "12/2021" => 1, "01/2022" => 1, "02/2022" => 1, "03/2022" => 1 }
+        { "01/2022" => 1, "02/2022" => 1, "03/2022" => 1, "04/2022" => 1 }
       )
       expect(stat.reload[:rdvs_count_grouped_by_month]).to eq(
-        { "12/2021" => 2, "01/2022" => 2, "02/2022" => 2, "03/2022" => 2 }
+        { "01/2022" => 2, "02/2022" => 2, "03/2022" => 2, "04/2022" => 2 }
       )
       expect(stat.reload[:sent_invitations_count_grouped_by_month]).to eq(
-        { "12/2021" => 3, "01/2022" => 3, "02/2022" => 3, "03/2022" => 3 }
+        { "01/2022" => 3, "02/2022" => 3, "03/2022" => 3, "04/2022" => 3 }
       )
       expect(stat.reload[:rate_of_no_show_for_invitations_grouped_by_month]).to eq(
-        { "12/2021" => 4, "01/2022" => 4, "02/2022" => 4, "03/2022" => 4 }
+        { "01/2022" => 4, "02/2022" => 4, "03/2022" => 4, "04/2022" => 4 }
       )
       expect(stat.reload[:rate_of_no_show_for_convocations_grouped_by_month]).to eq(
-        { "12/2021" => 9, "01/2022" => 9, "02/2022" => 9, "03/2022" => 9 }
+        { "01/2022" => 9, "02/2022" => 9, "03/2022" => 9, "04/2022" => 9 }
       )
       expect(stat.reload[:average_time_between_invitation_and_rdv_in_days_by_month]).to eq(
-        { "12/2021" => 5, "01/2022" => 5, "02/2022" => 5, "03/2022" => 5 }
+        { "01/2022" => 5, "02/2022" => 5, "03/2022" => 5, "04/2022" => 5 }
       )
       expect(stat.reload[:rate_of_users_oriented_in_less_than_30_days_by_month]).to eq(
         { "12/2021" => 7, "01/2022" => 7, "02/2022" => 7, "03/2022" => 7 }
       )
       expect(stat.reload[:rate_of_autonomous_users_grouped_by_month]).to eq(
-        { "12/2021" => 8, "01/2022" => 8, "02/2022" => 8, "03/2022" => 8 }
+        { "01/2022" => 8, "02/2022" => 8, "03/2022" => 8, "04/2022" => 8 }
       )
     end
 


### PR DESCRIPTION
Cette PR permet de corriger 2 problèmes liées au stats : 
- Le mois en cours était pris en compte et donnait des résultats biaisant la lecture des courbes :
<img width="1207" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/33063b20-b9cb-4989-affc-778d0ffd35d9">

- Les insertion manuelles de participations / rattrapage de données faite après les dates originales par les agents pouvaient fausser la lecture du graphique de délai moyen d'invitation en mettant des valeurs négatives. 
Afin de corriger ça on ne prend désormais plus en compte les valeurs négatives dans le calcul. 
<img width="598" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/a8aac7c3-c066-4c0d-a658-1f3e8b4f931b">

Fix https://github.com/betagouv/rdv-insertion/issues/1644