### PR TITLE
fix(perfs): improve performances for invitation dates filtering

### DIFF
--- a/app/views/users/_archived_users_table.html.erb
+++ b/app/views/users/_archived_users_table.html.erb
@@ -15,7 +15,7 @@
         <td><%= display_attribute user.last_name %></td>
         <td><%= display_attribute user.first_name %></td>
         <td><%= display_attribute format_date(user.created_at) %></td>
-        <td><%= display_attribute format_date(user.first_invitation_relative_to_last_participation_sent_at) %></td>
+        <td><%= display_attribute format_date(user.first_invitation_sent_at) %></td>
         <td><%= display_attribute(format_date(user.last_invitation_sent_at)) %></td>
         <td><%= display_attribute format_date(user.archive_for(@department.id).created_at) %></td>
         <td><%= display_attribute user.archive_for(@department.id).archiving_reason %></td>


### PR DESCRIPTION
close : https://github.com/betagouv/rdv-insertion/issues/1652
Le changement dans la méthode `invitations_belonging_to_rdv_contexts` fait gagner environ 70% de perfs.
Les changements dans `users_first_invitations` et `users_last_invitations` encore 80%.
Ce qui fait 94% de gain de perf 🚀 

Je ne sais pas si on souhaite vraiment garder les appels aux méthodes `first_sent_invitation` et `last_sent_invitation` du concern `Invitable` dans les méthodes `users_first_invitations` et `users_last_invitations` de `Filterable`
Je ne les utilises plus dans ma proposition. 
Si nécessaire on pourrait imaginer une refacto plus conséquente pour continuer à les utiliser.
On peut aussi décider de ne pas toucher aux methodes `users_first_invitations` et `users_last_invitations` en enlevant simplement le `includes(:rdvs)`ce qui fait gagner un peu de perfs (mais moins que le changement proposé)