### PR TITLE
fix(upload): Change wording and link

### DIFF
--- a/app/javascript/react/components/EnrichWithContactFile.jsx
+++ b/app/javascript/react/components/EnrichWithContactFile.jsx
@@ -40,7 +40,7 @@ export default function EnrichWithContactFile({ handleContactsFile, fileSize }) 
           />
           <p className="mt-3 mb-0">
             <a
-              href="https://forum.inclusion.beta.gouv.fr/t/communication-aux-departements-des-coordonnees-de-contact-des-beneficiaires-rsa-mise-a-disposition-hebdomadaire/7112"
+              href="https://resana.numerique.gouv.fr/public/information/consulterAccessUrl?cle_url=1564704891UjgFZVdbAj5QPVcxVjgHJwQ6XmNVdAJrDGcHOgZnW2EGN1VjUjFVMldjATdQYA=="
               target="_blank"
               rel="noreferrer"
             >

--- a/app/javascript/react/models/Users.jsx
+++ b/app/javascript/react/models/Users.jsx
@@ -23,7 +23,7 @@ class Users {
   get columns() {
     return [
       {
-        name: "Séléction",
+        name: "Sélection",
         attributes: { className: "text-center", scope: "col" },
         header: ({ users, column }) => (
           <>

--- a/app/javascript/react/pages/UsersUpload.jsx
+++ b/app/javascript/react/pages/UsersUpload.jsx
@@ -184,7 +184,7 @@ const UsersUpload = observer(
                 name="users-list-upload"
                 accept="text/plain, .csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel, application/vnd.oasis.opendocument.spreadsheet"
                 multiple={false}
-                uploadMessage={<span>Choisissez un fichier de nouveaux demandeurs</span>}
+                uploadMessage={<span>Choisissez un fichier d'usagers</span>}
                 pendingMessage="Récupération des informations, merci de patienter"
               />
             </div>

--- a/spec/features/agent_can_upload_user_list_spec.rb
+++ b/spec/features/agent_can_upload_user_list_spec.rb
@@ -141,7 +141,7 @@ describe "Agents can upload user list", js: true do
 
           click_link(motif_category.name)
 
-          expect(page).to have_content("Choisissez un fichier de nouveaux demandeurs")
+          expect(page).to have_content("Choisissez un fichier d'usagers")
           expect(page).to have_content(motif_category.name)
         end
 
@@ -154,7 +154,7 @@ describe "Agents can upload user list", js: true do
 
             click_link("Aucune catégorie de suivi")
 
-            expect(page).to have_content("Choisissez un fichier de nouveaux demandeurs")
+            expect(page).to have_content("Choisissez un fichier d'usagers")
 
             attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
 
@@ -759,7 +759,7 @@ describe "Agents can upload user list", js: true do
 
           click_link(motif_category.name)
 
-          expect(page).to have_content("Choisissez un fichier de nouveaux demandeurs")
+          expect(page).to have_content("Choisissez un fichier d'usagers")
           expect(page).to have_content(motif_category.name)
         end
 
@@ -772,7 +772,7 @@ describe "Agents can upload user list", js: true do
 
             click_link("Aucune catégorie de suivi")
 
-            expect(page).to have_content("Choisissez un fichier de nouveaux demandeurs")
+            expect(page).to have_content("Choisissez un fichier d'usagers")
 
             attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
 


### PR DESCRIPTION
Lié à #1517 . 
- Je change le wording sur la page upload pour parler d'usagers et non plus de demandeurs
- Je change le lien cassé vers le nouveau lien mis à disposition dans [ce commentaire](https://github.com/betagouv/rdv-insertion/issues/1517#issuecomment-1898679356)
- J'enlève l'accent en trop dans "Séléction" 