### PR TITLE
fix(mailers): conditional lieu display for transfer email reply job

### DIFF
--- a/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
@@ -12,7 +12,7 @@
   <h4>Message envoyé par rdv-insertion</h4>
   <p>Convocation pour un rdv le <%= I18n.l(@rdv.starts_at, format: :human) %></p>
   <p>Motif : <%= @rdv.motif_name %> </p>
-  <p>Lieu : <%= @rdv.lieu.name %></p>
-  <p>Adresse : <%= @rdv.lieu.address %></p>
+  <%= tag.p("Lieu : #{@rdv.lieu.name}") if @rdv.lieu.present? %>
+  <%= tag.p("Adresse : #{@rdv.lieu.address}") if @rdv.lieu.present? %>
 </blockquote>
 <%= render "link_to_user_page", user_page_url: @user_page_url %>

--- a/spec/mailers/reply_transfer_mailer_spec.rb
+++ b/spec/mailers/reply_transfer_mailer_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe ReplyTransferMailer do
       let!(:lieu) { nil }
 
       it "renders the content without the lieu" do
-        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une convocation")
+        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire")
         expect(mail.body.encoded).to match("<h4>coucou</h4>")
         expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
         expect(mail.body.encoded).to match("Merci de ne pas répondre à cet e-mail. Pour contacter la personne, ")

--- a/spec/mailers/reply_transfer_mailer_spec.rb
+++ b/spec/mailers/reply_transfer_mailer_spec.rb
@@ -140,6 +140,31 @@ RSpec.describe ReplyTransferMailer do
       )
       expect(mail.body.encoded).to match("Voir la fiche usager")
     end
+
+    context "when rdv has no lieu" do
+      let!(:lieu) { nil }
+
+      it "renders the content without the lieu" do
+        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une convocation")
+        expect(mail.body.encoded).to match("<h4>coucou</h4>")
+        expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
+        expect(mail.body.encoded).to match("Merci de ne pas répondre à cet e-mail. Pour contacter la personne, ")
+        expect(mail.body.encoded).to match("vous pouvez utiliser les informations contenues dans cet e-mail.")
+        expect(mail.body.encoded).to match("<h4>Éxpéditeur</h4>")
+        expect(mail.body.encoded).to match("M. Bénédicte FICIAIRE")
+        expect(mail.body.encoded).to match("bene_ficiaire@gmail.com")
+        expect(mail.body.encoded).to match("33782605941")
+        expect(mail.body.encoded).to match("Message envoyé par rdv-insertion")
+        expect(mail.body.encoded).to match("Convocation pour un rdv le jeudi 29 juin 2023 à 00h00")
+        expect(mail.body.encoded).to match("Motif : RSA orientation sur site")
+        expect(mail.body.encoded).not_to match("Lieu")
+        expect(mail.body.encoded).not_to match("Adresse")
+        expect(mail.body.encoded).to match(
+          "href=\"#{ENV['HOST']}/organisations/#{organisation.id}/users/#{user.id}\""
+        )
+        expect(mail.body.encoded).to match("Voir la fiche usager")
+      end
+    end
   end
 
   describe "#forward_to_default_mailbox" do


### PR DESCRIPTION
fix de [cette erreur Sentry](https://sentry.incubateur.net/organizations/betagouv/issues/82231/?query=is%3Aunresolved+TransferEmailReplyJob&referrer=issue-stream&statsPeriod=14d)