### PR TITLE
feat(security): ensure super admin cannot be updated

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -18,7 +18,7 @@ class Agent < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :rdv_solidarites_agent_id, uniqueness: true, allow_nil: true
 
-  validate :cannot_update_as_super_admin
+  validate :cannot_save_as_super_admin
 
   scope :not_betagouv, -> { where.not("agents.email LIKE ?", "%beta.gouv.fr") }
   scope :super_admins, -> { where(super_admin: true) }
@@ -38,7 +38,9 @@ class Agent < ApplicationRecord
 
   private
 
-  def cannot_update_as_super_admin
+  # This is to make sure an agent can't be set as super_admin through an agent creation or update in the app.
+  # To set an agent as superadmin a developer should use agent#update_column.
+  def cannot_save_as_super_admin
     return unless super_admin_changed? && super_admin == true
 
     errors.add(:super_admin, "ne peut pas être mis à jour")

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -3,9 +3,6 @@ class Agent < ApplicationRecord
 
   include Agent::RdvSolidaritesClient
 
-  validates :email, presence: true, uniqueness: true
-  validates :rdv_solidarites_agent_id, uniqueness: true, allow_nil: true
-
   has_many :agent_roles, dependent: :destroy
   has_many :referent_assignations, dependent: :destroy
   has_many :agents_rdvs, dependent: :destroy
@@ -17,6 +14,11 @@ class Agent < ApplicationRecord
   has_many :motif_categories, -> { distinct }, through: :organisations
   has_many :rdvs, through: :agents_rdvs
   has_many :users, through: :referent_assignations
+
+  validates :email, presence: true, uniqueness: true
+  validates :rdv_solidarites_agent_id, uniqueness: true, allow_nil: true
+
+  validate :cannot_update_as_super_admin
 
   scope :not_betagouv, -> { where.not("agents.email LIKE ?", "%beta.gouv.fr") }
   scope :super_admins, -> { where(super_admin: true) }
@@ -32,5 +34,13 @@ class Agent < ApplicationRecord
 
   def to_s
     "#{first_name} #{last_name}"
+  end
+
+  private
+
+  def cannot_update_as_super_admin
+    return unless super_admin_changed? && super_admin == true
+
+    errors.add(:super_admin, "ne peut pas être mis à jour")
   end
 end

--- a/spec/controllers/organisations_controller_spec.rb
+++ b/spec/controllers/organisations_controller_spec.rb
@@ -5,7 +5,7 @@ describe OrganisationsController do
                           independent_from_cd: true, department: department)
   end
   let!(:organisation2) { create(:organisation, department: department) }
-  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation], super_admin: true) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let(:agent2) { create(:agent, organisations: [organisation, organisation2]) }
 
   render_views

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -13,6 +13,13 @@ FactoryBot.define do
       admin_role_in_organisations { [] }
     end
 
+    trait :super_admin do
+      to_create do |instance|
+        instance.super_admin = true
+        instance.save(validate: false)
+      end
+    end
+
     after(:create) do |agent, evaluator|
       evaluator.basic_role_in_organisations.each do |organisation|
         create(:agent_role, agent: agent, organisation: organisation)

--- a/spec/features/administrate/super_admin_can_manage_departments_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_departments_spec.rb
@@ -1,5 +1,5 @@
 describe "Super admin can manage departments" do
-  let!(:super_admin) { create(:agent, super_admin: true) }
+  let!(:super_admin) { create(:agent, :super_admin) }
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department: department) }
 

--- a/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
@@ -1,5 +1,5 @@
 describe "Super admin can manage motif categories" do
-  let!(:super_admin) { create(:agent, super_admin: true) }
+  let!(:super_admin) { create(:agent, :super_admin) }
   let!(:template) { create(:template) }
   let!(:motif_category) { create(:motif_category, template: template) }
   let!(:motif) { create(:motif, motif_category: motif_category) }

--- a/spec/features/administrate/super_admin_can_manage_organisations_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_organisations_spec.rb
@@ -1,5 +1,5 @@
 describe "Super admin can manage organisations" do
-  let!(:super_admin) { create(:agent, super_admin: true) }
+  let!(:super_admin) { create(:agent, :super_admin) }
   let!(:department1) { create(:department) }
   let!(:organisation1) { create(:organisation, department: department1) }
   let!(:agent1) { create(:agent, organisations: [organisation1], super_admin: false) }

--- a/spec/features/administrate/super_admin_can_manage_templates_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_templates_spec.rb
@@ -1,5 +1,5 @@
 describe "Super admin can manage templates" do
-  let!(:super_admin) { create(:agent, super_admin: true) }
+  let!(:super_admin) { create(:agent, :super_admin) }
   let!(:template) { create(:template) }
   let!(:motif_category) { create(:motif_category, template: template) }
 

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -1,5 +1,5 @@
 describe "Super admin can manage users" do
-  let!(:super_admin) { create(:agent, super_admin: true) }
+  let!(:super_admin) { create(:agent, :super_admin) }
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department: department) }
   let!(:user) { create(:user, organisations: [organisation]) }

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -30,7 +30,7 @@ describe Agent do
     end
   end
 
-  describe "cannot update as super admin" do
+  describe "cannot save as super admin" do
     let!(:agent) { create(:agent, super_admin: false) }
 
     it "cannot update" do

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -29,4 +29,23 @@ describe Agent do
       end
     end
   end
+
+  describe "cannot update as super admin" do
+    let!(:agent) { create(:agent, super_admin: false) }
+
+    it "cannot update" do
+      expect(agent.update(super_admin: true)).to eq(false)
+      expect(agent.errors.full_messages.to_sentence).to include("Super admin ne peut pas être mis à jour")
+    end
+
+    context "on creation" do
+      let!(:agent) { build(:agent) }
+
+      it "is not valid" do
+        agent.super_admin = true
+        expect(agent).not_to be_valid
+        expect(agent.errors.full_messages.to_sentence).to include("Super admin ne peut pas être mis à jour")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Vu qu'on utilise maintenant pleinement la fonctionnalité de super_admin, je réduis la possibilité que qu'un agent soit marqué comme `super_admin` par inadvertance en empêchant l'update d'un agent comme super admin via `agent#update` ou `agent#save`. 
On devra explicitement utiliser `agent#update_column` en console lorsqu'on ajoutera un superadmin.