### PR TITLE
fix: stats NaN issue

### DIFF
--- a/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
+++ b/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
@@ -22,6 +22,9 @@ module Stats
 
         invitation_delays << rdv_context.time_between_invitation_and_rdv_in_days
       end
+
+      return 0.0 if invitation_delays.empty?
+
       invitation_delays.sum / invitation_delays.size.to_f
     end
   end

--- a/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
+++ b/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
@@ -50,6 +50,22 @@ describe Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays, type: :service 
       it "doesn't take into account negative values" do
         expect(result.value).to eq(4)
       end
+
+      context "no positive values" do
+        let!(:participation1) do
+          create(:participation, rdv_context: rdv_context1, created_at: (date - 2.days), status: "seen")
+        end
+        let!(:rdv1) { create(:rdv, created_at: (date - 2.days), participations: [participation1]) }
+
+        let!(:participation2) do
+          create(:participation, rdv_context: rdv_context2, created_at: (date - 4.days), status: "seen")
+        end
+        let!(:rdv2) { create(:rdv, created_at: (date - 4.days), participations: [participation2]) }
+
+        it "returns 0" do
+          expect(result.value).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Depuis la dernière mise à jour des stats il est devenu possible d'avoir des mois dans lesquelles aucune valeur n'est présente dans `ComputeAverageTimeBetweenInvitationAndRdvInDays`, cela engendrait une division de `0.0 / 0.0` qui donnait un NaN, sur lequel appeler un `.round` engendre l'erreur ci-dessous.  
<img width="438" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/48d37fcb-2f68-4d37-8cd6-c11aee7b2d93">

Pour prévenir ce cas on renvoi 0.0 si jamais aucune valeur n'est présente

Corrige https://sentry.incubateur.net/organizations/betagouv/issues/82504/?project=16&query=is%3Aunresolved&referrer=issue-stream