### PR TITLE
feat(creneaux_alert_job): add availability alert job for organisation…

### DIFF
--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -8,10 +8,6 @@ class MattermostClient
       send_message(ENV["MATTERMOST_MAIN_CHANNEL_URL"], text)
     end
 
-    def send_to_rgpd_channel(text)
-      send_message(ENV["MATTERMOST_RGPD_CHANNEL_URL"], text)
-    end
-
     private
 
     def send_message(url, text)

--- a/app/clients/mattermost_client.rb
+++ b/app/clients/mattermost_client.rb
@@ -8,6 +8,10 @@ class MattermostClient
       send_message(ENV["MATTERMOST_MAIN_CHANNEL_URL"], text)
     end
 
+    def send_to_rgpd_channel(text)
+      send_message(ENV["MATTERMOST_RGPD_CHANNEL_URL"], text)
+    end
+
     private
 
     def send_message(url, text)

--- a/app/javascript/stylesheets/mail.scss
+++ b/app/javascript/stylesheets/mail.scss
@@ -280,3 +280,11 @@ blockquote {
   padding: $padding;
   margin: 15px;
 }
+
+.margined-paragraph {
+  margin-left: 25px;
+  margin-bottom: 15px;
+  p {
+    margin: 0
+  }
+}

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -25,7 +25,7 @@ class NotifyUnavailableCreneauJob < ApplicationJob
 
   def notify_on_mattermost(organisation, unavailable_params_motifs)
     unavailable_params_motifs.each do |motif|
-      MattermostClient.send_to_rgpd_channel(formated_string_for_mattermost_message(organisation, motif))
+      MattermostClient.send_to_notif_channel(formated_string_for_mattermost_message(organisation, motif))
     end
   end
 

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -33,7 +33,8 @@ class NotifyUnavailableCreneauJob < ApplicationJob
     string =
       "Créneaux indisponibles pour l'organisation #{organisation.name}" \
       " (Département: #{organisation.department.name})\n" \
-      " Motif : #{motif[:motif_category_name]}\n"
+      " Motif : #{motif[:motif_category_name]}\n" \
+      " Nombre d'invitations concernées : #{motif[:invations_counter]}\n"
 
     string += " Codes postaux : #{motif[:city_codes].join(', ')}\n" if motif[:city_codes].present?
 

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -1,8 +1,8 @@
 class NotifyUnavailableCreneauJob < ApplicationJob
   def perform(organisation_id)
-    unavailable_params_motifs =
-      Invitations::VerifyOrganisationCreneauxAvailability.new(organisation_id: organisation_id).call
-    return if unavailable_params_motifs.empty?
+    result =
+      Invitations::VerifyOrganisationCreneauxAvailability.call(organisation_id: organisation_id)
+    return if result.unavailable_params_motifs.empty?
 
     # unavailable_params_motifs = [{
     #   motif_category_name: "RSA Orientation",
@@ -10,8 +10,8 @@ class NotifyUnavailableCreneauJob < ApplicationJob
     #   referent_ids: ["1", "2", "3"]
     # },...]
     organisation = Organisation.find(organisation_id)
-    deliver_email(organisation, unavailable_params_motifs)
-    notify_on_mattermost(organisation, unavailable_params_motifs)
+    deliver_email(organisation, result.unavailable_params_motifs)
+    notify_on_mattermost(organisation, result.unavailable_params_motifs)
   end
 
   private

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -33,12 +33,11 @@ class NotifyUnavailableCreneauJob < ApplicationJob
     string =
       "Créneaux indisponibles pour l'organisation #{organisation.name}" \
       " (Département: #{organisation.department.name})\n" \
-      "#{organisation.name} (Département: #{organisation.department.name})\n" \
       " Motif : #{motif[:motif_category_name]}"
 
     string += "\n Code postaux : #{motif[:city_codes].join(', ')}" \
 
-    string += "\n Référents : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
+    string += "\n Référents (rdvsp_ids) : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
 
     string += "L'organisation n'a pas d'email configuré et n'a pas été notifiée !\n" if organisation.email.blank?
 

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -2,43 +2,48 @@ class NotifyUnavailableCreneauJob < ApplicationJob
   def perform(organisation_id)
     result =
       Invitations::VerifyOrganisationCreneauxAvailability.call(organisation_id: organisation_id)
-    return if result.unavailable_params_motifs.empty?
+    return if result.grouped_invitation_params_by_category.empty?
 
-    # unavailable_params_motifs = [{
+    # grouped_invitation_params_by_category = [{
     #   motif_category_name: "RSA Orientation",
     #   city_code: ["75001", "75002", "75003"],
     #   referent_ids: ["1", "2", "3"]
     # },...]
     organisation = Organisation.find(organisation_id)
-    deliver_email(organisation, result.unavailable_params_motifs)
-    notify_on_mattermost(organisation, result.unavailable_params_motifs)
+    deliver_email(organisation, result.grouped_invitation_params_by_category)
+    notify_on_mattermost(organisation, result.grouped_invitation_params_by_category)
   end
 
   private
 
-  def deliver_email(organisation, unavailable_params_motifs)
+  def deliver_email(organisation, grouped_invitation_params_by_category)
     OrganisationMailer.creneau_unavailable(
       organisation: organisation,
-      motifs: unavailable_params_motifs
+      grouped_invitation_params_by_category: grouped_invitation_params_by_category
     ).deliver_now
   end
 
-  def notify_on_mattermost(organisation, unavailable_params_motifs)
-    unavailable_params_motifs.each do |motif|
-      MattermostClient.send_to_notif_channel(formated_string_for_mattermost_message(organisation, motif))
+  def notify_on_mattermost(organisation, grouped_invitation_params_by_category)
+    grouped_invitation_params_by_category.each do |grouped_invitation_params|
+      MattermostClient.send_to_notif_channel(formated_string_for_mattermost_message(organisation,
+                                                                                    grouped_invitation_params))
     end
   end
 
-  def formated_string_for_mattermost_message(organisation, motif)
+  def formated_string_for_mattermost_message(organisation, grouped_invitation_params)
     string =
       "Créneaux indisponibles pour l'organisation #{organisation.name}" \
       " (Département: #{organisation.department.name})\n" \
-      " Motif : #{motif[:motif_category_name]}\n" \
-      " Nombre d'invitations concernées : #{motif[:invations_counter]}\n"
+      " Motif : #{grouped_invitation_params[:motif_category_name]}\n" \
+      " Nombre d'invitations concernées : #{grouped_invitation_params[:invitations_counter]}\n"
 
-    string += " Codes postaux : #{motif[:city_codes].join(', ')}\n" if motif[:city_codes].present?
+    if grouped_invitation_params[:city_codes].present?
+      string += " Codes postaux : #{grouped_invitation_params[:city_codes].join(', ')}\n"
+    end
 
-    string += " Référents (rdvsp_ids) : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
+    if grouped_invitation_params[:referent_ids].present?
+      string += " Référents (rdvsp_ids) : #{grouped_invitation_params[:referent_ids].join(', ')}\n"
+    end
 
     string += " !! L'organisation n'a pas d'email configuré et n'a pas été notifiée !!\n" if organisation.email.blank?
 

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -1,0 +1,49 @@
+class NotifyUnavailableCreneauJob < ApplicationJob
+  def perform(organisation_id)
+    unavailable_params_motifs =
+      Invitations::VerifyOrganisationCreneauxAvailability.new(organisation_id: organisation_id).call
+    return if unavailable_params_motifs.empty?
+
+    # unavailable_params_motifs = [{
+    #   motif_category_name: "RSA Orientation",
+    #   city_code: ["75001", "75002", "75003"],
+    #   referent_ids: ["1", "2", "3"]
+    # },...]
+    organisation = Organisation.find(organisation_id)
+    deliver_email(organisation, unavailable_params_motifs)
+    notify_on_mattermost(organisation, unavailable_params_motifs)
+  end
+
+  private
+
+  def deliver_email(organisation, unavailable_params_motifs)
+    OrganisationMailer.creneau_unavailable(
+      organisation: organisation,
+      motifs: unavailable_params_motifs
+    ).deliver_now
+  end
+
+  def notify_on_mattermost(organisation, unavailable_params_motifs)
+    unavailable_params_motifs.each do |motif|
+      MattermostClient.send_to_rgpd_channel(formated_string_for_mattermost_message(organisation, motif))
+    end
+  end
+
+  def formated_string_for_mattermost_message(organisation, motif)
+    string =
+      "Créneaux indisponibles pour l'organisation #{organisation.name}" \
+      " (Département: #{organisation.department.name})\n" \
+      "#{organisation.name} (Département: #{organisation.department.name})\n" \
+      " Motif : #{motif[:motif_category_name]}"
+
+    string += "\n Code postaux : #{motif[:city_codes].join(', ')}" \
+
+    string += "\n Référents : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
+
+    string += "L'organisation n'a pas d'email configuré et n'a pas été notifiée !\n" if organisation.email.blank?
+
+    string += "\n\n"
+
+    string
+  end
+end

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -33,15 +33,13 @@ class NotifyUnavailableCreneauJob < ApplicationJob
     string =
       "Créneaux indisponibles pour l'organisation #{organisation.name}" \
       " (Département: #{organisation.department.name})\n" \
-      " Motif : #{motif[:motif_category_name]}"
+      " Motif : #{motif[:motif_category_name]}\n"
 
-    string += "\n Code postaux : #{motif[:city_codes].join(', ')}" \
+    string += " Codes postaux : #{motif[:city_codes].join(', ')}\n" if motif[:city_codes].present?
 
-    string += "\n Référents (rdvsp_ids) : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
+    string += " Référents (rdvsp_ids) : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
 
-    string += "L'organisation n'a pas d'email configuré et n'a pas été notifiée !\n" if organisation.email.blank?
-
-    string += "\n\n"
+    string += " !! L'organisation n'a pas d'email configuré et n'a pas été notifiée !!\n" if organisation.email.blank?
 
     string
   end

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -28,9 +28,11 @@ class SendCreneauAvailabilityAlertJob < ApplicationJob
   end
 
   def formated_string_for_mattermost_message(organisation, motif)
-    string = "Créneaux indisponibles pour l'organisation #{organisation.name} (Département: #{organisation.department.name})\n" \
-             "#{organisation.name} (Département: #{organisation.department.name})\n" \
-             " Motif : #{motif[:motif_name]}"
+    string =
+      "Créneaux indisponibles pour l'organisation #{organisation.name}" \
+      " (Département: #{organisation.department.name})\n" \
+      "#{organisation.name} (Département: #{organisation.department.name})\n" \
+      " Motif : #{motif[:motif_name]}"
 
     string += "\n Code postaux : #{motif[:city_codes].join(', ')}" \
 

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -2,44 +2,8 @@ class SendCreneauAvailabilityAlertJob < ApplicationJob
   def perform
     Department.all.each do |departement|
       departement.organisations.each do |organisation|
-        unavailable_motifs =
-          Invitations::VerifyOrganisationCreneauxAvailability.new(organisation_id: organisation.id).call
-        next if unavailable_motifs.empty?
-
-        deliver_email(organisation, unavailable_motifs)
-        notify_on_mattermost(organisation, unavailable_motifs)
+        NotifyUnavailableCreneauJob.perform_async(organisation.id)
       end
     end
-  end
-
-  private
-
-  def deliver_email(organisation, unavailable_motifs)
-    OrganisationMailer.creneau_unavailable(
-      organisation: organisation,
-      motifs: unavailable_motifs
-    ).deliver_now
-  end
-
-  def notify_on_mattermost(organisation, unavailable_motifs)
-    unavailable_motifs.each do |motif|
-      MattermostClient.send_to_rgpd_channel(formated_string_for_mattermost_message(organisation, motif))
-    end
-  end
-
-  def formated_string_for_mattermost_message(organisation, motif)
-    string =
-      "Créneaux indisponibles pour l'organisation #{organisation.name}" \
-      " (Département: #{organisation.department.name})\n" \
-      "#{organisation.name} (Département: #{organisation.department.name})\n" \
-      " Motif : #{motif[:motif_name]}"
-
-    string += "\n Code postaux : #{motif[:city_codes].join(', ')}" \
-
-    string += "\n Référents : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
-
-    string += "\n\n"
-
-    string
   end
 end

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -1,0 +1,43 @@
+class SendCreneauAvailabilityAlertJob < ApplicationJob
+  def perform
+    Department.all.each do |departement|
+      departement.organisations.each do |organisation|
+        unavailable_motifs =
+          Invitations::VerifyOrganisationCreneauxAvailability.new(organisation_id: organisation.id).call
+        next if unavailable_motifs.empty?
+
+        deliver_email(organisation, unavailable_motifs)
+        notify_on_mattermost(organisation, unavailable_motifs)
+      end
+    end
+  end
+
+  private
+
+  def deliver_email(organisation, unavailable_motifs)
+    OrganisationMailer.creneau_unavailable(
+      organisation: organisation,
+      motifs: unavailable_motifs
+    ).deliver_now
+  end
+
+  def notify_on_mattermost(organisation, unavailable_motifs)
+    unavailable_motifs.each do |motif|
+      MattermostClient.send_to_rgpd_channel(formated_string_for_mattermost_message(organisation, motif))
+    end
+  end
+
+  def formated_string_for_mattermost_message(organisation, motif)
+    string = "Créneaux indisponibles pour l'organisation #{organisation.name} (Département: #{organisation.department.name})\n" \
+             "#{organisation.name} (Département: #{organisation.department.name})\n" \
+             " Motif : #{motif[:motif_name]}"
+
+    string += "\n Code postaux : #{motif[:city_codes].join(', ')}" \
+
+    string += "\n Référents : #{motif[:referent_ids].join(', ')}\n" if motif[:referent_ids].present?
+
+    string += "\n\n"
+
+    string
+  end
+end

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -1,5 +1,7 @@
 class SendCreneauAvailabilityAlertJob < ApplicationJob
   def perform
+    return if staging_env?
+
     Department.all.each do |departement|
       departement.organisations.each do |organisation|
         NotifyUnavailableCreneauJob.perform_async(organisation.id)

--- a/app/mailers/organisation_mailer.rb
+++ b/app/mailers/organisation_mailer.rb
@@ -12,8 +12,10 @@ class OrganisationMailer < ApplicationMailer
   end
 
   def creneau_unavailable(organisation:, motifs:)
-    @motifs = motifs
+    return if organisation.email.blank?
+
     @organisation = organisation
+    @motifs = motifs
     mail(
       to: organisation.email,
       subject: "[Alerte créneaux] Vérifier qu'il y a suffisamment de créneaux de libre relativement au stock d'invitations en cours",

--- a/app/mailers/organisation_mailer.rb
+++ b/app/mailers/organisation_mailer.rb
@@ -10,4 +10,14 @@ class OrganisationMailer < ApplicationMailer
       reply_to: reply_to
     )
   end
+
+  def creneau_unavailable(organisation:, motifs:)
+    @motifs = motifs
+    @organisation = organisation
+    mail(
+      to: organisation.email,
+      subject: "[Alerte créneaux] Vérifier qu'il y a suffisamment de créneaux de libre relativement au stock d'invitations en cours",
+      reply_to: "rdv-insertion@beta.gouv.fr"
+    )
+  end
 end

--- a/app/mailers/organisation_mailer.rb
+++ b/app/mailers/organisation_mailer.rb
@@ -12,7 +12,7 @@ class OrganisationMailer < ApplicationMailer
   end
 
   def creneau_unavailable(organisation:, grouped_invitation_params_by_category:)
-    return if organisation.email.blank? || staging_env?
+    return if organisation.email.blank?
 
     @organisation = organisation
     @grouped_invitation_params_by_category = grouped_invitation_params_by_category

--- a/app/mailers/organisation_mailer.rb
+++ b/app/mailers/organisation_mailer.rb
@@ -11,11 +11,11 @@ class OrganisationMailer < ApplicationMailer
     )
   end
 
-  def creneau_unavailable(organisation:, motifs:)
+  def creneau_unavailable(organisation:, grouped_invitation_params_by_category:)
     return if organisation.email.blank?
 
     @organisation = organisation
-    @motifs = motifs
+    @grouped_invitation_params_by_category = grouped_invitation_params_by_category
     mail(
       to: organisation.email,
       subject: "[Alerte créneaux] Vérifier qu'il y a suffisamment de créneaux" \

--- a/app/mailers/organisation_mailer.rb
+++ b/app/mailers/organisation_mailer.rb
@@ -18,7 +18,8 @@ class OrganisationMailer < ApplicationMailer
     @motifs = motifs
     mail(
       to: organisation.email,
-      subject: "[Alerte créneaux] Vérifier qu'il y a suffisamment de créneaux de libre relativement au stock d'invitations en cours",
+      subject: "[Alerte créneaux] Vérifier qu'il y a suffisamment de créneaux" \
+               " de libre relativement au stock d'invitations en cours",
       reply_to: "rdv-insertion@beta.gouv.fr"
     )
   end

--- a/app/mailers/organisation_mailer.rb
+++ b/app/mailers/organisation_mailer.rb
@@ -12,7 +12,7 @@ class OrganisationMailer < ApplicationMailer
   end
 
   def creneau_unavailable(organisation:, grouped_invitation_params_by_category:)
-    return if organisation.email.blank?
+    return if organisation.email.blank? || staging_env?
 
     @organisation = organisation
     @grouped_invitation_params_by_category = grouped_invitation_params_by_category

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -30,20 +30,13 @@ module Invitations
     end
 
     def map_invitation_params(invitation, default_token)
-      # We map relevant params only (for creneaux search in rdvs) is done to reduce the number of calls to the RDVSP API
-      # The uniq filter on this mapping reduce the number of average calls to the API by /3
+      # We keep uniq relevant params only (for creneaux search in rdvs) to reduce the number of calls to the RDVSP API
       # We take the first invitation token as default token
       # We keep the original invitation_token only if the invitation has a referent_id
-      token = invitation.link_params["referent_ids"].nil? ? default_token : invitation.link_params["invitation_token"]
-      {
-        organisation_ids: invitation.link_params["organisation_ids"],
-        referent_ids: invitation.link_params["referent_ids"],
-        motif_category_short_name: invitation.link_params["motif_category_short_name"],
-        departement: invitation.link_params["departement"],
-        city_code: invitation.link_params["city_code"],
-        street_ban_id: invitation.link_params["street_ban_id"],
-        invitation_token: token
-      }
+      invitation.link_params.symbolize_keys.merge(
+        invitation_token:
+          invitation.link_params["referent_ids"].nil? ? default_token : invitation.link_params["invitation_token"]
+      ).except(:latitude, :longitude, :address)
     end
 
     def creneau_available?(params)

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -2,6 +2,7 @@ module Invitations
   class VerifyOrganisationCreneauxAvailability < BaseService
     def initialize(organisation_id:)
       @organisation = Organisation.find(organisation_id)
+      # On prend le premier agent de l'organisation pour les appels à l'API RDVSP
       Current.agent = @organisation.agents.first
       @invitations_params_without_creneau = []
       @grouped_invitation_params_by_category = []
@@ -9,13 +10,14 @@ module Invitations
 
     def call
       process_invitations
-      result.unavailable_params_motifs = process_invitations_params_without_creneau
+      process_invitations_params_without_creneau
+      result.grouped_invitation_params_by_category = @grouped_invitation_params_by_category
     end
 
     private
 
     def process_invitations
-      return unless @organisation.invitations.valid.any?
+      return if organisation_valid_invitations.empty?
 
       invitations_params.each do |params|
         @invitations_params_without_creneau << params unless creneau_available?(params)
@@ -23,9 +25,13 @@ module Invitations
     end
 
     def invitations_params
-      @organisation.invitations.valid.select("DISTINCT ON (rdv_context_id) *").to_a.map do |invitation|
+      organisation_valid_invitations.select("DISTINCT ON (rdv_context_id) *").to_a.map do |invitation|
         invitation.link_params.symbolize_keys
       end
+    end
+
+    def organisation_valid_invitations
+      @organisation.invitations.valid
     end
 
     def creneau_available?(params)
@@ -44,13 +50,13 @@ module Invitations
       city_code = invitation[:city_code]
       referent_ids = invitation[:referent_ids]
       category_params_group = find_or_initialize_category_params_group(motif_category_name)
-      category_params_group[:invations_counter] += 1
+      category_params_group[:invitations_counter] += 1
       unless category_params_group[:city_codes].include?(city_code) || city_code.nil?
         category_params_group[:city_codes] << city_code
       end
       return if category_params_group[:referent_ids].include?(referent_ids) || referent_ids.nil?
 
-      category_params_group[:referent_ids] << referent_ids
+      category_params_group[:referent_ids] += referent_ids
     end
 
     def find_or_initialize_category_params_group(motif_category_name)
@@ -60,7 +66,7 @@ module Invitations
       return category_params_group if category_params_group.present?
 
       category_params_group = { motif_category_name: motif_category_name, city_codes: [], referent_ids: [],
-                                invations_counter: 0 }
+                                invitations_counter: 0 }
       @grouped_invitation_params_by_category << category_params_group
       category_params_group
     end

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -1,0 +1,81 @@
+module Invitations
+  class VerifyOrganisationCreneauxAvailability < BaseService
+    def initialize(organisation_id:)
+      @organisation = Organisation.find(organisation_id)
+      # Quid de l'agent connecté pour la vérication des créneaux disponibles ? utiliser un super agent ? comme proposé ici https://github.com/betagouv/rdv-insertion/blob/2526b569660d32ad1d15fcdc7b8e4c596125f8b4/app/helpers/admin_jobs_agent_helper.rb
+      Current.agent = @organisation.agents.first
+      @invitations_params_without_creneau = []
+      @unavailable_motifs = []
+    end
+
+    def call
+      process_invitations
+      process_invitations_params_without_creneau
+    end
+
+    private
+
+    def process_invitations
+      return unless @organisation.invitations.valid.any?
+
+      grouped_invitations_params.each do |params|
+        @invitations_params_without_creneau << params unless creneau_available?(params)
+      end
+    end
+
+    def grouped_invitations_params
+      default_token = @organisation.invitations.valid.first.rdv_solidarites_token
+      @organisation.invitations.valid.map do |invitation|
+        map_invitation_params(invitation, default_token)
+      end.uniq
+    end
+
+    def map_invitation_params(invitation, default_token)
+      # We take the first invitation token as default token
+      # this mapping is done to reduce the number of calls to the RDVSP API.
+      # The uniq filter on this mapping reduce the number of average calls to the API by /3
+      # We keep the original invitation_token only if the invitation has a referent_id
+      {
+        organisation_ids: invitation.link_params["organisation_ids"],
+        referent_ids: invitation.link_params["referent_ids"],
+        motif_category_short_name: invitation.link_params["motif_category_short_name"],
+        departement: invitation.link_params["departement"],
+        city_code: invitation.link_params["city_code"],
+        street_ban_id: invitation.link_params["street_ban_id"],
+        invitation_token: invitation.link_params["referent_ids"].nil? ? default_token : invitation.link_params["invitation_token"]
+      }
+    end
+
+    def creneau_available?(params)
+      RdvSolidaritesApi::RetrieveCreneauAvailability.call(link_params: params).creneau_availability
+    end
+
+    def process_invitations_params_without_creneau
+      @invitations_params_without_creneau.each do |invitation_params|
+        add_invitation_motif_to_unavailable_motifs(invitation_params)
+      end
+
+      @unavailable_motifs
+    end
+
+    def add_invitation_motif_to_unavailable_motifs(invitation)
+      motif_name = MotifCategory.find_by(short_name: invitation[:motif_category_short_name]).name
+      city_code = invitation[:city_code]
+      referent_ids = invitation[:referent_ids]
+      motif_hash = find_or_initialize_motif_hash(motif_name)
+      motif_hash[:city_codes] << city_code unless motif_hash[:city_codes].include?(city_code) || city_code.nil?
+      return if motif_hash[:referent_ids].include?(referent_ids) || referent_ids.nil?
+
+      motif_hash[:referent_ids] << referent_ids
+    end
+
+    def find_or_initialize_motif_hash(motif_name)
+      motif_hash = @unavailable_motifs.find { |m| m[:motif_name] == motif_name }
+      return motif_hash if motif_hash.present?
+
+      motif_hash = { motif_name: motif_name, city_codes: [], referent_ids: [] }
+      @unavailable_motifs << motif_hash
+      motif_hash
+    end
+  end
+end

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -51,12 +51,8 @@ module Invitations
       referent_ids = invitation[:referent_ids]
       category_params_group = find_or_initialize_category_params_group(motif_category_name)
       category_params_group[:invitations_counter] += 1
-      unless category_params_group[:city_codes].include?(city_code) || city_code.nil?
-        category_params_group[:city_codes] << city_code
-      end
-      return if category_params_group[:referent_ids].include?(referent_ids) || referent_ids.nil?
-
-      category_params_group[:referent_ids] += referent_ids
+      category_params_group[:city_codes].add(city_code) if city_code.present?
+      category_params_group[:referent_ids].merge(referent_ids) if referent_ids.present?
     end
 
     def find_or_initialize_category_params_group(motif_category_name)
@@ -65,7 +61,7 @@ module Invitations
       end
       return category_params_group if category_params_group.present?
 
-      category_params_group = { motif_category_name: motif_category_name, city_codes: [], referent_ids: [],
+      category_params_group = { motif_category_name: motif_category_name, city_codes: Set.new, referent_ids: Set.new,
                                 invitations_counter: 0 }
       @grouped_invitation_params_by_category << category_params_group
       category_params_group

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -17,26 +17,15 @@ module Invitations
     def process_invitations
       return unless @organisation.invitations.valid.any?
 
-      grouped_invitations_params.each do |params|
+      invitations_params.each do |params|
         @invitations_params_without_creneau << params unless creneau_available?(params)
       end
     end
 
-    def grouped_invitations_params
-      default_token = @organisation.invitations.valid.first.rdv_solidarites_token
+    def invitations_params
       @organisation.invitations.valid.select("DISTINCT ON (rdv_context_id) *").to_a.map do |invitation|
-        map_invitation_params(invitation, default_token)
-      end.uniq
-    end
-
-    def map_invitation_params(invitation, default_token)
-      # We keep uniq relevant params only (for creneaux search in rdvs) to reduce the number of calls to the RDVSP API
-      # We take the first invitation token as default token
-      # We keep the original invitation_token only if the invitation has a referent_id
-      invitation.link_params.symbolize_keys.merge(
-        invitation_token:
-          invitation.link_params["referent_ids"].nil? ? default_token : invitation.link_params["invitation_token"]
-      ).except(:latitude, :longitude, :address)
+        invitation.link_params.symbolize_keys
+      end
     end
 
     def creneau_available?(params)
@@ -55,6 +44,7 @@ module Invitations
       city_code = invitation[:city_code]
       referent_ids = invitation[:referent_ids]
       category_params_group = find_or_initialize_category_params_group(motif_category_name)
+      category_params_group[:invations_counter] += 1
       unless category_params_group[:city_codes].include?(city_code) || city_code.nil?
         category_params_group[:city_codes] << city_code
       end
@@ -69,7 +59,8 @@ module Invitations
       end
       return category_params_group if category_params_group.present?
 
-      category_params_group = { motif_category_name: motif_category_name, city_codes: [], referent_ids: [] }
+      category_params_group = { motif_category_name: motif_category_name, city_codes: [], referent_ids: [],
+                                invations_counter: 0 }
       @grouped_invitation_params_by_category << category_params_group
       category_params_group
     end

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -2,7 +2,8 @@ module Invitations
   class VerifyOrganisationCreneauxAvailability < BaseService
     def initialize(organisation_id:)
       @organisation = Organisation.find(organisation_id)
-      # Quid de l'agent connecté pour la vérication des créneaux disponibles ? utiliser un super agent ? comme proposé ici https://github.com/betagouv/rdv-insertion/blob/2526b569660d32ad1d15fcdc7b8e4c596125f8b4/app/helpers/admin_jobs_agent_helper.rb
+      # Quid de l'agent connecté pour la vérication des créneaux disponibles ? utiliser un super agent ? comme proposé
+      # ici : https://github.com/betagouv/rdv-insertion/pull/1449/commits/2526b569660d32ad1d15fcdc7b8e4c596125f8b4
       Current.agent = @organisation.agents.first
       @invitations_params_without_creneau = []
       @unavailable_motifs = []
@@ -31,10 +32,11 @@ module Invitations
     end
 
     def map_invitation_params(invitation, default_token)
-      # We take the first invitation token as default token
-      # this mapping is done to reduce the number of calls to the RDVSP API.
+      # We map relevant params only (for creneaux search in rdvs) is done to reduce the number of calls to the RDVSP API
       # The uniq filter on this mapping reduce the number of average calls to the API by /3
+      # We take the first invitation token as default token
       # We keep the original invitation_token only if the invitation has a referent_id
+      token = invitation.link_params["referent_ids"].nil? ? default_token : invitation.link_params["invitation_token"]
       {
         organisation_ids: invitation.link_params["organisation_ids"],
         referent_ids: invitation.link_params["referent_ids"],
@@ -42,7 +44,7 @@ module Invitations
         departement: invitation.link_params["departement"],
         city_code: invitation.link_params["city_code"],
         street_ban_id: invitation.link_params["street_ban_id"],
-        invitation_token: invitation.link_params["referent_ids"].nil? ? default_token : invitation.link_params["invitation_token"]
+        invitation_token: token
       }
     end
 

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -9,7 +9,7 @@ module Invitations
 
     def call
       process_invitations
-      process_invitations_params_without_creneau
+      result.unavailable_params_motifs = process_invitations_params_without_creneau
     end
 
     private
@@ -47,7 +47,6 @@ module Invitations
       @invitations_params_without_creneau.each do |invitation_params|
         group_invitation_params_by_category(invitation_params)
       end
-
       @grouped_invitation_params_by_category
     end
 

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -1,29 +1,29 @@
 <h1>Créneaux de rendez-vous complets</h1>
 
 <p>Madame, Monsieur,</p>
-<% if @motifs.one? %>
+<% if @grouped_invitation_params_by_category.one? %>
   <p>Vous avez invité des personnes à prendre rdv sur la catégorie suivante :</p>
 <% else %>
   <p>Vous avez invité des personnes à prendre rdv sur les catégories suivantes :</p>
 <% end %>
 
-<% @motifs.each do |motif| %>
+<% @grouped_invitation_params_by_category.each do |grouped_invitation_params| %>
   <div class="margined-paragraph">
-    <p><span class="font-weight-bold"><%= motif[:motif_category_name] %></span></p>
-    <p>Nombre d'invitations concernnées : <span class="font-weight-bold"><%= motif[:invations_counter] %></span></p>
-    <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.*") if motif[:city_codes].present? %>
-    <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: motif[:referent_ids]).map(&:email).join(", ")}.") if motif[:referent_ids].present? %>
-    <%= tag.p tag.span("*Les codes postaux n'ont de l'importance que si la sectorisation n'est pas activée.", style: "color: grey;") if motif[:city_codes].present? %>
+    <p><span class="font-weight-bold"><%= grouped_invitation_params[:motif_category_name] %></span></p>
+    <p>Nombre d'invitations concernnées : <span class="font-weight-bold"><%= grouped_invitation_params[:invitations_counter] %></span></p>
+    <%= tag.p ("Les codes postaux concernés sont : #{grouped_invitation_params[:city_codes].join(", ")}.*") if grouped_invitation_params[:city_codes].present? %>
+    <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: grouped_invitation_params[:referent_ids]).map(&:email).join(", ")}.") if grouped_invitation_params[:referent_ids].present? %>
+    <%= tag.p tag.span("*Les codes postaux n'ont de l'importance que si la sectorisation est activée.", style: "color: grey;") if grouped_invitation_params[:city_codes].present? %>
   </div>
 <% end %>
 
 <p>Les créneaux que vous aviez ouverts dans l'organisation <span class="font-weight-bold"><%= @organisation.name %></span> sont dorénavant complets.</p>
 <p>Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels ou collectifs, afin que les usagers puissent bien prendre rendez-vous.</p>
+<p>Vous pouvez également allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
 
 <p class="btn-wrapper">
-  <%= link_to "Ouvrir des créneaux", "https://www.rdv-solidarites.fr/agents/sign_in", class: "btn btn-primary", target: :blank %>
+  <%= link_to @organisation.rdv_solidarites_url, class: "btn btn-primary", target: "_blank" do %>
 </p>
 
-<p>Vous pouvez également allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
 <p>Vous remerciant par avance et restant à votre disposition,</p>
 <p>L'équipe RDV-Insertion</p>

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -1,8 +1,8 @@
 <h1>Madame, Monsieur,</h1>
 <% @motifs.each do |motif| %>
-  <p>Vous avez ouvert des motifs de RDV sur la catégorie <%= motif[:motif_name] %>. et vous avez invité des personnes à prendre rendez-vous.</p>
+  <p>Vous avez ouvert des motifs de RDV sur la catégorie <b><%= motif[:motif_name] %></b> et vous avez invité des personnes à prendre rendez-vous.</p>
   <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.") if motif[:city_codes].present? %>
-  <%= tag.p ("Les référents concernés sont, #{motif[:referent_ids].join(", ")}.") if motif[:referent_ids].present? %>
+  <%= tag.p ("Les référents concernés sont : #{motif[:referent_ids].join(", ")}.") if motif[:referent_ids].present? %>
 <% end %>
 <p>Hors, il n'y a désormais plus assez de créneaux de libre pour ces RDV dans l'organisation <%= @organisation.name %>. Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels (ou bien créer de nouveau RDV collectifs) et à faire passer le message à vos équipes, afin que les usagers puissent bien prendre rendez-vous. Une autre solution est d'allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
 <p>Vous remerciant par avance et restant à votre disposition,</p>

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -1,6 +1,7 @@
 <h1>Madame, Monsieur,</h1>
 <% @motifs.each do |motif| %>
   <p>Vous avez ouvert des motifs de RDV sur la catégorie <b><%= motif[:motif_category_name] %></b> et vous avez invité des personnes à prendre rendez-vous.</p>
+  <p>Nombre d'invitations concernnées : <b><%= motif[:invations_counter] %></b></p>
   <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.") if motif[:city_codes].present? %>
   <p>Les codes postaux n'ont de l'importance que si la sectorisation n'est pas activée.</p>
   <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: motif[:referent_ids]).map(&:email).join(", ")}.") if motif[:referent_ids].present? %>

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -22,7 +22,9 @@
 <p>Vous pouvez également allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
 
 <p class="btn-wrapper">
-  <%= link_to @organisation.rdv_solidarites_url, class: "btn btn-primary", target: "_blank" do %>
+  <%= link_to @organisation.rdv_solidarites_url, target: "_blank", class:"btn btn-primary" do %>
+    Ouvrir des créneaux
+  <% end %>
 </p>
 
 <p>Vous remerciant par avance et restant à votre disposition,</p>

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -1,9 +1,10 @@
 <h1>Madame, Monsieur,</h1>
 <% @motifs.each do |motif| %>
-  <p>Vous avez ouvert des motifs de RDV sur la catégorie <b><%= motif[:motif_name] %></b> et vous avez invité des personnes à prendre rendez-vous.</p>
+  <p>Vous avez ouvert des motifs de RDV sur la catégorie <b><%= motif[:motif_category_name] %></b> et vous avez invité des personnes à prendre rendez-vous.</p>
   <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.") if motif[:city_codes].present? %>
-  <%= tag.p ("Les référents concernés sont : #{motif[:referent_ids].join(", ")}.") if motif[:referent_ids].present? %>
+  <p>Les codes postaux n'ont de l'importance que si la sectorisation n'est pas activée.</p>
+  <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: motif[:referent_ids]).map(&:email).join(", ")}.") if motif[:referent_ids].present? %>
 <% end %>
-<p>Hors, il n'y a désormais plus assez de créneaux de libre pour ces RDV dans l'organisation <%= @organisation.name %>. Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels (ou bien créer de nouveau RDV collectifs) et à faire passer le message à vos équipes, afin que les usagers puissent bien prendre rendez-vous. Une autre solution est d'allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
+<p>Hors, il n'y a désormais plus assez de créneaux de libre pour ces RDV dans l'organisation <b><%= @organisation.name %></b>. Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels (ou bien créer de nouveau RDV collectifs) et à faire passer le message à vos équipes, afin que les usagers puissent bien prendre rendez-vous. Une autre solution est d'allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
 <p>Vous remerciant par avance et restant à votre disposition,</p>
 <p>L'équipe RDV-Insertion</p>

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -1,0 +1,9 @@
+<h1>Madame, Monsieur,</h1>
+<% @motifs.each do |motif| %>
+  <p>Vous avez ouvert des motifs de RDV sur la catégorie <%= motif[:motif_name] %>. et vous avez invité des personnes à prendre rendez-vous.</p>
+  <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.") if motif[:city_codes].present? %>
+  <%= tag.p ("Les référents concernés sont, #{motif[:referent_ids].join(", ")}.") if motif[:referent_ids].present? %>
+<% end %>
+<p>Hors, il n'y a désormais plus assez de créneaux de libre pour ces RDV dans l'organisation <%= @organisation.name %>. Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels (ou bien créer de nouveau RDV collectifs) et à faire passer le message à vos équipes, afin que les usagers puissent bien prendre rendez-vous. Une autre solution est d'allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
+<p>Vous remerciant par avance et restant à votre disposition,</p>
+<p>L'équipe RDV-Insertion</p>

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -1,11 +1,29 @@
-<h1>Madame, Monsieur,</h1>
-<% @motifs.each do |motif| %>
-  <p>Vous avez ouvert des motifs de RDV sur la catégorie <b><%= motif[:motif_category_name] %></b> et vous avez invité des personnes à prendre rendez-vous.</p>
-  <p>Nombre d'invitations concernnées : <b><%= motif[:invations_counter] %></b></p>
-  <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.") if motif[:city_codes].present? %>
-  <p>Les codes postaux n'ont de l'importance que si la sectorisation n'est pas activée.</p>
-  <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: motif[:referent_ids]).map(&:email).join(", ")}.") if motif[:referent_ids].present? %>
+<h1>Créneaux de rendez-vous complets</h1>
+
+<p>Madame, Monsieur,</p>
+<% if @motifs.one? %>
+  <p>Vous avez invité des personnes à prendre rdv sur la catégorie suivante :</p>
+<% else %>
+  <p>Vous avez invité des personnes à prendre rdv sur les catégories suivantes :</p>
 <% end %>
-<p>Hors, il n'y a désormais plus assez de créneaux de libre pour ces RDV dans l'organisation <b><%= @organisation.name %></b>. Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels (ou bien créer de nouveau RDV collectifs) et à faire passer le message à vos équipes, afin que les usagers puissent bien prendre rendez-vous. Une autre solution est d'allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
+
+<% @motifs.each do |motif| %>
+  <div class="margined-paragraph">
+    <p><span class="font-weight-bold"><%= motif[:motif_category_name] %></span></p>
+    <p>Nombre d'invitations concernnées : <span class="font-weight-bold"><%= motif[:invations_counter] %></span></p>
+    <%= tag.p ("Les codes postaux concernés sont : #{motif[:city_codes].join(", ")}.*") if motif[:city_codes].present? %>
+    <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: motif[:referent_ids]).map(&:email).join(", ")}.") if motif[:referent_ids].present? %>
+    <%= tag.p tag.span("*Les codes postaux n'ont de l'importance que si la sectorisation n'est pas activée.", style: "color: grey;") if motif[:city_codes].present? %>
+  </div>
+<% end %>
+
+<p>Les créneaux que vous aviez ouverts dans l'organisation <span class="font-weight-bold"><%= @organisation.name %></span> sont dorénavant complets.</p>
+<p>Nous vous invitons donc à créer de nouvelles plages d'ouverture pour des RDV individuels ou collectifs, afin que les usagers puissent bien prendre rendez-vous.</p>
+
+<p class="btn-wrapper">
+  <%= link_to "Ouvrir des créneaux", "https://www.rdv-solidarites.fr/agents/sign_in", class: "btn btn-primary", target: :blank %>
+</p>
+
+<p>Vous pouvez également allonger le délai de visibilité de votre motif (n'hésitez pas à nous contacter par retour de mail si vous avez besoin d'aide pour le faire).</p>
 <p>Vous remerciant par avance et restant à votre disposition,</p>
 <p>L'équipe RDV-Insertion</p>

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -25,3 +25,6 @@ send_convocation_reminders_job:
 designate_on_watch_developer_job:
   cron: "0 10 * * mon" # we designate an on watch developer once a week, monday at 10:00
   class: "DesignateOnWatchDeveloperJob"
+send_creneau_availability_alert_job:
+  cron: "0 01 * * *" # we verify organisations creneaux availability once a day, at 01:00
+  class: "SendCreneauAvailabilityAlertJob"

--- a/spec/jobs/notify_unavailable_creneau_job_spec.rb
+++ b/spec/jobs/notify_unavailable_creneau_job_spec.rb
@@ -7,33 +7,34 @@ describe NotifyUnavailableCreneauJob do
   let!(:organisation_id) { organisation.id }
   let!(:organisation_mail) { instance_double("organisation_mail") }
 
-  let!(:unavailable_params_motifs) do
+  let!(:grouped_invitation_params_by_category) do
     [
       {
         motif_category_name: "RSA Orientation",
         city_code: %w[75001 75002 75003],
         referent_ids: ["1"],
-        invations_counter: 3
+        invitations_counter: 3
       },
       {
         motif_category_name: "RSA Accompagnement",
         city_code: ["75004"],
         referent_ids: [],
-        invations_counter: 1
+        invitations_counter: 1
       }
     ]
   end
 
   before do
     allow(Invitations::VerifyOrganisationCreneauxAvailability).to receive(:call)
-      .and_return(OpenStruct.new(success?: true, unavailable_params_motifs: unavailable_params_motifs))
+      .and_return(OpenStruct.new(success?: true,
+                                 grouped_invitation_params_by_category: grouped_invitation_params_by_category))
     allow(OrganisationMailer).to receive(:creneau_unavailable).and_return(organisation_mail)
     allow(organisation_mail).to receive(:deliver_now)
   end
 
   it "send the email" do
     expect(OrganisationMailer).to receive(:creneau_unavailable)
-      .with(organisation: organisation, motifs: unavailable_params_motifs)
+      .with(organisation: organisation, grouped_invitation_params_by_category: grouped_invitation_params_by_category)
     expect(organisation_mail).to receive(:deliver_now)
     subject
   end
@@ -43,16 +44,16 @@ describe NotifyUnavailableCreneauJob do
       .with(
         "Créneaux indisponibles pour l'organisation #{organisation.name}" \
         " (Département: #{organisation.department.name})\n" \
-        " Motif : #{unavailable_params_motifs[0][:motif_category_name]}\n" \
-        " Nombre d'invitations concernées : #{unavailable_params_motifs[0][:invations_counter]}\n" \
-        " Référents (rdvsp_ids) : #{unavailable_params_motifs[0][:referent_ids].join(', ')}\n" \
+        " Motif : #{grouped_invitation_params_by_category[0][:motif_category_name]}\n" \
+        " Nombre d'invitations concernées : #{grouped_invitation_params_by_category[0][:invitations_counter]}\n" \
+        " Référents (rdvsp_ids) : #{grouped_invitation_params_by_category[0][:referent_ids].join(', ')}\n" \
       )
     expect(MattermostClient).to receive(:send_to_notif_channel)
       .with(
         "Créneaux indisponibles pour l'organisation #{organisation.name}" \
         " (Département: #{organisation.department.name})\n" \
-        " Motif : #{unavailable_params_motifs[1][:motif_category_name]}\n" \
-        " Nombre d'invitations concernées : #{unavailable_params_motifs[1][:invations_counter]}\n" \
+        " Motif : #{grouped_invitation_params_by_category[1][:motif_category_name]}\n" \
+        " Nombre d'invitations concernées : #{grouped_invitation_params_by_category[1][:invitations_counter]}\n" \
       )
     subject
   end

--- a/spec/jobs/notify_unavailable_creneau_job_spec.rb
+++ b/spec/jobs/notify_unavailable_creneau_job_spec.rb
@@ -1,0 +1,59 @@
+describe NotifyUnavailableCreneauJob do
+  subject do
+    described_class.new.perform(organisation_id)
+  end
+
+  let!(:organisation) { create(:organisation) }
+  let!(:organisation_id) { organisation.id }
+  let!(:organisation_mail) { instance_double("organisation_mail") }
+
+  let!(:unavailable_params_motifs) do
+    [
+      {
+        motif_category_name: "RSA Orientation",
+        city_code: %w[75001 75002 75003],
+        referent_ids: ["1"],
+        invations_counter: 3
+      },
+      {
+        motif_category_name: "RSA Accompagnement",
+        city_code: ["75004"],
+        referent_ids: [],
+        invations_counter: 1
+      }
+    ]
+  end
+
+  before do
+    allow(Invitations::VerifyOrganisationCreneauxAvailability).to receive(:call)
+      .and_return(OpenStruct.new(success?: true, unavailable_params_motifs: unavailable_params_motifs))
+    allow(OrganisationMailer).to receive(:creneau_unavailable).and_return(organisation_mail)
+    allow(organisation_mail).to receive(:deliver_now)
+  end
+
+  it "send the email" do
+    expect(OrganisationMailer).to receive(:creneau_unavailable)
+      .with(organisation: organisation, motifs: unavailable_params_motifs)
+    expect(organisation_mail).to receive(:deliver_now)
+    subject
+  end
+
+  it "send the message to mattermost" do
+    expect(MattermostClient).to receive(:send_to_notif_channel)
+      .with(
+        "Créneaux indisponibles pour l'organisation #{organisation.name}" \
+        " (Département: #{organisation.department.name})\n" \
+        " Motif : #{unavailable_params_motifs[0][:motif_category_name]}\n" \
+        " Nombre d'invitations concernées : #{unavailable_params_motifs[0][:invations_counter]}\n" \
+        " Référents (rdvsp_ids) : #{unavailable_params_motifs[0][:referent_ids].join(', ')}\n" \
+      )
+    expect(MattermostClient).to receive(:send_to_notif_channel)
+      .with(
+        "Créneaux indisponibles pour l'organisation #{organisation.name}" \
+        " (Département: #{organisation.department.name})\n" \
+        " Motif : #{unavailable_params_motifs[1][:motif_category_name]}\n" \
+        " Nombre d'invitations concernées : #{unavailable_params_motifs[1][:invations_counter]}\n" \
+      )
+    subject
+  end
+end

--- a/spec/jobs/send_creneau_availability_alert_job_spec.rb
+++ b/spec/jobs/send_creneau_availability_alert_job_spec.rb
@@ -1,0 +1,23 @@
+describe SendCreneauAvailabilityAlertJob do
+  subject { described_class.new.perform }
+
+  describe "#perform" do
+    let(:departments_count) { 3 }
+    let(:organisations_per_department) { 2 }
+
+    before do
+      departments_count.times do
+        department = create(:department)
+        organisations_per_department.times do
+          create(:organisation, department: department)
+        end
+      end
+    end
+
+    it "perform NotifyUnavailableCreneauJob for all organisations" do
+      expect(NotifyUnavailableCreneauJob).to receive(:perform_async).exactly(6).times
+
+      subject
+    end
+  end
+end

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -1,0 +1,107 @@
+describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
+  subject do
+    described_class.call(organisation_id: organisation.id)
+  end
+
+  include_context "with all existing categories"
+
+  let!(:organisation) { create(:organisation) }
+  let!(:organisation_id) { organisation.id }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:rdv_context_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
+  let!(:rdv_context_with_creneau) { create(:rdv_context, motif_category: category_rsa_accompagnement_sociopro) }
+  let!(:rdv_context_with_referent_without_creneau) do
+    create(:rdv_context, motif_category: category_rsa_accompagnement_social)
+  end
+
+  let!(:invitation_with_no_creneau) do
+    create(
+      :invitation,
+      organisations: [organisation],
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=IGNORED&city_code=12255&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
+      format: "email",
+      rdv_context: rdv_context_without_creneau
+    )
+  end
+  let!(:invitation_with_no_creneau_relevant_params) do
+    { :city_code => "12255",
+      :departement => "12",
+      :invitation_token => "some_token",
+      :motif_category_short_name => "rsa_orientation",
+      :organisation_ids => [organisation_id.to_s],
+      :street_ban_id => "12255_0070" }
+  end
+  let!(:invitation_with_creneau) do
+    create(
+      :invitation,
+      organisations: [organisation],
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=IGNORED&city_code=12000&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000",
+      format: "email",
+      rdv_context: rdv_context_with_creneau
+    )
+  end
+  let!(:invitation_with_creneau_relevant_params) do
+    { :city_code => "12000",
+      :departement => "12",
+      :invitation_token => "some_token",
+      :motif_category_short_name => "rsa_accompagnement_sociopro",
+      :organisation_ids => [organisation_id.to_s],
+      :street_ban_id => "12000_0000" }
+  end
+  let!(:invitation_with_referent_without_creneau) do
+    create(
+      :invitation,
+      organisations: [organisation],
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=IGNORED&city_code=10000&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000&referent_ids%5B%5D=1",
+      format: "email",
+      rdv_context: rdv_context_with_referent_without_creneau
+    )
+  end
+  let!(:invitation_with_referent_without_creneau_relevant_params) do
+    { :city_code => "10000",
+      :departement => "12",
+      :invitation_token => "UIXR0X2T",
+      :motif_category_short_name => "rsa_accompagnement_sociopro",
+      :organisation_ids => [organisation_id.to_s],
+      :street_ban_id => "12000_0000",
+      :referent_ids => ["1"] }
+  end
+
+  describe "#call" do
+    before do
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
+        .with(link_params: invitation_with_creneau_relevant_params)
+        .and_return(OpenStruct.new(success?: true, creneau_availability: true))
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
+        .with(link_params: invitation_with_no_creneau_relevant_params)
+        .and_return(OpenStruct.new(success?: true, creneau_availability: false))
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
+        .with(link_params: invitation_with_referent_without_creneau_relevant_params)
+        .and_return(OpenStruct.new(success?: true, creneau_availability: false))
+    end
+
+    it "is a success" do
+      is_a_success
+    end
+
+    context "with results" do
+      let!(:result) { subject }
+
+      it "returns the right result" do
+        excepted_result = [
+          {
+            motif_category_name: "RSA orientation",
+            city_codes: ["12255"],
+            referent_ids: []
+          },
+          {
+            motif_category_name: "RSA accompagnement socio-pro",
+            city_codes: ["10000"],
+            referent_ids: [["1"]]
+          }
+        ]
+        expect(result.unavailable_params_motifs).to eq(excepted_result)
+      end
+    end
+  end
+end

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -9,6 +9,7 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
   let!(:organisation_id) { organisation.id }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:rdv_context_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
+  let!(:rdv_context2_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
   let!(:rdv_context_with_creneau) { create(:rdv_context, motif_category: category_rsa_accompagnement_sociopro) }
   let!(:rdv_context_with_referent_without_creneau) do
     create(:rdv_context, motif_category: category_rsa_accompagnement_social)
@@ -18,15 +19,38 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
     create(
       :invitation,
       organisations: [organisation],
-      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=IGNORED&city_code=12255&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1RueTest&city_code=12255&departement=12&invitation_token=XIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
       format: "email",
       rdv_context: rdv_context_without_creneau
     )
   end
   let!(:invitation_with_no_creneau_relevant_params) do
     { :city_code => "12255",
+      :address => "1RueTest",
+      :latitude => "44.0",
+      :longitude => "2.0",
       :departement => "12",
-      :invitation_token => "some_token",
+      :invitation_token => "XIXR0X2T",
+      :motif_category_short_name => "rsa_orientation",
+      :organisation_ids => [organisation_id.to_s],
+      :street_ban_id => "12255_0070" }
+  end
+  let!(:invitation2_with_no_creneau) do
+    create(
+      :invitation,
+      organisations: [organisation],
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1bRueTest&city_code=12255&departement=12&invitation_token=ZIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
+      format: "email",
+      rdv_context: rdv_context2_without_creneau
+    )
+  end
+  let!(:invitation2_with_no_creneau_relevant_params) do
+    { :city_code => "12255",
+      :address => "1bRueTest",
+      :latitude => "44.0",
+      :longitude => "2.0",
+      :departement => "12",
+      :invitation_token => "ZIXR0X2T",
       :motif_category_short_name => "rsa_orientation",
       :organisation_ids => [organisation_id.to_s],
       :street_ban_id => "12255_0070" }
@@ -35,15 +59,18 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
     create(
       :invitation,
       organisations: [organisation],
-      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=IGNORED&city_code=12000&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000",
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=2RueTest&city_code=12000&departement=12&invitation_token=JIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000",
       format: "email",
       rdv_context: rdv_context_with_creneau
     )
   end
   let!(:invitation_with_creneau_relevant_params) do
     { :city_code => "12000",
+      :address => "2RueTest",
+      :latitude => "44.0",
+      :longitude => "2.0",
       :departement => "12",
-      :invitation_token => "some_token",
+      :invitation_token => "JIXR0X2T",
       :motif_category_short_name => "rsa_accompagnement_sociopro",
       :organisation_ids => [organisation_id.to_s],
       :street_ban_id => "12000_0000" }
@@ -52,13 +79,16 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
     create(
       :invitation,
       organisations: [organisation],
-      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=IGNORED&city_code=10000&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000&referent_ids%5B%5D=1",
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=3RueTest&city_code=10000&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000&referent_ids%5B%5D=1",
       format: "email",
       rdv_context: rdv_context_with_referent_without_creneau
     )
   end
   let!(:invitation_with_referent_without_creneau_relevant_params) do
     { :city_code => "10000",
+      :address => "3RueTest",
+      :latitude => "44.0",
+      :longitude => "2.0",
       :departement => "12",
       :invitation_token => "UIXR0X2T",
       :motif_category_short_name => "rsa_accompagnement_sociopro",
@@ -70,13 +100,16 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
   describe "#call" do
     before do
       allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
+        .with(link_params: invitation_with_referent_without_creneau_relevant_params)
+        .and_return(OpenStruct.new(success?: true, creneau_availability: false))
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
         .with(link_params: invitation_with_creneau_relevant_params)
         .and_return(OpenStruct.new(success?: true, creneau_availability: true))
       allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
-        .with(link_params: invitation_with_no_creneau_relevant_params)
+        .with(link_params: invitation2_with_no_creneau_relevant_params)
         .and_return(OpenStruct.new(success?: true, creneau_availability: false))
       allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
-        .with(link_params: invitation_with_referent_without_creneau_relevant_params)
+        .with(link_params: invitation_with_no_creneau_relevant_params)
         .and_return(OpenStruct.new(success?: true, creneau_availability: false))
     end
 
@@ -92,12 +125,14 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
           {
             motif_category_name: "RSA orientation",
             city_codes: ["12255"],
-            referent_ids: []
+            referent_ids: [],
+            invations_counter: 2
           },
           {
             motif_category_name: "RSA accompagnement socio-pro",
             city_codes: ["10000"],
-            referent_ids: [["1"]]
+            referent_ids: [["1"]],
+            invations_counter: 1
           }
         ]
         expect(result.unavailable_params_motifs).to eq(excepted_result)

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -126,16 +126,16 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
             motif_category_name: "RSA orientation",
             city_codes: ["12255"],
             referent_ids: [],
-            invations_counter: 2
+            invitations_counter: 2
           },
           {
             motif_category_name: "RSA accompagnement socio-pro",
             city_codes: ["10000"],
-            referent_ids: [["1"]],
-            invations_counter: 1
+            referent_ids: ["1"],
+            invitations_counter: 1
           }
         ]
-        expect(result.unavailable_params_motifs).to eq(excepted_result)
+        expect(result.grouped_invitation_params_by_category).to eq(excepted_result)
       end
     end
   end

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -124,14 +124,14 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
         excepted_result = [
           {
             motif_category_name: "RSA orientation",
-            city_codes: ["12255"],
-            referent_ids: [],
+            city_codes: Set.new(["12255"]),
+            referent_ids: Set.new([]),
             invitations_counter: 2
           },
           {
             motif_category_name: "RSA accompagnement socio-pro",
-            city_codes: ["10000"],
-            referent_ids: ["1"],
+            city_codes: Set.new(["10000"]),
+            referent_ids: Set.new(["1"]),
             invitations_counter: 1
           }
         ]


### PR DESCRIPTION
Close : https://github.com/betagouv/rdv-insertion/issues/1540

Toutes les nuits à 1h on vérifie si toutes les invitations actuellement valides ont un créneau dispo dans RDVSP.
Le job prend environ 6 minutes pour 1000 invitations. (A améliorer dans le futur quand le nb d'invitations à vérifier  grossira)
Ci dessous plusieurs exemples du mail mis en place que les organisations recevront dans le cas ou une ou plusieurs catégorie de motif n'a pas de créneau. Merci Sam pour la structure du mail :)

Une seule catégorie d'invitation sans code postal précisé dans les liens d'invitations :
<img width="1117" alt="Capture d’écran 2024-01-30 à 15 26 03" src="https://github.com/betagouv/rdv-insertion/assets/28594222/f98e7b09-1f60-4310-a203-824b4ee7644d">
Une seule catégorie d'invitation avec des codes postaux précisés dans les liens d'invitations :
<img width="1117" alt="Capture d’écran 2024-01-30 à 15 17 58" src="https://github.com/betagouv/rdv-insertion/assets/28594222/4005f00f-df49-4bc4-a04a-5545067cdaa0">
Plusieurs catégories d'invitations sont concernés avec des codes postaux et des agents référents :
<img width="1117" alt="Capture d’écran 2024-01-30 à 15 13 25" src="https://github.com/betagouv/rdv-insertion/assets/28594222/708a336f-09eb-4a32-9296-d86bfc4ada37">


