### PR TITLE
fix(admin): display services errors in super admin

### DIFF
--- a/app/controllers/concerns/super_admins/redirect_and_render_concern.rb
+++ b/app/controllers/concerns/super_admins/redirect_and_render_concern.rb
@@ -2,7 +2,7 @@ module SuperAdmins
   module RedirectAndRenderConcern
     # the methods below are extracted from the default actions in Administrate::ApplicationController
     # they are redefined here to allow an easier customization of the actions
-    def redirect_after_succesful_action(action_name, record)
+    def redirect_after_succesful_action(record)
       redirect_to(
         send("after_resource_#{action_name}d_path", record),
         notice: translate_with_resource("#{action_name}.success")

--- a/app/controllers/concerns/super_admins/redirect_and_render_concern.rb
+++ b/app/controllers/concerns/super_admins/redirect_and_render_concern.rb
@@ -2,9 +2,9 @@ module SuperAdmins
   module RedirectAndRenderConcern
     # the methods below are extracted from the default actions in Administrate::ApplicationController
     # they are redefined here to allow an easier customization of the actions
-    def redirect_after_succesful_action(action_name)
+    def redirect_after_succesful_action(action_name, record)
       redirect_to(
-        send("after_resource_#{action_name}d_path", resource),
+        send("after_resource_#{action_name}d_path", record),
         notice: translate_with_resource("#{action_name}.success")
       )
     end

--- a/app/controllers/concerns/super_admins/redirect_and_render_concern.rb
+++ b/app/controllers/concerns/super_admins/redirect_and_render_concern.rb
@@ -2,29 +2,17 @@ module SuperAdmins
   module RedirectAndRenderConcern
     # the methods below are extracted from the default actions in Administrate::ApplicationController
     # they are redefined here to allow an easier customization of the actions
-    def redirect_after_successful_create
+    def redirect_after_succesful_action(action_name)
       redirect_to(
-        after_resource_created_path(resource),
-        notice: translate_with_resource("create.success")
+        send("after_resource_#{action_name}d_path", resource),
+        notice: translate_with_resource("#{action_name}.success")
       )
     end
 
-    def redirect_after_successful_update
-      redirect_to(
-        after_resource_updated_path(requested_resource),
-        notice: translate_with_resource("update.success")
-      )
-    end
-
-    def render_new
-      render :new, locals: {
-        page: Administrate::Page::Form.new(dashboard, resource)
-      }, status: :unprocessable_entity
-    end
-
-    def render_edit
-      render :edit, locals: {
-        page: Administrate::Page::Form.new(dashboard, requested_resource)
+    def render_page(page, record, errors)
+      flash[:error] = errors.join("<br/>")
+      render page, locals: {
+        page: Administrate::Page::Form.new(dashboard, record)
       }, status: :unprocessable_entity
     end
   end

--- a/app/controllers/super_admins/motif_categories_controller.rb
+++ b/app/controllers/super_admins/motif_categories_controller.rb
@@ -5,7 +5,11 @@ module SuperAdmins
     #
 
     def create
-      create_motif_category.success? ? redirect_after_successful_create : render_new
+      if create_motif_category.success?
+        redirect_after_succesful_action("create")
+      else
+        render_page(:new, resource, create_motif_category.errors)
+      end
     end
 
     private

--- a/app/controllers/super_admins/motif_categories_controller.rb
+++ b/app/controllers/super_admins/motif_categories_controller.rb
@@ -6,7 +6,7 @@ module SuperAdmins
 
     def create
       if create_motif_category.success?
-        redirect_after_succesful_action("create")
+        redirect_after_succesful_action("create", resource)
       else
         render_page(:new, resource, create_motif_category.errors)
       end

--- a/app/controllers/super_admins/motif_categories_controller.rb
+++ b/app/controllers/super_admins/motif_categories_controller.rb
@@ -6,7 +6,7 @@ module SuperAdmins
 
     def create
       if create_motif_category.success?
-        redirect_after_succesful_action("create", resource)
+        redirect_after_succesful_action(resource)
       else
         render_page(:new, resource, create_motif_category.errors)
       end

--- a/app/controllers/super_admins/organisations_controller.rb
+++ b/app/controllers/super_admins/organisations_controller.rb
@@ -6,7 +6,7 @@ module SuperAdmins
 
     def create
       if create_organisation.success?
-        redirect_after_succesful_action("create")
+        redirect_after_succesful_action("create", resource)
       else
         render_page(:new, resource, create_organisation.errors)
       end
@@ -15,7 +15,7 @@ module SuperAdmins
     def update
       requested_resource.assign_attributes(**resource_params)
       if update_organisation.success?
-        redirect_after_succesful_action("update")
+        redirect_after_succesful_action("update", requested_resource)
       else
         render_page(:edit, requested_resource, update_organisation.errors)
       end

--- a/app/controllers/super_admins/organisations_controller.rb
+++ b/app/controllers/super_admins/organisations_controller.rb
@@ -5,12 +5,20 @@ module SuperAdmins
     #
 
     def create
-      create_organisation.success? ? redirect_after_successful_create : render_new
+      if create_organisation.success?
+        redirect_after_succesful_action("create")
+      else
+        render_page(:new, resource, create_organisation.errors)
+      end
     end
 
     def update
       requested_resource.assign_attributes(**resource_params)
-      update_organisation.success? ? redirect_after_successful_update : render_edit
+      if update_organisation.success?
+        redirect_after_succesful_action("update")
+      else
+        render_page(:edit, requested_resource, update_organisation.errors)
+      end
     end
 
     private

--- a/app/controllers/super_admins/organisations_controller.rb
+++ b/app/controllers/super_admins/organisations_controller.rb
@@ -6,7 +6,7 @@ module SuperAdmins
 
     def create
       if create_organisation.success?
-        redirect_after_succesful_action("create", resource)
+        redirect_after_succesful_action(resource)
       else
         render_page(:new, resource, create_organisation.errors)
       end
@@ -15,7 +15,7 @@ module SuperAdmins
     def update
       requested_resource.assign_attributes(**resource_params)
       if update_organisation.success?
-        redirect_after_succesful_action("update", requested_resource)
+        redirect_after_succesful_action(requested_resource)
       else
         render_page(:edit, requested_resource, update_organisation.errors)
       end

--- a/app/controllers/super_admins/users_controller.rb
+++ b/app/controllers/super_admins/users_controller.rb
@@ -7,7 +7,7 @@ module SuperAdmins
     def update
       requested_resource.assign_attributes(**formatted_attributes)
       if save_user.success?
-        redirect_after_succesful_action("update", requested_resource)
+        redirect_after_succesful_action(requested_resource)
       else
         render_page(:edit, requested_resource, save_user.errors)
       end

--- a/app/controllers/super_admins/users_controller.rb
+++ b/app/controllers/super_admins/users_controller.rb
@@ -6,7 +6,11 @@ module SuperAdmins
 
     def update
       requested_resource.assign_attributes(**formatted_attributes)
-      save_user.success? ? redirect_after_successful_update : render_edit
+      if save_user.success?
+        redirect_after_succesful_action("update")
+      else
+        render_page(:edit, requested_resource, save_user.errors)
+      end
     end
 
     private

--- a/app/controllers/super_admins/users_controller.rb
+++ b/app/controllers/super_admins/users_controller.rb
@@ -7,7 +7,7 @@ module SuperAdmins
     def update
       requested_resource.assign_attributes(**formatted_attributes)
       if save_user.success?
-        redirect_after_succesful_action("update")
+        redirect_after_succesful_action("update", requested_resource)
       else
         render_page(:edit, requested_resource, save_user.errors)
       end


### PR DESCRIPTION
Lorsqu'une erreur n'était pas liée au modèle, elle n'était pas affichée sur le formulaire superadmin de new ou edit. Je fais en sorte que ce soit le cas.