### PR TITLE
fix(rgpd): destroy job name in schedule file

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -21,7 +21,7 @@ send_convocation_reminders_job:
   class: "SendConvocationRemindersJob"
 destroy_old_ressources_job:
   cron: "0 0 * * *" # we destroy inactive users and useless ressources once a day, at 00:00
-  class: "DestroyInactiveUsersJob"
+  class: "DestroyOldRessourcesJob"
 designate_on_watch_developer_job:
   cron: "0 10 * * mon" # we designate an on watch developer once a week, monday at 10:00
   class: "DesignateOnWatchDeveloperJob"


### PR DESCRIPTION
Petite coquille dans le nom du job rgpd dans le schedule file. Cette PR résout ce problème