### PR TITLE
feat(stats): add # of users with Rdv taken or seen stat

### DIFF
--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -13,6 +13,6 @@ module StatsHelper
   end
 
   def exclude_current_month(stat)
-    stat.delete_if { |key, _value| key == Time.zone.now.strftime("%m/%Y") }
+    stat&.delete_if { |key, _value| key == Time.zone.now.strftime("%m/%Y") }
   end
 end

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -36,6 +36,12 @@ class Stat < ApplicationRecord
     participations
   end
 
+  def user_ids_with_rdv_sample
+    participations_sample.where(status: %w[seen unknown])
+                         .select(:user_id)
+                         .distinct
+  end
+
   # We filter participations to keep only convocations
   def participations_with_notifications_sample
     participations_sample.joins(:notifications).select("participations.id, participations.status").distinct

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -13,21 +13,26 @@ module Stats
 
       def global_stats
         @global_stats ||= {
-          users_count: users_count,
-          rdvs_count: rdvs_count,
-          sent_invitations_count: sent_invitations_count,
-          rate_of_no_show_for_invitations: rate_of_no_show_for_invitations,
-          rate_of_no_show_for_convocations: rate_of_no_show_for_convocations,
-          average_time_between_invitation_and_rdv_in_days: average_time_between_invitation_and_rdv_in_days,
-          rate_of_users_oriented_in_less_than_30_days: rate_of_users_oriented_in_less_than_30_days,
-          rate_of_users_oriented: rate_of_users_oriented,
-          rate_of_autonomous_users: rate_of_autonomous_users,
-          agents_count: agents_count
+          users_count:,
+          users_with_rdv_count:,
+          rdvs_count:,
+          sent_invitations_count:,
+          rate_of_no_show_for_invitations:,
+          rate_of_no_show_for_convocations:,
+          average_time_between_invitation_and_rdv_in_days:,
+          rate_of_users_oriented_in_less_than_30_days:,
+          rate_of_users_oriented:,
+          rate_of_autonomous_users:,
+          agents_count:
         }
       end
 
       def users_count
         @stat.all_users.count
+      end
+
+      def users_with_rdv_count
+        @stat.user_ids_with_rdv_sample.count
       end
 
       def rdvs_count

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -15,6 +15,7 @@ module Stats
       def stats_for_focused_month
         @stats_for_focused_month ||= {
           users_count_grouped_by_month: users_count_for_focused_month,
+          users_with_rdv_count_grouped_by_month: users_with_rdv_count_grouped_by_month,
           rdvs_count_grouped_by_month: rdvs_count_for_focused_month,
           sent_invitations_count_grouped_by_month: sent_invitations_count_for_focused_month,
           rate_of_no_show_for_invitations_grouped_by_month: rate_of_no_show_for_invitations_for_focused_month,
@@ -31,6 +32,10 @@ module Stats
 
       def users_count_for_focused_month
         created_during_focused_month(@stat.all_users).count
+      end
+
+      def users_with_rdv_count_grouped_by_month
+        created_during_focused_month(@stat.user_ids_with_rdv_sample).count
       end
 
       def rdvs_count_for_focused_month

--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -55,6 +55,11 @@
         <p class="highlight-stat margin-left">d'usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
         <%= line_chart exclude_current_month(@stat.rate_of_users_oriented_grouped_by_month), title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
       </div>
+      <div class="col-12 col-md-6 px-5 pb-5">
+        <p class="highlight-stat big margin-left"><%= @stat.users_with_rdv_count&.round %></p>
+        <p class="highlight-stat margin-left">usagers <strong>ont été mis en relation via rdv-insertion</strong></p>
+        <%= line_chart exclude_current_month(@stat.users_with_rdv_count_grouped_by_month), title: "Nombre d'usagers ayant eu un rendez-vous par mois", colors: ["#083b66"] %>
+      </div>
     </div>
     <div class="row d-flex justify-content-center flex-wrap">
       <div class="col-12 col-md-6 px-5 pb-5 d-flex flex-column justify-content-center align-items-center">

--- a/db/migrate/20240124101508_add_columns_to_stats.rb
+++ b/db/migrate/20240124101508_add_columns_to_stats.rb
@@ -1,0 +1,6 @@
+class AddColumnsToStats < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stats, :users_with_rdv_count, :integer
+    add_column :stats, :users_with_rdv_count_grouped_by_month, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_22_104935) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_24_101508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -377,6 +377,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_22_104935) do
     t.json "rate_of_no_show_for_invitations_grouped_by_month"
     t.float "rate_of_users_oriented"
     t.json "rate_of_users_oriented_grouped_by_month"
+    t.integer "users_with_rdv_count"
+    t.json "users_with_rdv_count_grouped_by_month"
     t.index ["statable_type", "statable_id"], name: "index_stats_on_statable"
   end
 

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -22,6 +22,8 @@ describe Stats::GlobalStats::Compute, type: :service do
     before do
       allow(stat).to receive(:all_users)
         .and_return(User.where(id: [user1, user2]))
+      allow(stat).to receive(:user_ids_with_rdv_sample)
+        .and_return(Participation.where(id: [participation1, participation2]).select(:user_id))
       allow(stat).to receive(:all_participations)
         .and_return(Participation.where(id: [participation1, participation2]))
       allow(stat).to receive(:invitations_sample)
@@ -64,6 +66,7 @@ describe Stats::GlobalStats::Compute, type: :service do
 
     it "renders all the stats" do
       expect(subject.stat_attributes).to include(:users_count)
+      expect(subject.stat_attributes).to include(:users_with_rdv_count)
       expect(subject.stat_attributes).to include(:rdvs_count)
       expect(subject.stat_attributes).to include(:sent_invitations_count)
       expect(subject.stat_attributes).to include(:rate_of_no_show_for_invitations)
@@ -77,6 +80,7 @@ describe Stats::GlobalStats::Compute, type: :service do
 
     it "renders the stats in the right format" do
       expect(subject.stat_attributes[:users_count]).to be_a(Integer)
+      expect(subject.stat_attributes[:users_with_rdv_count]).to be_a(Integer)
       expect(subject.stat_attributes[:rdvs_count]).to be_a(Integer)
       expect(subject.stat_attributes[:sent_invitations_count]).to be_a(Integer)
       expect(subject.stat_attributes[:rate_of_no_show_for_invitations]).to be_a(Float)
@@ -91,6 +95,11 @@ describe Stats::GlobalStats::Compute, type: :service do
     it "counts the users" do
       expect(stat).to receive(:all_users)
       expect(subject.stat_attributes[:users_count]).to eq(2)
+    end
+
+    it "counts the users with rdv" do
+      expect(stat).to receive(:user_ids_with_rdv_sample)
+      expect(subject.stat_attributes[:users_with_rdv_count]).to eq(2)
     end
 
     it "counts the rdvs" do

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -28,6 +28,8 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
     before do
       allow(stat).to receive(:all_users)
         .and_return(User.where(id: [user1, user2]))
+      allow(stat).to receive(:user_ids_with_rdv_sample)
+        .and_return(Participation.where(id: [participation1, participation2]).select(:user_id))
       allow(stat).to receive(:all_participations)
         .and_return(Participation.where(id: [participation1, participation2]))
       allow(stat).to receive(:invitations_sample)
@@ -68,6 +70,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
 
     it "renders all the stats" do
       expect(subject.stats_values).to include(:users_count_grouped_by_month)
+      expect(subject.stats_values).to include(:users_with_rdv_count_grouped_by_month)
       expect(subject.stats_values).to include(:rdvs_count_grouped_by_month)
       expect(subject.stats_values).to include(:sent_invitations_count_grouped_by_month)
       expect(subject.stats_values).to include(:rate_of_no_show_for_invitations_grouped_by_month)
@@ -80,6 +83,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
 
     it "renders the stats in the right format" do
       expect(subject.stats_values[:users_count_grouped_by_month]).to be_a(Integer)
+      expect(subject.stats_values[:users_with_rdv_count_grouped_by_month]).to be_a(Integer)
       expect(subject.stats_values[:rdvs_count_grouped_by_month]).to be_a(Integer)
       expect(subject.stats_values[:sent_invitations_count_grouped_by_month]).to be_a(Integer)
       expect(subject.stats_values[:rate_of_no_show_for_invitations_grouped_by_month]).to be_a(Integer)
@@ -94,6 +98,11 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
       expect(stat).to receive(:all_users)
       # user1 is ok, user2 is not created in the focused month
       expect(subject.stats_values[:users_count_grouped_by_month]).to eq(1)
+    end
+
+    it "counts the users with rdv for the focused month" do
+      expect(stat).to receive(:user_ids_with_rdv_sample)
+      expect(subject.stats_values[:users_with_rdv_count_grouped_by_month]).to eq(1)
     end
 
     it "counts the rdvs for the focused month" do


### PR DESCRIPTION
Dans cette PR j'ajoute la nouvelle statistique demandée par le GIP : le nombre d'utilisateurs mis en relation via l'outil

Cela correspond au nombre d'utilisateurs ayant eu au moins un rendez-vous "honoré" ou "pris"

https://github.com/betagouv/rdv-insertion/issues/1565