### PR TITLE
refactor(notifications): Change user notifiable conditions

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,7 +121,7 @@ class User < ApplicationRecord
   end
 
   def notifiable?
-    sent_invitations.any? && title.present?
+    title.present?
   end
 
   private

--- a/spec/features/agent_can_generate_convocation_pdf_spec.rb
+++ b/spec/features/agent_can_generate_convocation_pdf_spec.rb
@@ -2,8 +2,7 @@ describe "Agents can generate convocation pdf", js: true do
   let!(:agent) { create(:agent, organisations: [organisation]) }
   let!(:organisation) { create(:organisation) }
   let!(:user) do
-    create(:user, organisations: [organisation], title: "monsieur",
-                  invitations: [create(:invitation, sent_at: 1.week.ago)])
+    create(:user, organisations: [organisation], title: "monsieur")
   end
   let!(:motif_category) { create(:motif_category) }
   let!(:motif) do
@@ -96,18 +95,6 @@ describe "Agents can generate convocation pdf", js: true do
 
   context "when the user has no title" do
     before { user.update! title: nil }
-
-    it "cannot generate a pdf" do
-      visit organisation_user_rdv_contexts_path(organisation_id: organisation.id, user_id: user.id)
-
-      expect(page).not_to have_button "Courrier"
-    end
-  end
-
-  context "when the user has no sent invitations" do
-    let!(:user) do
-      create(:user, organisations: [organisation], title: "monsieur")
-    end
 
     it "cannot generate a pdf" do
       visit organisation_user_rdv_contexts_path(organisation_id: organisation.id, user_id: user.id)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -234,22 +234,13 @@ describe User do
     subject { user.notifiable? }
 
     let!(:user) { create(:user, title: "monsieur") }
-    let!(:invitation) { create(:invitation, sent_at: 2.years.ago, user:) }
 
-    it "is notifiable if the title is present and the user has been invited" do
+    it "is notifiable if the title is present" do
       expect(subject).to eq(true)
     end
 
     context "when the user has no title" do
       let!(:user) { create(:user, title: nil) }
-
-      it "is not notifiable" do
-        expect(subject).to eq(false)
-      end
-    end
-
-    context "when the user has no invitations" do
-      let!(:invitation) { nil }
 
       it "is not notifiable" do
         expect(subject).to eq(false)


### PR DESCRIPTION
On ne vérifie plus si un usager a reçu des invitations au préalable pour savoir si on lui envoie une convocation ou non: https://mattermost.incubateur.net/betagouv/pl/bcfp95yau78bdnm7rkdadysowo