### PR TITLE
refactor(orientations): Allow orientation without agents

### DIFF
--- a/app/models/orientation.rb
+++ b/app/models/orientation.rb
@@ -1,7 +1,7 @@
 class Orientation < ApplicationRecord
   belongs_to :user
   belongs_to :organisation
-  belongs_to :agent
+  belongs_to :agent, optional: true
 
   validates :starts_at, :orientation_type, presence: true
 

--- a/app/views/orientations/_orientation.html.erb
+++ b/app/views/orientations/_orientation.html.erb
@@ -10,7 +10,11 @@
     Orientation <strong><%= I18n.t("activerecord.attributes.orientation.orientation_types.#{orientation.orientation_type}") %></strong>
   </div>
   <div class="w-100">Structure <strong><%= orientation.organisation.name %></strong></div>
-  <div class="w-100">Référent unique <strong><%= orientation.agent.to_s %></strong></div>
+  <% if orientation.agent_id? %>
+    <div class="w-100">Référent unique <strong><%= orientation.agent.to_s %></strong></div>
+  <% else %>
+    <div class="w-100">Référent unique <em>non renseigné</em></div>
+  <% end %>
   <div class="w-100 text-end">
     <%= link_to edit_user_orientation_path(id: orientation.id, user_id: orientation.user_id), data: { turbo_frame: 'remote_modal' } do %>
       <i class="fas fa-pencil-alt text-dark-blue"></i>

--- a/app/views/orientations/_orientation_form.html.erb
+++ b/app/views/orientations/_orientation_form.html.erb
@@ -57,7 +57,7 @@
     %>
   </div>
   <div class="form-group text-center">
-    <label><%= Orientation.human_attribute_name(:agent) %></label>
+    <label><%= Orientation.human_attribute_name(:agent) %><span class="fw-lighter"> (optionel)</p></label>
     <%=
       form.input(
         :agent_id,

--- a/db/migrate/20240129172812_remove_not_null_constraint_from_agents_in_orientations.rb
+++ b/db/migrate/20240129172812_remove_not_null_constraint_from_agents_in_orientations.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromAgentsInOrientations < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :orientations, :agent_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_24_101508) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_29_172812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -283,7 +283,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_24_101508) do
   create_table "orientations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "organisation_id", null: false
-    t.bigint "agent_id", null: false
+    t.bigint "agent_id"
     t.integer "orientation_type"
     t.date "starts_at"
     t.date "ends_at"

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -63,6 +63,7 @@ describe "Agents can add user orientation", js: true do
       expect(page).to have_content("Structure CD 26")
       expect(page).to have_content("Référent unique Kad Merad")
 
+      # orientation without agent
       click_button("Ajouter une orientation")
 
       page.select "Professionnelle", from: "orientation_orientation_type"
@@ -74,8 +75,6 @@ describe "Agents can add user orientation", js: true do
       page.select "Asso 26", from: "orientation_organisation_id"
       expect(page).to have_select("orientation_agent_id", with_options: other_organisation_agents.map(&:to_s))
 
-      page.select "Jean-Paul Rouve", from: "orientation_agent_id"
-
       click_button "Enregistrer"
 
       expect(page).to have_content("Du 03/07/2023 au 03/10/2023")
@@ -86,7 +85,7 @@ describe "Agents can add user orientation", js: true do
       expect(page).to have_content("Du 03/10/2023 à aujourd'hui")
       expect(page).to have_content("Orientation Professionnelle")
       expect(page).to have_content("Structure Asso 26")
-      expect(page).to have_content("Référent unique Jean-Paul Rouve")
+      expect(page).to have_content("Référent unique non renseigné")
     end
   end
 end


### PR DESCRIPTION
Lié à #1703 

Je fais en sorte que l'ajout d'un référent unique lorsqu'on renseigne un référent unique soit optionnel. 

## Previews 📷 

<img width="433" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/7602809/deab0d7d-48b3-41de-8c06-4a768965096c">

<img width="1518" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/7602809/b60c46fa-fd5e-46f1-838b-3eda74fef648">

