### PR TITLE
fix(tags): add policy restriction

### DIFF
--- a/app/controllers/tag_assignations_controller.rb
+++ b/app/controllers/tag_assignations_controller.rb
@@ -16,7 +16,7 @@ class TagAssignationsController < ApplicationController
   private
 
   def set_available_tags
-    @available_tags = department_level? ? department.tags.uniq : organisation.tags.uniq
+    @available_tags = department_level? ? department.tags.uniq : organisation.tags
   end
 
   def set_user

--- a/app/controllers/tag_assignations_controller.rb
+++ b/app/controllers/tag_assignations_controller.rb
@@ -16,7 +16,7 @@ class TagAssignationsController < ApplicationController
   private
 
   def set_available_tags
-    @available_tags = department_level? ? department.tags.uniq : organisation.tags
+    @available_tags = department_level? ? policy_scope(department.tags).distinct : organisation.tags
   end
 
   def set_user

--- a/app/controllers/tag_assignations_controller.rb
+++ b/app/controllers/tag_assignations_controller.rb
@@ -16,7 +16,7 @@ class TagAssignationsController < ApplicationController
   private
 
   def set_available_tags
-    @available_tags = department_level? ? department.tags : organisation.tags
+    @available_tags = department_level? ? department.tags.uniq : organisation.tags.uniq
   end
 
   def set_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -175,12 +175,11 @@ class UsersController < ApplicationController
   end
 
   def set_filterable_tags
-    @tags = (@organisation || @department).tags.order(:value).distinct
+    @tags = policy_scope((@organisation || @department).tags).order(:value).distinct
   end
 
   def set_user_tags
-    @tags = @user
-            .tags
+    @tags = policy_scope(@user.tags)
             .joins(:organisations)
             .where(organisations: department_level? ? @department.organisations : @organisation)
             .order(:value)

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -1,0 +1,7 @@
+class TagPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.joins(:organisations).where(organisations: pundit_user.organisations)
+    end
+  end
+end


### PR DESCRIPTION
Ajout d'une policy sur les tags pour n'afficher que ceux des organisations de l'agent connecté. 
Correction aussi d'un problème de distinct, la liste des tags affichés n'étaient pas dé-dupliquée. 
J'ai vérifié en prod il n'y a pas de doublon dans la table Tag c'était bien juste un distinct à ajouter pour la jointure

Fix https://github.com/betagouv/rdv-insertion/issues/1655
Fix https://github.com/betagouv/rdv-insertion/issues/1658