### PR TITLE
fix(view): Rewrite error messages on user invitation

### DIFF
--- a/app/controllers/rdv_contexts_controller.rb
+++ b/app/controllers/rdv_contexts_controller.rb
@@ -6,7 +6,7 @@ class RdvContextsController < ApplicationController
   def create
     @rdv_context = RdvContext.new(**rdv_context_params)
     authorize @rdv_context
-    if create_rdv_context.success?
+    if save_rdv_context.success?
       respond_to do |format|
         # html is used for the show page
         format.html do
@@ -15,7 +15,7 @@ class RdvContextsController < ApplicationController
         format.turbo_stream { replace_new_button_cell_by_rdv_context_status_cell } # turbo is used for index page
       end
     else
-      turbo_stream_display_error_modal(create_rdv_context.errors)
+      turbo_stream_display_error_modal(save_rdv_context.errors)
     end
   end
 
@@ -29,8 +29,8 @@ class RdvContextsController < ApplicationController
     @user = policy_scope(User).preload(:archives).find(rdv_context_params[:user_id])
   end
 
-  def create_rdv_context
-    @create_rdv_context ||= RdvContexts::Create.call(rdv_context: @rdv_context, user: @user)
+  def save_rdv_context
+    @save_rdv_context ||= RdvContexts::Save.call(rdv_context: @rdv_context)
   end
 
   def replace_new_button_cell_by_rdv_context_status_cell

--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -52,7 +52,7 @@ class InviteUser < BaseService
   def check_if_invitation_should_be_sent!
     return unless invitation_already_sent_today? && !@invitation.format_postal?
 
-    fail!("Une invitation #{@invitation.format} a déjà été envoyée aujourd'hui à cet utilisateur")
+    fail!("Une invitation #{@invitation.format} a déjà été envoyée aujourd'hui à cet usager")
   end
 
   def invitation_already_sent_today?

--- a/app/services/rdv_contexts/save.rb
+++ b/app/services/rdv_contexts/save.rb
@@ -10,6 +10,8 @@ module RdvContexts
       result.rdv_context = @rdv_context
     end
 
+    private
+
     def check_if_user_has_an_organisation_for_this_motif_category!
       return if user.organisations_motif_category_ids.include?(@rdv_context.motif_category_id)
 

--- a/app/services/rdv_contexts/save.rb
+++ b/app/services/rdv_contexts/save.rb
@@ -1,8 +1,7 @@
 module RdvContexts
-  class Create < BaseService
-    def initialize(rdv_context:, user:)
+  class Save < BaseService
+    def initialize(rdv_context:)
       @rdv_context = rdv_context
-      @user = user
     end
 
     def call
@@ -12,9 +11,11 @@ module RdvContexts
     end
 
     def check_if_user_has_an_organisation_for_this_motif_category!
-      return if @user.organisations_motif_category_ids.include?(@rdv_context.motif_category_id)
+      return if user.organisations_motif_category_ids.include?(@rdv_context.motif_category_id)
 
-      fail!("L'utilisateur n'appartient à aucune organisation gérant cette catégorie de motifs")
+      fail!("L'usager n'appartient à aucune organisation gérant cette catégorie de motifs")
     end
+
+    def user = @rdv_context.user
   end
 end

--- a/spec/services/invite_user_spec.rb
+++ b/spec/services/invite_user_spec.rb
@@ -179,7 +179,7 @@ describe InviteUser, type: :service do
         end
 
         it "stores the error" do
-          expect(subject.errors).to eq(["Une invitation sms a déjà été envoyée aujourd'hui à cet utilisateur"])
+          expect(subject.errors).to eq(["Une invitation sms a déjà été envoyée aujourd'hui à cet usager"])
         end
 
         context "when the format is postal" do

--- a/spec/services/rdv_contexts/save_spec.rb
+++ b/spec/services/rdv_contexts/save_spec.rb
@@ -1,5 +1,5 @@
-describe RdvContexts::Create do
-  subject { described_class.call(rdv_context:, user:) }
+describe RdvContexts::Save do
+  subject { described_class.call(rdv_context:) }
 
   let!(:user) { create(:user, organisations: [organisation]) }
   let!(:organisation) { create(:organisation, configurations: [configuration]) }
@@ -22,7 +22,7 @@ describe RdvContexts::Create do
 
       it "stores the error" do
         expect(subject.errors).to eq(
-          ["L'utilisateur n'appartient à aucune organisation gérant cette catégorie de motifs"]
+          ["L'usager n'appartient à aucune organisation gérant cette catégorie de motifs"]
         )
       end
     end


### PR DESCRIPTION
En testant en demo je me suis rendu compte que les erreurs prises en compte dans #1699 faisaient référence à des "utilisateurs" et non des usagers . 
Je change ça ici et j'en profite pour renommer le service `RdvContexts::Create` en `RdvContexts::Save`.