### PR TITLE
fix(view): Align file upload button

### DIFF
--- a/app/javascript/react/components/FileHandler.jsx
+++ b/app/javascript/react/components/FileHandler.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
 import PendingMessage from "./PendingMessage";
 
@@ -16,6 +16,7 @@ export default function FileHandler({
   uploadMessage = DEFAULT_UPLOAD_MESSAGE,
 }) {
   const [isPending, setIsPending] = useState(false);
+  const fileInputRef = useRef(null);
 
   const handleFiles = async (filesToHandle) => {
     await Promise.all([...filesToHandle].map(async (file) => handleFile(file)));
@@ -32,20 +33,27 @@ export default function FileHandler({
 
   return (
     <>
-      {/* <p className={styles.description}> */}
       <p className="text-center">
         {isPending && <PendingMessage message={pendingMessage} fileSize={fileSize} />}
         {!isPending && uploadMessage}
       </p>
-      <div className="file-input-div">
+      <div className="text-center">
         <input
           type="file"
           name={name}
-          className="text-white"
+          className="d-none"
           accept={accept}
           onChange={handleUploads}
           multiple={multiple}
+          ref={fileInputRef}
         />
+        <button
+          type="button"
+          className="btn btn-blue"
+          onClick={() => fileInputRef.current.click()}
+        >
+          Choisir un fichier
+        </button>
       </div>
     </>
   );

--- a/app/javascript/react/components/FileHandler.jsx
+++ b/app/javascript/react/components/FileHandler.jsx
@@ -16,7 +16,7 @@ export default function FileHandler({
   uploadMessage = DEFAULT_UPLOAD_MESSAGE,
 }) {
   const [isPending, setIsPending] = useState(false);
-  const fileInputRef = useRef(null);
+  const hiddenFileInput = useRef(null);
 
   const handleFiles = async (filesToHandle) => {
     await Promise.all([...filesToHandle].map(async (file) => handleFile(file)));
@@ -45,12 +45,12 @@ export default function FileHandler({
           accept={accept}
           onChange={handleUploads}
           multiple={multiple}
-          ref={fileInputRef}
+          ref={hiddenFileInput}
         />
         <button
           type="button"
           className="btn btn-blue"
-          onClick={() => fileInputRef.current.click()}
+          onClick={() => hiddenFileInput.current.click()}
         >
           Choisir un fichier
         </button>

--- a/app/javascript/react/lib/uploadFile.js
+++ b/app/javascript/react/lib/uploadFile.js
@@ -14,6 +14,7 @@ export default async function uploadFile(file, sheetName, columnNames) {
       const missingColumnNames = checkColumnNames(columnNames, parameterizeArray(headerNames));
       if (missingColumnNames.length > 0) {
         displayMissingColumnsWarning(missingColumnNames);
+        resolve();
       } else {
         let rows = XLSX.utils.sheet_to_row_object_array(sheet);
         rows = rows.map((row) => parameterizeObjectKeys(row));

--- a/app/javascript/react/pages/UsersUpload.jsx
+++ b/app/javascript/react/pages/UsersUpload.jsx
@@ -55,6 +55,8 @@ const UsersUpload = observer(
       users.isDepartmentLevel = isDepartmentLevel;
 
       const rows = await uploadFile(file, sheetName, columnNames);
+      if (typeof(rows) === "undefined") return;
+
       rows.forEach((row) => {
         const user = new User(
           {

--- a/app/javascript/stylesheets/components/_button.scss
+++ b/app/javascript/stylesheets/components/_button.scss
@@ -68,10 +68,6 @@ button, input[type="button"] {
   padding: 0.25rem;
 }
 
-.file-input-div {
-  width: 87px;
-}
-
 .text-array__remove {
   cursor: pointer;
 }

--- a/spec/features/agent_can_archive_and_unarchive_user_spec.rb
+++ b/spec/features/agent_can_archive_and_unarchive_user_spec.rb
@@ -109,7 +109,7 @@ describe "Agents can archive and unarchive user", js: true do
     it "can unarchive an user" do
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_button "Rouvrir le dossier"
       expect(page).to have_content "Dossier archivé"
@@ -133,7 +133,7 @@ describe "Agents can archive and unarchive user", js: true do
       it "does not show the user as archived" do
         visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-        attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+        attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
         expect(page).to have_button "Inviter par SMS"
 

--- a/spec/features/agent_can_create_carnet_spec.rb
+++ b/spec/features/agent_can_create_carnet_spec.rb
@@ -70,7 +70,7 @@ describe "Agents can create a carnet", js: true do
 
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_button("Créer carnet", disabled: true)
       click_button("Créer compte")

--- a/spec/features/agent_can_edit_uploaded_user_list_spec.rb
+++ b/spec/features/agent_can_edit_uploaded_user_list_spec.rb
@@ -41,7 +41,7 @@ describe "Agents can upload user list", js: true do
     it "can edit an user infos" do
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       click_button("Créer compte")
 

--- a/spec/features/agent_can_update_contacts_info_spec.rb
+++ b/spec/features/agent_can_update_contacts_info_spec.rb
@@ -24,14 +24,14 @@ describe "Agents can update contact info with caf file", js: true do
     it "updates the user list with the info from the csv file" do
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_content("hernan@crespo.com")
       expect(page).to have_content("0620022002")
 
       click_button("Enrichir avec des données de contacts CNAF")
 
-      attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
+      attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"), make_visible: true)
 
       expect(page).to have_content("hernan.crespo@hotmail.fr")
       expect(page).to have_content("698943255")
@@ -65,7 +65,7 @@ describe "Agents can update contact info with caf file", js: true do
     it "can update the user attributes with the info from the csv file one by one" do
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_content("hernan@crespo.com")
       expect(page).to have_content("+33620022002")
@@ -75,7 +75,7 @@ describe "Agents can update contact info with caf file", js: true do
 
       click_button("Enrichir avec des données de contacts CNAF")
 
-      attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
+      attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"), make_visible: true)
 
       expect(page).to have_content("Nouvelles données trouvées pour Hernan Crespo")
       expect(page).to have_content("hernan.crespo@hotmail.fr")
@@ -104,14 +104,14 @@ describe "Agents can update contact info with caf file", js: true do
     it "can update all the attributes at once" do
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_content("hernan@crespo.com")
       expect(page).to have_content("+33620022002")
 
       click_button("Enrichir avec des données de contacts CNAF")
 
-      attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
+      attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"), make_visible: true)
 
       expect(page).to have_content("Nouvelles données trouvées pour Hernan Crespo")
       expect(page).to have_content("hernan.crespo@hotmail.fr")
@@ -142,13 +142,14 @@ describe "Agents can update contact info with caf file", js: true do
       it "does not show the update button" do
         visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-        attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+        attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
         expect(page).to have_content("hernan@crespo.com")
         expect(page).to have_content("Ajouter à cette organisation")
         click_button("Enrichir avec des données de contacts CNAF")
 
-        attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
+        attach_file("contact-file-upload", Rails.root.join("spec/fixtures/fichier_contact_test.csv"),
+                    make_visible: true)
 
         expect(page).not_to have_content("Nouvelles données trouvées pour Hernan Crespo")
       end

--- a/spec/features/agent_can_upload_user_list_spec.rb
+++ b/spec/features/agent_can_upload_user_list_spec.rb
@@ -46,7 +46,7 @@ describe "Agents can upload user list", js: true do
 
       ### Upload
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_content("Civilité")
       expect(page).to have_content("M")
@@ -120,7 +120,7 @@ describe "Agents can upload user list", js: true do
 
       visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_css("i.fas.fa-link")
       expect(page).not_to have_button("Créer compte")
@@ -156,7 +156,8 @@ describe "Agents can upload user list", js: true do
 
             expect(page).to have_content("Choisissez un fichier d'usagers")
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_button("Créer compte")
             expect(page).not_to have_content("Invitation SMS")
@@ -203,7 +204,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
 
@@ -231,7 +233,8 @@ describe "Agents can upload user list", js: true do
           it "can add the user to the org" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Ajouter à cette organisation")
 
@@ -269,7 +272,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -294,7 +298,8 @@ describe "Agents can upload user list", js: true do
             it "can add the user to the org" do
               visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                          make_visible: true)
 
               expect(page).to have_content("Ajouter à cette organisation")
 
@@ -340,7 +345,8 @@ describe "Agents can upload user list", js: true do
             it "fails to add the user to the org" do
               visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                          make_visible: true)
 
               expect(page).to have_content("Ajouter à cette organisation")
 
@@ -376,7 +382,8 @@ describe "Agents can upload user list", js: true do
           it "does not match the user" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Créer compte")
           end
@@ -396,7 +403,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -419,7 +427,8 @@ describe "Agents can upload user list", js: true do
             it "can add the user to the org" do
               visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                          make_visible: true)
 
               expect(page).to have_content("Ajouter à cette organisation")
 
@@ -456,7 +465,8 @@ describe "Agents can upload user list", js: true do
           it "does not match the user" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Créer compte")
           end
@@ -475,7 +485,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -497,7 +508,8 @@ describe "Agents can upload user list", js: true do
           it "can add the user to the org" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Ajouter à cette organisation")
 
@@ -534,7 +546,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -556,7 +569,8 @@ describe "Agents can upload user list", js: true do
           it "can add the user to the org" do
             visit new_organisation_upload_path(organisation, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Ajouter à cette organisation")
 
@@ -594,7 +608,7 @@ describe "Agents can upload user list", js: true do
 
       ### Upload
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_content("Civilité")
 
@@ -667,7 +681,7 @@ describe "Agents can upload user list", js: true do
 
       visit new_department_upload_path(department, configuration_id: configuration.id)
 
-      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+      attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"), make_visible: true)
 
       expect(page).to have_css("i.fas.fa-link")
       expect(page).not_to have_button("Créer compte")
@@ -683,7 +697,8 @@ describe "Agents can upload user list", js: true do
         it "can bulk create users" do
           visit new_department_upload_path(department, configuration_id: configuration.id)
 
-          attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+          attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                      make_visible: true)
 
           first('input[type="checkbox"]', visible: :visible).click
           click_button("Actions pour toute la sélection")
@@ -698,7 +713,8 @@ describe "Agents can upload user list", js: true do
         it "can bulk invite" do
           visit new_department_upload_path(department, configuration_id: configuration.id)
 
-          attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+          attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                      make_visible: true)
 
           first('input[type="checkbox"]', visible: :visible).click
           click_button("Actions pour toute la sélection")
@@ -721,7 +737,8 @@ describe "Agents can upload user list", js: true do
           it "highlights users with errors" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             first('input[type="checkbox"]', visible: :visible).click
             click_button("Actions pour toute la sélection")
@@ -736,7 +753,8 @@ describe "Agents can upload user list", js: true do
           it "highlights users with errors" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test_invalid.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test_invalid.xlsx"),
+                        make_visible: true)
 
             first('input[type="checkbox"]', visible: :visible).click
             click_button("Actions pour toute la sélection")
@@ -774,7 +792,8 @@ describe "Agents can upload user list", js: true do
 
             expect(page).to have_content("Choisissez un fichier d'usagers")
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_button("Créer compte")
             expect(page).not_to have_content("Invitation SMS")
@@ -820,7 +839,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -842,7 +862,8 @@ describe "Agents can upload user list", js: true do
           it "can add the user to the org" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Ajouter à cette organisation")
 
@@ -880,7 +901,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -903,7 +925,8 @@ describe "Agents can upload user list", js: true do
             it "can add the user to the org" do
               visit new_department_upload_path(department, configuration_id: configuration.id)
 
-              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                          make_visible: true)
 
               expect(page).to have_content("Ajouter à cette organisation")
 
@@ -940,7 +963,8 @@ describe "Agents can upload user list", js: true do
           it "does not match the user" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Créer compte")
           end
@@ -960,7 +984,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -983,7 +1008,8 @@ describe "Agents can upload user list", js: true do
             it "can add the user to the org" do
               visit new_department_upload_path(department, configuration_id: configuration.id)
 
-              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+              attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                          make_visible: true)
 
               expect(page).to have_content("Ajouter à cette organisation")
 
@@ -1020,7 +1046,8 @@ describe "Agents can upload user list", js: true do
           it "does not match the user" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Créer compte")
           end
@@ -1039,7 +1066,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -1061,7 +1089,8 @@ describe "Agents can upload user list", js: true do
           it "can add the user to the org" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Ajouter à cette organisation")
 
@@ -1096,7 +1125,8 @@ describe "Agents can upload user list", js: true do
           it "does not match the user" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Créer compte")
           end
@@ -1115,7 +1145,8 @@ describe "Agents can upload user list", js: true do
           it "displays the link to the user page" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).not_to have_content("Créer compte")
             expect(page).to have_css("i.fas.fa-link")
@@ -1137,7 +1168,8 @@ describe "Agents can upload user list", js: true do
           it "can add the user to the org" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Ajouter à cette organisation")
 
@@ -1172,7 +1204,8 @@ describe "Agents can upload user list", js: true do
           it "does not match the user" do
             visit new_department_upload_path(department, configuration_id: configuration.id)
 
-            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"))
+            attach_file("users-list-upload", Rails.root.join("spec/fixtures/fichier_usager_test.xlsx"),
+                        make_visible: true)
 
             expect(page).to have_content("Créer compte")
           end


### PR DESCRIPTION
Lié à #1686 

Je réaligne le CTA "Choisir un fichier" en mettant un bouton identique aux CTA sur le reste de l'appli.
J'en profite pour corriger un bug: lorsque le fichier xls d'entrée n'avaient pas les bonnes colonnes, la modale d'erreur s'affichait mais lorsqu'on la fermait on voyait toujours le texte "Récupération des informations, merci de patienter". Ce n'est plus le cas.

## Preview 📷 

![image](https://github.com/betagouv/rdv-insertion/assets/7602809/38fb4970-be95-48d4-b9fa-366cc2b81516)
