### PR TITLE
ux(batch_actions_btn): change batch actions btn place and visibility

### DIFF
--- a/app/javascript/react/components/UserBatchActions.jsx
+++ b/app/javascript/react/components/UserBatchActions.jsx
@@ -32,61 +32,66 @@ export default observer(({ users }) => {
     }
   };
 
+  const isAnyUserSelected = users.list.some((user) => user.selected);
+
   return (
-    users.list.some((user) => user.selected) && (
-      <div style={{ marginRight: 20, position: "relative" }}>
-        <button type="button" className="btn btn-primary dropdown-toggle" onClick={toggle}>
-          Actions pour toute la sélection
+    <div style={{ marginRight: 20, position: "relative" }}>
+      <button
+        type="button"
+        className="btn btn-primary dropdown-toggle"
+        onClick={toggle}
+        disabled={!isAnyUserSelected}
+      >
+        Actions pour toute la sélection
+      </button>
+      <div className="dropdown-menu" id="batch-actions">
+        <button
+          type="button"
+          className="dropdown-item d-flex justify-content-between align-items-center"
+          onClick={createAccounts}
+        >
+          <span>Créer comptes</span>
+          <i className="fas fa-user" />
         </button>
-        <div className="dropdown-menu" id="batch-actions">
+        {users.canBeInvitedBy("email") && (
           <button
             type="button"
             className="dropdown-item d-flex justify-content-between align-items-center"
-            onClick={createAccounts}
+            onClick={() => inviteBy("email")}
           >
-            <span>Créer comptes</span>
-            <i className="fas fa-user" />
+            <span>Invitation par mail</span>
+            <i className="fas fa-inbox" />
           </button>
-          {users.canBeInvitedBy("email") && (
-            <button
-              type="button"
-              className="dropdown-item d-flex justify-content-between align-items-center"
-              onClick={() => inviteBy("email")}
-            >
-              <span>Invitation par mail</span>
-              <i className="fas fa-inbox" />
-            </button>
-          )}
-          {users.canBeInvitedBy("sms") && (
-            <button
-              type="button"
-              className="dropdown-item d-flex justify-content-between align-items-center"
-              onClick={() => inviteBy("sms")}
-            >
-              <span>Invitation par sms</span>
-              <i className="fas fa-comment" />
-            </button>
-          )}
-          {users.canBeInvitedBy("postal") && (
-            <button
-              type="button"
-              className="dropdown-item d-flex justify-content-between align-items-center"
-              onClick={() => inviteBy("postal")}
-            >
-              <span>Invitation par courrier &nbsp;</span>
-              <i className="fas fa-envelope" />
-            </button>
-          )}
+        )}
+        {users.canBeInvitedBy("sms") && (
           <button
             type="button"
             className="dropdown-item d-flex justify-content-between align-items-center"
-            onClick={deleteAll}
+            onClick={() => inviteBy("sms")}
           >
-            <span>Cacher la sélection</span>
-            <i className="fas fa-eye-slash" />
+            <span>Invitation par sms</span>
+            <i className="fas fa-comment" />
           </button>
-        </div>
+        )}
+        {users.canBeInvitedBy("postal") && (
+          <button
+            type="button"
+            className="dropdown-item d-flex justify-content-between align-items-center"
+            onClick={() => inviteBy("postal")}
+          >
+            <span>Invitation par courrier &nbsp;</span>
+            <i className="fas fa-envelope" />
+          </button>
+        )}
+        <button
+          type="button"
+          className="dropdown-item d-flex justify-content-between align-items-center"
+          onClick={deleteAll}
+        >
+          <span>Cacher la sélection</span>
+          <i className="fas fa-eye-slash" />
+        </button>
       </div>
-    )
-  );
+    </div>
+  )
 });

--- a/app/javascript/react/pages/UsersUpload.jsx
+++ b/app/javascript/react/pages/UsersUpload.jsx
@@ -217,32 +217,34 @@ const UsersUpload = observer(
           {users.list.length > 0 && (
             <>
               <div className="row my-1" style={{ height: 50 }}>
-                <div className="d-flex justify-content-end align-items-center">
+                <div className="d-flex justify-content-between align-items-center">
                   <UserBatchActions users={users} />
-                  <i className="fas fa-user" />
-                  {users.showReferentColumn ? (
-                    <Tippy content="Cacher colonne référent">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          users.showReferentColumn = false;
-                        }}
-                      >
-                        <i className="fas fa-minus" />
-                      </button>
-                    </Tippy>
-                  ) : (
-                    <Tippy content="Montrer colonne référent">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          users.showReferentColumn = true;
-                        }}
-                      >
-                        <i className="fas fa-plus" />
-                      </button>
-                    </Tippy>
-                  )}
+                  <div>
+                    <i className="fas fa-user" />
+                    {users.showReferentColumn ? (
+                      <Tippy content="Cacher colonne référent">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            users.showReferentColumn = false;
+                          }}
+                        >
+                          <i className="fas fa-minus" />
+                        </button>
+                      </Tippy>
+                    ) : (
+                      <Tippy content="Montrer colonne référent">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            users.showReferentColumn = true;
+                          }}
+                        >
+                          <i className="fas fa-plus" />
+                        </button>
+                      </Tippy>
+                    )}
+                  </div>
                 </div>
               </div>
             </>


### PR DESCRIPTION
close: https://github.com/betagouv/rdv-insertion/issues/1687

Ce n'était pas demandé dans le ticket mais vu en sprint planning. J'ai également mis le bouton à gauche de l'écran. Plus proche de la selection des usagers pour que ce soit plus cohérent. L'inconvénient c'est que le bouton pour afficher la colonne référent est un peu perdu tout seul à droite comme on peut le voir sur la vidéo. Je peux le mettre à gauche avec le bouton des actions. Qu'en penses tu @samanthaauffret ?

https://github.com/betagouv/rdv-insertion/assets/28594222/ff8b9959-3b0f-4243-9944-c6c2ef05a458

