### PR TITLE
fix(csv): display actual orientation date in user csv

### DIFF
--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -11,7 +11,6 @@ class Participation < ApplicationRecord
   has_many :rdv_context_invitations, through: :rdv_context, source: :invitations
 
   has_one :organisation, through: :rdv
-  has_one :motif_category, through: :rdv_context
   has_many :configurations, through: :organisation
 
   validates :status, presence: true

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -26,6 +26,7 @@ class Participation < ApplicationRecord
            :rdv_solidarites_url, :rdv_solidarites_rdv_id, :instruction_for_rdv,
            to: :rdv
   delegate :phone_number_is_mobile?, :email?, to: :user
+  delegate :motif_category, to: :rdv_context
 
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -11,6 +11,7 @@ class Participation < ApplicationRecord
   has_many :rdv_context_invitations, through: :rdv_context, source: :invitations
 
   has_one :organisation, through: :rdv
+  has_one :motif_category, through: :rdv_context
   has_many :configurations, through: :organisation
 
   validates :status, presence: true
@@ -25,7 +26,6 @@ class Participation < ApplicationRecord
            :rdv_solidarites_url, :rdv_solidarites_rdv_id, :instruction_for_rdv,
            to: :rdv
   delegate :phone_number_is_mobile?, :email?, to: :user
-  delegate :motif_category, to: :rdv_context
 
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -47,6 +47,10 @@ class Rdv < ApplicationRecord
 
   def self.jwt_payload_keys = [:id, :address, :starts_at]
 
+  def self.latest
+    all.to_a.max_by(&:starts_at)
+  end
+
   def rdv_solidarites_url
     "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/" \
       "#{organisation.rdv_solidarites_organisation_id}/rdvs/#{rdv_solidarites_rdv_id}"

--- a/app/policies/participation_policy.rb
+++ b/app/policies/participation_policy.rb
@@ -1,4 +1,10 @@
 class ParticipationPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.joins(:organisation).where(organisations: pundit_user.organisations)
+    end
+  end
+
   def create?
     pundit_user.organisation_ids.include?(record.organisation.id)
   end

--- a/app/policies/rdv_policy.rb
+++ b/app/policies/rdv_policy.rb
@@ -1,4 +1,10 @@
 class RdvPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.joins(:organisation).where(organisations: pundit_user.organisations)
+    end
+  end
+
   def show?
     record.organisation_id.in?(pundit_user.organisation_ids)
   end

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -198,7 +198,7 @@ module Exporters
                      .participations
                      .seen
                      .joins(:motif_category)
-                     .where("motif_categories.short_name ilike ?", "%orientation%")
+                     .where(motif_categories: { leads_to_orientation: true })
                      .order(created_at: :asc)
 
       if @agent.present?

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -1,6 +1,8 @@
 # rubocop:disable Metrics/ClassLength
 module Exporters
   class GenerateUsersCsv < Csv
+    attr_reader :agent
+
     def initialize(user_ids:, agent:, structure: nil, motif_category: nil)
       @user_ids = user_ids
       @structure = structure
@@ -172,11 +174,13 @@ module Exporters
     end
 
     def last_rdv_date(user)
-      @motif_category.present? ? rdv_context_for_export(user)&.last_rdv_starts_at : user.last_rdv_starts_at
+      last_rdv(user)&.starts_at
     end
 
     def last_rdv(user)
-      @motif_category.present? ? rdv_context_for_export(user)&.last_rdv : user.last_rdv
+      rdvs = @motif_category.present? ? rdv_context_for_export(user)&.rdvs : user.rdvs
+
+      RdvPolicy::Scope.new(agent, rdvs).resolve.latest if rdvs.present?
     end
 
     def last_participation(user)

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -198,7 +198,7 @@ module Exporters
     end
 
     def orientation_date(user)
-      scoped_participations = ParticipationPolicy::Scope.new(@agent, user.participations).resolve
+      scoped_participations = user.participations.joins(:organisation).where(organisations: { department_id: })
       created_at = scoped_participations
                    .seen
                    .joins(:rdv_context)

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -194,20 +194,15 @@ module Exporters
     end
 
     def orientation_date(user)
-      orientations = user
-                     .participations
-                     .seen
-                     .joins(:motif_category)
-                     .where(motif_categories: { leads_to_orientation: true })
-                     .order(created_at: :asc)
+      participations_for_orientations = ParticipationPolicy::Scope
+                                        .new(@agent, user.participations)
+                                        .resolve
+                                        .seen
+                                        .joins(:motif_category)
+                                        .where(motif_categories: { leads_to_orientation: true })
+                                        .order(created_at: :asc)
 
-      if @agent.present?
-        orientations = orientations
-                       .joins(:organisation)
-                       .where(organisations: @agent.organisations)
-      end
-
-      display_date(orientations.first&.created_at)
+      display_date(participations_for_orientations.first&.created_at)
     end
 
     def rdv_taken_in_autonomy?(user)

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/ClassLength
 module Exporters
   class GenerateUsersCsv < Csv
-    def initialize(user_ids:, structure: nil, motif_category: nil, agent: nil)
+    def initialize(user_ids:, agent:, structure: nil, motif_category: nil)
       @user_ids = user_ids
       @structure = structure
       @motif_category = motif_category

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -198,15 +198,16 @@ module Exporters
     end
 
     def orientation_date(user)
-      participations_for_orientations = ParticipationPolicy::Scope
-                                        .new(@agent, user.participations)
-                                        .resolve
-                                        .seen
-                                        .joins(:motif_category)
-                                        .where(motif_categories: { leads_to_orientation: true })
-                                        .order(created_at: :asc)
+      scoped_participations = ParticipationPolicy::Scope.new(@agent, user.participations).resolve
+      created_at = scoped_participations
+                   .seen
+                   .joins(:rdv_context)
+                   .joins("INNER JOIN motif_categories ON motif_categories.id = rdv_contexts.motif_category_id")
+                   .where(motif_categories: { leads_to_orientation: true })
+                   .order(created_at: :asc)
+                   .first&.created_at
 
-      display_date(participations_for_orientations.first&.created_at)
+      display_date(created_at)
     end
 
     def rdv_taken_in_autonomy?(user)

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -198,11 +198,14 @@ module Exporters
                      .participations
                      .seen
                      .joins(:motif_category)
-                     .joins(:organisation)
                      .where("motif_categories.short_name ilike ?", "%orientation%")
                      .order(created_at: :asc)
 
-      orientations = orientations.where(organisations: @agent.organisations) if @agent.present?
+      if @agent.present?
+        orientations = orientations
+                       .joins(:organisation)
+                       .where(organisations: @agent.organisations)
+      end
 
       display_date(orientations.first&.created_at)
     end

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -3,7 +3,9 @@ describe Exporters::GenerateUsersCsv, type: :service do
 
   let!(:now) { Time.zone.parse("22/06/2022") }
   let!(:timestamp) { now.to_i }
-  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation") }
+  let!(:motif_category) do
+    create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation", leads_to_orientation: true)
+  end
   let!(:department) { create(:department, name: "Drôme", number: "26") }
   let!(:organisation) { create(:organisation, name: "Drome RSA", department: department) }
   let!(:structure) { organisation }

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -38,7 +38,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
                  created_by: "user",
                  participations: [participation_rdv])
   end
-  let!(:participation_rdv) { create(:participation, user: user1, status: "seen") }
+  let!(:participation_rdv) { create(:participation, user: user1, status: "seen", created_at: "2022-05-23") }
 
   let!(:first_invitation) do
     create(:invitation, user: user1, format: "email", sent_at: Time.zone.parse("2022-05-21"))
@@ -163,7 +163,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
           expect(csv).to include("Rendez-vous honoré") # rdv status
           expect(csv).to include("Statut du RDV à préciser") # rdv_context status
           expect(csv).to include("Statut du RDV à préciser;Oui") # first rdv in less than 30 days ?
-          expect(csv).to include("Rendez-vous honoré;Statut du RDV à préciser;Oui;25/05/2022") # orientation date
+          expect(csv).to include("Rendez-vous honoré;Statut du RDV à préciser;Oui;23/05/2022") # orientation date
         end
 
         it "displays the organisation infos" do

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -1,5 +1,5 @@
 describe Exporters::GenerateUsersCsv, type: :service do
-  subject { described_class.call(user_ids: users.ids, structure: structure, motif_category: motif_category) }
+  subject { described_class.call(user_ids: users.ids, structure:, motif_category:, agent:) }
 
   let!(:now) { Time.zone.parse("22/06/2022") }
   let!(:timestamp) { now.to_i }
@@ -8,6 +8,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
   end
   let!(:department) { create(:department, name: "Drôme", number: "26") }
   let!(:organisation) { create(:organisation, name: "Drome RSA", department: department) }
+  let!(:agent) { create(:agent, organisations: [organisation]) }
   let!(:structure) { organisation }
   let!(:configuration) { create(:configuration, organisation: organisation, motif_category: motif_category) }
   let!(:nir) { generate_random_nir }
@@ -38,6 +39,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
   let!(:rdv) do
     create(:rdv, starts_at: Time.zone.parse("2022-05-25"),
                  created_by: "user",
+                 organisation:,
                  participations: [participation_rdv])
   end
   let!(:participation_rdv) { create(:participation, user: user1, status: "seen", created_at: "2022-05-23") }
@@ -201,7 +203,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
       end
 
       context "when no motif category is passed" do
-        subject { described_class.call(user_ids: users.ids, structure: structure, motif_category: nil) }
+        subject { described_class.call(user_ids: users.ids, structure: structure, motif_category: nil, agent:) }
 
         it "is a success" do
           expect(subject.success?).to eq(true)

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -42,6 +42,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
                  organisation:,
                  participations: [participation_rdv])
   end
+
   let!(:participation_rdv) { create(:participation, user: user1, status: "seen", created_at: "2022-05-23") }
 
   let!(:first_invitation) do
@@ -199,6 +200,21 @@ describe Exporters::GenerateUsersCsv, type: :service do
             expect(subject.csv).to include("20/06/2022") # archive status
             expect(subject.csv).to include("20/06/2022;test") # archive reason
           end
+        end
+      end
+
+      context "when last_rdv is not authorized for agent" do
+        let!(:other_organisation) { create(:organisation, name: "Drome RSA", department: department) }
+
+        let!(:rdv) do
+          create(:rdv, starts_at: Time.zone.parse("2022-05-31"),
+                       created_by: "user",
+                       organisation: other_organisation,
+                       participations: [participation_rdv])
+        end
+
+        it "does not take it into account" do
+          expect(csv).not_to include("31/05/2022")
         end
       end
 

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -203,6 +203,23 @@ describe Exporters::GenerateUsersCsv, type: :service do
         end
       end
 
+      context "when rdvs are in a different department" do
+        let!(:rdv) do
+          create(:rdv, starts_at: Time.zone.parse("2022-06-03"),
+                       created_by: "user",
+                       organisation: other_organisation,
+                       participations: [participation_rdv])
+        end
+
+        let!(:other_department) { create(:department, name: "Gironde", number: "33") }
+
+        let!(:other_organisation) { create(:organisation, name: "Drome RSA", department: department) }
+
+        it "does not take it into account" do
+          expect(csv).not_to include("03/06/2022")
+        end
+      end
+
       context "when last_rdv is not authorized for agent" do
         let!(:other_organisation) { create(:organisation, name: "Drome RSA", department: department) }
 


### PR DESCRIPTION
Ce fix permet d'afficher la date réelle d'orientation de l'utilisateur. 
Elle correspond désormais à la date du premier rendez-vous honoré d'une catégorie d'orientation, scopé par les organisations auquel l'agent a accès. 

Pour info j'ai voulu enlever le `delegate` pour garder uniquement le `has_one` mais ce n'est pas possible car `delegate` gère le chaining de delegate différemment et cela causait des erreurs à cause notamment des delegate présents dans `app/models/concerns/templatable.rb` 

fix #1702