### PR TITLE
fix(assets): Redirect old logos urls

### DIFF
--- a/app/controllers/asset_redirections_controller.rb
+++ b/app/controllers/asset_redirections_controller.rb
@@ -1,0 +1,19 @@
+# For old images served through webpacker in old emails to still be served
+class AssetRedirectionsController < ApplicationController
+  skip_before_action :authenticate_agent!
+
+  include ActionView::Helpers::AssetUrlHelper
+
+  def new
+    old_logo_path, logo_format = params[:old_path].split(".")
+    # we remove the fingerprint from the logo path
+    logo_name = old_logo_path.match(/^(.+)-([a-f0-9]+)/)[1]
+
+    return if logo_name.blank?
+
+    asset_path = AssetHelper.retrieve_asset_path("logos/#{logo_name}.#{logo_format}")
+    return unless asset_path
+
+    redirect_to "#{ENV["HOST"]}/assets/#{asset_path}", status: :moved_permanently
+  end
+end

--- a/app/controllers/asset_redirections_controller.rb
+++ b/app/controllers/asset_redirections_controller.rb
@@ -14,6 +14,6 @@ class AssetRedirectionsController < ApplicationController
     asset_path = AssetHelper.retrieve_asset_path("logos/#{logo_name}.#{logo_format}")
     return unless asset_path
 
-    redirect_to "#{ENV["HOST"]}/assets/#{asset_path}", status: :moved_permanently
+    redirect_to "#{ENV['HOST']}/assets/#{asset_path}", status: :moved_permanently
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
   end
 
   def asset_exists?(asset_path)
-    AssetHelper.find_asset(asset_path).present?
+    AssetHelper.asset_exists?(asset_path)
   end
 
   def show_login_button?

--- a/app/lib/asset_helper.rb
+++ b/app/lib/asset_helper.rb
@@ -1,12 +1,22 @@
 module AssetHelper
   class << self
-    def find_asset(asset_path)
-      if Rails.configuration.assets.respond_to?(:find_asset)
-        # Dynamic compilation
-        Rails.application.assets.find_asset(asset_path).present?
-      else
+    def asset_exists?(asset_path)
+      if Rails.env.production?
         # Pre-compiled
         Rails.application.assets_manifest.assets.key?(asset_path)
+      else
+        # Dynamic compilation
+        Rails.application.assets.find_asset(asset_path).present?
+      end
+    end
+
+    def retrieve_asset_path(asset_path)
+      if Rails.env.production?
+        # Pre-compiled
+        Rails.application.assets_manifest.assets[asset_path]
+      else
+        # Dynamic compilation
+        Rails.application.assets.find_asset(asset_path)&.digest_path
       end
     end
   end

--- a/app/models/logo.rb
+++ b/app/models/logo.rb
@@ -16,7 +16,7 @@ class Logo
 
   def available_formats
     %w[svg png jpg].select do |format|
-      AssetHelper.find_asset("#{BASE_PATH}#{@name}.#{format}")
+      AssetHelper.asset_exists?("#{BASE_PATH}#{@name}.#{format}")
     end
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,6 +37,4 @@ workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 
-if Rails.env.development?
-  worker_timeout 3600
-end
+worker_timeout 3600 if Rails.env.development?

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,3 +36,7 @@ workers ENV.fetch("WEB_CONCURRENCY") { 1 }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+if Rails.env.development?
+  worker_timeout 3600
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,9 @@ Rails.application.routes.draw do
   get "422", to: "errors#unprocessable_entity"
   get "500", to: "errors#internal_server_error"
 
+  # redirect logos that used to be served through webpacker
+  get "/packs/media/images/logos/*old_path", to: "asset_redirections#new", format: false
+
   resources :rdv_solidarites_webhooks, only: [:create]
 
   resources :sessions, only: [:create]


### PR DESCRIPTION
Suite au retrait de webpacker, nos assets ne sont plus servies via la même route. Ça a pour conséquences que les logos ne sont plus affichés correctement sur les emails envoyés avant le retrait de webpacker.

![image](https://github.com/betagouv/rdv-insertion/assets/7602809/33fc226b-6134-4f34-852e-c22e4771b153)


Je fais en sorte ici de continuer à bien les afficher en redirigeant vers la nouvelle image lorsqu'on requête l'ancienne route.