### PR TITLE
fix(convocation): Convene on user organisation

### DIFF
--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -42,7 +42,7 @@
             <td>
               <%= render "rdv_contexts/convocation_button",
                           user_id: user.id, motif_category_id: @current_motif_category.id,
-                          organisation_ids: department_level? ? @organisations.map(&:id) : [@organisation.id] %>
+                          organisation_ids: department_level? ? (@organisations.map(&:id) & user.organisation_ids) : [@organisation.id] %>
             </td>
           <% else %>
             <td><%= display_attribute format_date(rdv_context.last_sent_convocation_sent_at) %></td>


### PR DESCRIPTION
Lié à #1747 . Lorsque l'on convoque au niveau du département, l'organisation qui est prise en compte n'est pas forcément celle de l'usager. Cette PR règle ça en prenant toujours une organisation à laquelle appartient l'usager.