### PR TITLE
fix(view): Do not repeat error flash message

### DIFF
--- a/app/controllers/concerns/turbo_stream_concern.rb
+++ b/app/controllers/concerns/turbo_stream_concern.rb
@@ -10,6 +10,10 @@ module TurboStreamConcern
     render turbo_stream: turbo_stream.prepend("flashes", partial: "common/flash", locals: { flash: })
   end
 
+  def turbo_stream_replace_flash_message(flash)
+    render turbo_stream: turbo_stream.replace("flashes", partial: "common/flash", locals: { flash: })
+  end
+
   def turbo_stream_remove(element_id)
     render turbo_stream: turbo_stream.remove(element_id)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -120,7 +120,7 @@ class UsersController < ApplicationController
 
   def render_errors(errors)
     respond_to do |format|
-      format.turbo_stream { turbo_stream_prepend_flash_message(error: errors.join(", ")) }
+      format.turbo_stream { turbo_stream_replace_flash_message(error: errors.join(", ")) }
       format.html do
         flash.now[:error] = errors.join(",")
         render(action_name == "update" ? :edit : :new, status: :unprocessable_entity)

--- a/app/views/common/_flash.html.erb
+++ b/app/views/common/_flash.html.erb
@@ -1,11 +1,13 @@
-<% [:success, :notice, :error, :alert].each do |type| %>
-  <% if flash[type] %>
-    <div class="row text-center <%= type == :error ? "" : "flash_message" %>" data-controller="flash" data-action="animationend->flash#remove">
-      <div class="alert <%= alert_class_for(type) %> alert-dismissible fade show" role="alert">
-        <%= flash[type] %>
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+<div id="flashes">
+  <% [:success, :notice, :error, :alert].each do |type| %>
+    <% if flash[type] %>
+      <div class="row text-center <%= type == :error ? "" : "flash_message" %>" data-controller="flash" data-action="animationend->flash#remove">
+        <div class="alert <%= alert_class_for(type) %> alert-dismissible fade show" role="alert">
+          <%= flash[type] %>
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,9 +16,7 @@
   <body>
     <%= render 'layouts/rdv_insertion_instance_name' %>
     <%= render 'common/header' %>
-    <div id="flashes">
-      <%= render 'common/flash' %>
-    </div>
+    <%= render 'common/flash' %>
     <div class="wrapper">
       <%= turbo_frame_tag "remote_modal", target: "_top" %>
       <%= yield %>


### PR DESCRIPTION
Lié à #1737 . 
Je fais en sorte que les messages d'erreurs ne s'empilent pas mais qu'ils soient remplacés à chaque requête. Pour ça j'introduis une méthode `turbo_stream_replace_flash_message` analogue à `turbo_stream_prepend_flash_message` dans le `TurboStreamConcern` que j'utilise lorsqu'on renvoie une erreur à la création d'usager.