### PR TITLE
fix(view): conditionally display filter sentence

### DIFF
--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -28,7 +28,9 @@
 
     <div class="d-flex justify-content-between mt-1" data-controller="index-filters">
       <div class="text-left mt-2">
-        <i class="fas fa-filter"></i> Filtrer par :
+        <% if @tags.any? || @current_configuration.present? %>
+          <i class="fas fa-filter"></i> Filtrer par :
+        <% end %>
         <% if @current_configuration.present? %>
           <div class="mt-1">
             <input type="checkbox" name="action_required" class="form-check-input"></input> Usagers avec intervention nécessaire


### PR DESCRIPTION
On ne veut pas afficher la phrase "filter par :" lorsqu'il n'y a pas de tags renseignés ou lorsqu'on ne peut pas filtrer par intervention nécessaire