### PR TITLE
feat(csvs): better rdvs csv exports

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,8 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
@@ -515,6 +517,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -4,16 +4,20 @@ module Exporters
 
     def each_element(&block)
       @users.each do |user|
-        user.participations.joins(:rdv).where(rdv: { organisation_id: @agent.organisation_ids }).to_a.each(&block)
+        user.participations
+            .joins(:rdv)
+            .order("rdvs.starts_at desc")
+            .where(rdvs: { organisation_id: @agent.organisation_ids })
+            .to_a.each(&block)
       end
     end
 
     def preload_associations
       @users =
         if @motif_category
-          User.preload(:archives, :tags, :referents, :organisations)
+          User.preload(:tags, :referents, :organisations)
         else
-          User.preload(:invitations, :notifications, :archives, :organisations, :tags, :referents)
+          User.preload(:invitations, :notifications, :organisations, :tags, :referents)
         end
 
       @users = @users.preload(
@@ -32,7 +36,15 @@ module Exporters
     end
 
     def headers
-      [User.human_attribute_name(:title),
+      ["Date du RDV",
+       "Heure du RDV",
+       "Motif du RDV",
+       "Nature du RDV",
+       "RDV pris en autonomie ?",
+       Rdv.human_attribute_name(:status),
+       User.human_attribute_name(:referents),
+       "Organisation du rendez-vous",
+       User.human_attribute_name(:title),
        User.human_attribute_name(:last_name),
        User.human_attribute_name(:first_name),
        User.human_attribute_name(:affiliation_number),
@@ -46,23 +58,21 @@ module Exporters
        User.human_attribute_name(:created_at),
        User.human_attribute_name(:rights_opening_date),
        User.human_attribute_name(:role),
-       "Date du RDV",
-       "Heure du RDV",
-       "Motif du RDV",
-       "Nature du RDV",
-       "Dernier RDV pris en autonomie ?",
-       Rdv.human_attribute_name(:status),
-       Archive.human_attribute_name(:created_at),
-       Archive.human_attribute_name(:archiving_reason),
-       User.human_attribute_name(:referents),
-       "Organisation du rendez-vous",
        User.human_attribute_name(:tags)]
     end
 
     def csv_row(participation) # rubocop:disable Metrics/AbcSize
       user = participation.user
 
-      [user.title,
+      [display_date(rdv_date(participation)),
+       display_time(rdv_date(participation)),
+       rdv_motif(participation),
+       rdv_type(participation),
+       rdv_taken_in_autonomy?(participation),
+       human_status(participation),
+       user.referents.map(&:email).join(", "),
+       participation.organisation.name,
+       user.title,
        user.last_name,
        user.first_name,
        user.affiliation_number,
@@ -76,16 +86,6 @@ module Exporters
        display_date(user.created_at),
        display_date(user.rights_opening_date),
        user.role,
-       display_date(rdv_date(participation)),
-       display_time(rdv_date(participation)),
-       rdv_motif(participation),
-       rdv_type(participation),
-       rdv_taken_in_autonomy?(participation),
-       human_status(participation),
-       display_date(user.archive_for(department_id)&.created_at),
-       user.archive_for(department_id)&.archiving_reason,
-       user.referents.map(&:email).join(", "),
-       participation.organisation.name,
        user.tags.pluck(:value).join(", ")]
     end
 

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -80,6 +80,14 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
 
       it "generates headers" do
         expect(csv).to start_with("\uFEFF")
+        expect(csv).to include("Statut du rdv")
+        expect(csv).to include("Date du RDV")
+        expect(csv).to include("Heure du RDV")
+        expect(csv).to include("Motif du RDV")
+        expect(csv).to include("Nature du RDV")
+        expect(csv).to include("RDV pris en autonomie ?")
+        expect(csv).to include("Référent(s)")
+        expect(csv).to include("Organisation du rendez-vous")
         expect(csv).to include("Civilité")
         expect(csv).to include("Nom")
         expect(csv).to include("Prénom")
@@ -94,16 +102,6 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
         expect(csv).to include("Date de création")
         expect(csv).to include("Date d'entrée flux")
         expect(csv).to include("Rôle")
-        expect(csv).to include("Archivé le")
-        expect(csv).to include("Motif d'archivage")
-        expect(csv).to include("Statut du rdv")
-        expect(csv).to include("Date du RDV")
-        expect(csv).to include("Heure du RDV")
-        expect(csv).to include("Motif du RDV")
-        expect(csv).to include("Nature du RDV")
-        expect(csv).to include("Dernier RDV pris en autonomie ?")
-        expect(csv).to include("Référent(s)")
-        expect(csv).to include("Organisation du rendez-vous")
       end
 
       context "it exports all the concerned users" do
@@ -153,28 +151,6 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
 
         it "displays the referent emails" do
           expect(csv).to include("monreferent@gouv.fr")
-        end
-
-        context "when the user is archived" do
-          let!(:user1) do
-            create(
-              :user,
-              organisations: [organisation],
-              archives: [archive]
-            )
-          end
-          let!(:archive) do
-            create(
-              :archive,
-              created_at: Time.zone.parse("2022-06-20"),
-              department: department, archiving_reason: "test"
-            )
-          end
-
-          it "displays the archive infos" do
-            expect(subject.csv).to include("20/06/2022") # archive status
-            expect(subject.csv).to include("20/06/2022;test") # archive reason
-          end
         end
       end
 


### PR DESCRIPTION
closes #1711 

Dans cette PR, je traite les 3 points notés dans le ticket pour améliorer l'export csv des participations : 
- retrait des colonnes `Archivé le` et `Motif d'archivage`
- nouvel ordering en fonction des dates de rdv d'un usager, avec les rdvs les plus récents en premier
- inversion de l'ordre des colonnes pour faire ressortir l'entité rendez-vous