### PR TITLE
feat(errors): better creneaux error message

### DIFF
--- a/app/javascript/stylesheets/components/_color.scss
+++ b/app/javascript/stylesheets/components/_color.scss
@@ -25,6 +25,14 @@
   }
 }
 
+.link-purple-underlined {
+  text-decoration: underline;
+  color: $purple;
+  &:hover {
+    color: $alt-grey;
+  }
+}
+
 .blue-out {
   background-color: white;
   color: $dark-blue;

--- a/app/services/invitations/save_and_send.rb
+++ b/app/services/invitations/save_and_send.rb
@@ -42,7 +42,7 @@ module Invitations
       fail!(
         "<strong>Il n'y a plus de créneaux disponibles</strong> pour inviter cet utilisateur. " \
         "<br/><br/>" \
-        "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface " \
+        "Nous vous invitons à créer de nouvelles plages d'ouverture ou augmenter le délai de prise de rdv depuis " \
         "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations." \
         "<br/><br/>" \
         "Plus d'informations sur " \

--- a/app/services/invitations/save_and_send.rb
+++ b/app/services/invitations/save_and_send.rb
@@ -40,9 +40,15 @@ module Invitations
       return if retrieve_creneau_availability.creneau_availability
 
       fail!(
-        "L'envoi d'une invitation est impossible car il n'y a plus de créneaux disponibles. " \
-        "Nous invitons donc à créer de nouvelles plages d'ouverture depuis l'interface " \
-        "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations"
+        "<strong>Il n'y a plus de créneaux disponibles</strong> pour inviter cet utilisateur. " \
+        "<br/><br/>" \
+        "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface " \
+        "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations." \
+        "<br/><br/>" \
+        "Plus d'informations sur " \
+        "<a href='https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/configurer-loutil-et-envoyer" \
+        "-des-invitations/envoyer-des-invitations-ou-convocations/inviter-les-personnes-a-prendre-rdv" \
+        "#cas-des-creneaux-indisponibles' target='_blank' class='link-purple-underlined'>notre guide</a>." \
       )
     end
 

--- a/spec/features/agent_can_invite_users_from_index_page_spec.rb
+++ b/spec/features/agent_can_invite_users_from_index_page_spec.rb
@@ -61,9 +61,9 @@ describe "Agents can invite from index page", :js do
         check("email_invite")
         expect(page).to have_content("Impossible d'inviter l'utilisateur")
         expect(page).to have_content(
-          "L'envoi d'une invitation est impossible car il n'y a plus de créneaux disponibles. " \
-          "Nous invitons donc à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités " \
-          "pour pouvoir à nouveau envoyer des invitations"
+          "Il n'y a plus de créneaux disponibles pour inviter cet utilisateur.\n\n" \
+          "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités pour pouvoir " \
+          "à nouveau envoyer des invitations.\n\nPlus d'informations sur notre guide"
         )
       end
     end
@@ -145,9 +145,9 @@ describe "Agents can invite from index page", :js do
           check("email_invite")
           expect(page).to have_content("Impossible d'inviter l'utilisateur")
           expect(page).to have_content(
-            "L'envoi d'une invitation est impossible car il n'y a plus de créneaux disponibles. " \
-            "Nous invitons donc à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités " \
-            "pour pouvoir à nouveau envoyer des invitations"
+            "Il n'y a plus de créneaux disponibles pour inviter cet utilisateur.\n\n" \
+            "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités pour pouvoir " \
+            "à nouveau envoyer des invitations.\n\nPlus d'informations sur notre guide"
           )
         end
       end

--- a/spec/features/agent_can_invite_users_from_index_page_spec.rb
+++ b/spec/features/agent_can_invite_users_from_index_page_spec.rb
@@ -62,8 +62,8 @@ describe "Agents can invite from index page", :js do
         expect(page).to have_content("Impossible d'inviter l'utilisateur")
         expect(page).to have_content(
           "Il n'y a plus de créneaux disponibles pour inviter cet utilisateur.\n\n" \
-          "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités pour pouvoir " \
-          "à nouveau envoyer des invitations.\n\nPlus d'informations sur notre guide"
+          "Nous vous invitons à créer de nouvelles plages d'ouverture ou augmenter le délai de prise de rdv depuis " \
+          "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations.\n\nPlus d'informations sur notre guide"
         )
       end
     end
@@ -146,8 +146,8 @@ describe "Agents can invite from index page", :js do
           expect(page).to have_content("Impossible d'inviter l'utilisateur")
           expect(page).to have_content(
             "Il n'y a plus de créneaux disponibles pour inviter cet utilisateur.\n\n" \
-            "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités pour pouvoir " \
-            "à nouveau envoyer des invitations.\n\nPlus d'informations sur notre guide"
+            "Nous vous invitons à créer de nouvelles plages d'ouverture ou augmenter le délai de prise de rdv depuis " \
+            "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations.\n\nPlus d'informations sur notre guide"
           )
         end
       end

--- a/spec/services/invitations/save_and_send_spec.rb
+++ b/spec/services/invitations/save_and_send_spec.rb
@@ -139,9 +139,12 @@ describe Invitations::SaveAndSend, type: :service do
 
       it "stores an error message" do
         expect(subject.errors).to include(
-          "L'envoi d'une invitation est impossible car il n'y a plus de créneaux disponibles. " \
-          "Nous invitons donc à créer de nouvelles plages d'ouverture depuis l'interface " \
-          "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations"
+          "<strong>Il n'y a plus de créneaux disponibles</strong> pour inviter cet utilisateur. <br/><br/>" \
+          "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités pour pouvoir" \
+          " à nouveau envoyer des invitations.<br/><br/>Plus d'informations sur " \
+          "<a href='https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/configurer-loutil-et-envoyer" \
+          "-des-invitations/envoyer-des-invitations-ou-convocations/inviter-les-personnes-a-prendre-rdv#cas-" \
+          "des-creneaux-indisponibles' target='_blank' class='link-purple-underlined'>notre guide</a>."
         )
       end
 

--- a/spec/services/invitations/save_and_send_spec.rb
+++ b/spec/services/invitations/save_and_send_spec.rb
@@ -140,8 +140,8 @@ describe Invitations::SaveAndSend, type: :service do
       it "stores an error message" do
         expect(subject.errors).to include(
           "<strong>Il n'y a plus de créneaux disponibles</strong> pour inviter cet utilisateur. <br/><br/>" \
-          "Nous invitons à créer de nouvelles plages d'ouverture depuis l'interface RDV-Solidarités pour pouvoir" \
-          " à nouveau envoyer des invitations.<br/><br/>Plus d'informations sur " \
+          "Nous vous invitons à créer de nouvelles plages d'ouverture ou augmenter le délai de prise de rdv depuis " \
+          "RDV-Solidarités pour pouvoir à nouveau envoyer des invitations.<br/><br/>Plus d'informations sur " \
           "<a href='https://rdv-insertion.gitbook.io/guide-dutilisation-rdv-insertion/configurer-loutil-et-envoyer" \
           "-des-invitations/envoyer-des-invitations-ou-convocations/inviter-les-personnes-a-prendre-rdv#cas-" \
           "des-creneaux-indisponibles' target='_blank' class='link-purple-underlined'>notre guide</a>."


### PR DESCRIPTION
closes #1714 

Dans cette PR, je rajoute un lien vers notre guide dans le message d'erreur des créneaux. J'en profite aussi pour améliorer sa lisibilité (en ajoutant des sauts de ligne + en mettant l'info principale du message dès le début du message)
Avant : 
![image](https://github.com/betagouv/rdv-insertion/assets/46218316/974828d2-0b80-4a87-9dc2-dcb3c1d75d48)
Après : 
<img width="1285" alt="Capture d’écran 2024-02-22 à 11 44 11" src="https://github.com/betagouv/rdv-insertion/assets/46218316/d92df10f-6bac-46bb-aa40-b74a825b432e">
