### PR TITLE
fix(sync): verify user sync with rdvs when its needed

### DIFF
--- a/app/controllers/referent_assignations_controller.rb
+++ b/app/controllers/referent_assignations_controller.rb
@@ -1,6 +1,6 @@
 class ReferentAssignationsController < ApplicationController
   before_action :set_department, :set_user, :set_agents, only: [:index, :create, :destroy]
-  before_action :verify_user_is_sync_with_rdv_solidarites, only: [:create]
+  before_action :verify_user_is_sync_with_rdv_solidarites, only: [:create, :destroy]
   before_action :set_agent, only: [:create, :destroy]
 
   def index; end

--- a/app/controllers/users_organisations_controller.rb
+++ b/app/controllers/users_organisations_controller.rb
@@ -2,7 +2,7 @@ class UsersOrganisationsController < ApplicationController
   before_action :set_user, :set_department, :set_organisations,
                 only: [:index, :create, :destroy]
   before_action :assign_motif_category, :set_organisation_to_add, only: [:create]
-  before_action :set_organisation_to_remove, only: [:destroy]
+  before_action :set_organisation_to_remove, :verify_user_is_sync_with_rdv_solidarites, only: [:destroy]
 
   def index; end
 
@@ -80,6 +80,10 @@ class UsersOrganisationsController < ApplicationController
     return if users_organisation_params[:motif_category_id].blank?
 
     @user.assign_motif_category(users_organisation_params[:motif_category_id])
+  end
+
+  def verify_user_is_sync_with_rdv_solidarites
+    sync_user_with_rdv_solidarites(@user) if @user.rdv_solidarites_user_id.nil?
   end
 
   def save_user

--- a/spec/controllers/referent_assignations_controller_spec.rb
+++ b/spec/controllers/referent_assignations_controller_spec.rb
@@ -79,7 +79,7 @@ describe ReferentAssignationsController do
       expect(response.body).to match(/Le référent a bien été assigné/)
     end
 
-    context "when the user has no rdvs_id and the sync with rdvs fails" do
+    context "when the user has no rdv_solidarites_user_id and the sync with rdvs fails" do
       let!(:user) do
         create(:user, id: user_id, organisations: [organisation1, organisation2], rdv_solidarites_user_id: nil)
       end
@@ -180,6 +180,27 @@ describe ReferentAssignationsController do
         expect(unescaped_response_body).to match(/flashes/)
         expect(unescaped_response_body).to match(/Something wrong happened/)
         expect(unescaped_response_body).to match(/Une erreur s'est produite lors du détachement du référent/)
+      end
+    end
+
+    context "when the user has no rdv_solidarites_user_id and the sync with rdvs fails" do
+      let!(:user) do
+        create(:user, id: user_id, organisations: [organisation1, organisation2], rdv_solidarites_user_id: nil)
+      end
+
+      before do
+        allow(Users::SyncWithRdvSolidarites).to receive(:call)
+          .with(user: user)
+          .and_return(OpenStruct.new(success?: false, errors: ["Something went wrong"]))
+      end
+
+      it "displays an error message" do
+        subject
+
+        expect(response).to be_successful
+        expect(unescaped_response_body).to match(/flashes/)
+        expect(unescaped_response_body).to match(/Something went wrong/)
+        expect(unescaped_response_body).to match(/L'utilisateur n'est plus lié à rdv-solidarités/)
       end
     end
   end

--- a/spec/controllers/users_organisations_controller_spec.rb
+++ b/spec/controllers/users_organisations_controller_spec.rb
@@ -118,6 +118,5 @@ describe UsersOrganisationsController do
         expect(unescaped_response_body).to match(/L'utilisateur n'est plus lié à rdv-solidarités/)
       end
     end
-
   end
 end

--- a/spec/controllers/users_organisations_controller_spec.rb
+++ b/spec/controllers/users_organisations_controller_spec.rb
@@ -99,5 +99,25 @@ describe UsersOrganisationsController do
         expect(unescaped_response_body).to match(/something failed/)
       end
     end
+
+    context "when the user has no rdv_solidarites_user_id and the sync with rdvs fails" do
+      let!(:user) { create(:user, id: user_id, organisations: [organisation1], rdv_solidarites_user_id: nil) }
+
+      before do
+        allow(Users::SyncWithRdvSolidarites).to receive(:call)
+          .with(user: user)
+          .and_return(OpenStruct.new(success?: false, errors: ["Something went wrong"]))
+      end
+
+      it "displays an error message" do
+        subject
+
+        expect(response).to be_successful
+        expect(unescaped_response_body).to match(/flashes/)
+        expect(unescaped_response_body).to match(/Something went wrong/)
+        expect(unescaped_response_body).to match(/L'utilisateur n'est plus lié à rdv-solidarités/)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
closes #1791 

Dans cette PR, je fais en sorte que la synchro avec rdvs soit vérifiée à la suppression d'un référent ou d'une orga.

N.B. : pas besoin de l'ajouter pour l'ajout d'une orga, c'est déjà le cas dans le service `Save`