### PR TITLE
feat(app): Handle better deleted users 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class User < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
     :first_name, :last_name, :birth_date, :email, :phone_number, :address, :affiliation_number, :birth_name
@@ -59,6 +60,7 @@ class User < ApplicationRecord
   enum created_through: { rdv_insertion: 0, rdv_solidarites: 1 }, _prefix: true
 
   scope :active, -> { where(deleted_at: nil) }
+  scope :deleted, -> { where.not(deleted_at: nil) }
   scope :without_rdv_contexts, lambda { |motif_categories|
     where.not(id: joins(:rdv_contexts).where(rdv_contexts: { motif_category: motif_categories }).ids)
   }
@@ -104,7 +106,9 @@ class User < ApplicationRecord
       france_travail_id: nil,
       nir: nil,
       email: nil,
-      phone_number: nil
+      phone_number: nil,
+      old_rdv_solidarites_user_id: rdv_solidarites_user_id,
+      rdv_solidarites_user_id: nil
     )
   end
 
@@ -151,3 +155,4 @@ class User < ApplicationRecord
     errors.add(:birth_date, "n'est pas valide")
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/users/sync_with_rdv_solidarites.rb
+++ b/app/services/users/sync_with_rdv_solidarites.rb
@@ -1,5 +1,7 @@
 module Users
   class SyncWithRdvSolidarites < BaseService
+    attr_reader :rdv_solidarites_user_id
+
     def initialize(user:)
       @user = user.reload # we need to be sure the associations are correctly loaded
       @rdv_solidarites_user_id = @user.rdv_solidarites_user_id
@@ -76,7 +78,7 @@ module Users
     def sync_organisations
       @sync_organisations ||= call_service!(
         RdvSolidaritesApi::CreateUserProfiles,
-        rdv_solidarites_user_id: @rdv_solidarites_user_id,
+        rdv_solidarites_user_id: rdv_solidarites_user_id,
         rdv_solidarites_organisation_ids: rdv_solidarites_organisation_ids
       )
     end
@@ -84,7 +86,7 @@ module Users
     def sync_referents
       @sync_referents ||= call_service!(
         RdvSolidaritesApi::CreateReferentAssignations,
-        rdv_solidarites_user_id: @rdv_solidarites_user_id,
+        rdv_solidarites_user_id: rdv_solidarites_user_id,
         rdv_solidarites_agent_ids: referent_rdv_solidarites_ids
       )
     end
@@ -93,7 +95,7 @@ module Users
       @update_rdv_solidarites_user ||= call_service!(
         RdvSolidaritesApi::UpdateUser,
         user_attributes: rdv_solidarites_user_attributes,
-        rdv_solidarites_user_id: @rdv_solidarites_user_id
+        rdv_solidarites_user_id: rdv_solidarites_user_id
       )
     end
 

--- a/db/migrate/20240226140143_add_old_rdv_solidarites_user_id_to_users.rb
+++ b/db/migrate/20240226140143_add_old_rdv_solidarites_user_id_to_users.rb
@@ -1,0 +1,22 @@
+class AddOldRdvSolidaritesUserIdToUsers < ActiveRecord::Migration[7.1]
+  def up
+    add_column :users, :old_rdv_solidarites_user_id, :bigint
+
+    User.where.not(deleted_at: nil).find_each do |user|
+      user.update_columns(
+        old_rdv_solidarites_user_id: user.rdv_solidarites_user_id,
+        rdv_solidarites_user_id: nil
+      )
+    end
+  end
+
+  def down
+    User.where.not(deleted_at: nil).find_each do |user|
+      user.update_columns(
+        rdv_solidarites_user_id: user.old_rdv_solidarites_user_id
+      )
+    end
+
+    remove_column :users, :old_rdv_solidarites_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_123509) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_26_140143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -458,6 +458,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_20_123509) do
     t.string "france_travail_id"
     t.string "carnet_de_bord_carnet_id"
     t.integer "created_through", default: 0
+    t.bigint "old_rdv_solidarites_user_id"
     t.index ["department_internal_id"], name: "index_users_on_department_internal_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["nir"], name: "index_users_on_nir"


### PR DESCRIPTION
##  Contexte

Lorsqu'un usager est soft deleté sur rdvi, on n'enlève pas son `rdv_solidarites_user_id`. Or il se peut que l'usager ne soit pas supprimé côté rdvsp, notamment si l'usager en question appartient à des organisations qui n'ont pas pour verticale `rdv_insertion`. 
Ça crée un problème si on veut recréer l'usager, parce qu'on fera le lien avec l'usager existant sur rdvsp mais on détectera qu'on a déjà un record avec cet id rdv_solidarites en DB (dans la méthode `handle_email_taken_error` du service `User::SyncWithRdvSolidarites`) et ça va empêcher la création de l'usager.


## Solution

Je mets le `rdv_solidarites_user_id` à `nil` lorsque l'usager est soft deleté et j'ajoute une colonne `old_rdv_solidarites_user_id` pour quand même faire le lien avec le record côté rdvsp. 

Une amélioration possible serait de challenger l'utilité du soft delete au sein de notre app et possiblement supprimer définitivement les usagers plutôt que de les soft deleter.

## Développement annexes

J'en profite pour réécrire un peu le service `Users::SyncWithSolidarites`, la méthode `rdv_solidarites_user_id` que j'avais introduite il y a longtemps n'était pas claire et rendait le service pas très lisible. Je change pour une variable d'instance `@rdv_solidarites_user_id` que j'assigne en fonction du déroulement de l'exécution du service.