### PR TITLE
feat(upload): simplified file upload

### DIFF
--- a/app/javascript/controllers/parcours_documents_controller.js
+++ b/app/javascript/controllers/parcours_documents_controller.js
@@ -1,9 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  enableSubmit(event) {
+  fetchFile() {
+    this.element.querySelector("input[type=file]").click()
+  }
+
+  submit(event) {
     if (event.target.value.length > 0) {
-      this.element.querySelector("button").removeAttribute("disabled")
+      window.Turbo.navigator.submitForm(this.element)
     }
   }
 

--- a/app/views/parcours_documents/_document_form.html.erb
+++ b/app/views/parcours_documents/_document_form.html.erb
@@ -3,15 +3,15 @@
   <div class="w-50 my-4">
     <%= f.file_field(
       :file,
-      class: "form-control my-2", 
+      class: "d-none", 
       id: "file-input-#{type}", 
       accept: ParcoursDocument::MIME_TYPES.join(', '),
       data: {
-        action: "change->parcours-documents#enableSubmit",
+        action: "change->parcours-documents#submit",
       }
     ) %>
   </div>
-  <%= button_tag type: 'submit', class: "btn btn-primary", disabled: true do %>
+  <%= button_tag type: 'button', class: "btn btn-primary", data: { action: "click->parcours-documents#fetchFile" } do %>
     <i class="fas fa-plus"></i>
     <div class="spinner-border spinner-border-sm text-white d-none" role="status">
       <span class="visually-hidden">Loading...</span>

--- a/spec/features/agent_can_upload_documents_for_users_spec.rb
+++ b/spec/features/agent_can_upload_documents_for_users_spec.rb
@@ -30,22 +30,19 @@ describe "Agents can upload documents for users", :js do
       expect(page).to have_content("Aucun diagnostic renseigné.")
 
       # Making sure the file is not uploaded if the format is not correct
-      find_by_id("file-input-diagnostic").set(Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
-      click_button("Ajouter un diagnostic")
+      find_by_id("file-input-diagnostic", visible: false).set(Rails.root.join("spec/fixtures/fichier_contact_test.csv"))
 
       expect(page).to have_content("Seuls les formats PDF")
       expect(page).to have_content("Aucun diagnostic renseigné.")
 
-      find_by_id("file-input-diagnostic").set(Rails.root.join("spec/fixtures/dummy.pdf"))
-      click_button("Ajouter un diagnostic")
+      find_by_id("file-input-diagnostic", visible: false).set(Rails.root.join("spec/fixtures/dummy.pdf"))
 
       expect(page).to have_no_content("Aucun diagnostic renseigné.")
       expect(page).to have_content("dummy.pdf")
       expect(page).to have_css(".document-link", count: 1)
       expect(user.diagnostics.first.file.filename).to eq("dummy.pdf")
 
-      find_by_id("file-input-contract").set(Rails.root.join("spec/fixtures/dummy.pdf"))
-      click_button("Ajouter un contrat")
+      find_by_id("file-input-contract", visible: false).set(Rails.root.join("spec/fixtures/dummy.pdf"))
 
       expect(page).to have_no_content("Aucun contrat renseigné.")
       expect(page).to have_content("dummy.pdf")


### PR DESCRIPTION
Dans cette PR j'enlève la combinaison de bouton + champ à remplir pour n'avoir qu'un seul bouton permettant de sélectionner et uploader directement le fichier :

https://github.com/betagouv/rdv-insertion/assets/4990201/4ce2b970-9cff-49dd-bf51-557fa9e6d311

Closes https://github.com/betagouv/rdv-insertion/issues/1713