### PR TITLE
feat(orientation): allow today's date

### DIFF
--- a/app/models/orientation.rb
+++ b/app/models/orientation.rb
@@ -29,8 +29,8 @@ class Orientation < ApplicationRecord
   end
 
   def starts_at_in_the_past
-    return if starts_at < Time.zone.today
+    return if starts_at <= Time.zone.today
 
-    errors.add(:starts_at, "la date de début doit être antérieure à la date d'aujourd'hui")
+    errors.add(:starts_at, "la date de début doit être antérieure ou égale à la date d'aujourd'hui")
   end
 end

--- a/spec/models/orientation_spec.rb
+++ b/spec/models/orientation_spec.rb
@@ -24,14 +24,20 @@ describe Orientation do
     end
   end
 
-  describe "starts_at is in the past" do
+  describe "starts_at is in the future" do
     let(:orientation) { build(:orientation, starts_at: Date.tomorrow) }
 
     it "adds errors" do
       expect(orientation).not_to be_valid
       expect(orientation.errors.full_messages.to_sentence)
-        .to include("la date de début doit être antérieure à la date d'aujourd'hui")
+        .to include("la date de début doit être antérieure ou égale à la date d'aujourd'hui")
     end
+  end
+
+  describe "starts_at is today" do
+    let(:orientation) { build(:orientation, starts_at: Date.today) }
+
+    it { expect(orientation).to be_valid }
   end
 
   describe "ends_at after starts_at" do

--- a/spec/models/orientation_spec.rb
+++ b/spec/models/orientation_spec.rb
@@ -35,7 +35,7 @@ describe Orientation do
   end
 
   describe "starts_at is today" do
-    let(:orientation) { build(:orientation, starts_at: Date.today) }
+    let(:orientation) { build(:orientation, starts_at: Time.zone.today) }
 
     it { expect(orientation).to be_valid }
   end


### PR DESCRIPTION
Cette PR permet d'enregistrer la date du jour comme date de début de l'orientation. 

Closes https://github.com/betagouv/rdv-insertion/issues/1733