### PR TITLE
fix(cron): Prevent duplicated periodic invitations

### DIFF
--- a/app/jobs/send_periodic_invite_job.rb
+++ b/app/jobs/send_periodic_invite_job.rb
@@ -1,16 +1,33 @@
 class SendPeriodicInviteJob < ApplicationJob
   def perform(invitation_id, configuration_id, format)
-    invitation = Invitation.find(invitation_id)
-    configuration = Configuration.find(configuration_id)
-    new_invitation = invitation.dup
+    @invitation = Invitation.find(invitation_id)
+    @configuration = Configuration.find(configuration_id)
+    @format = format
 
-    new_invitation.format = format
+    return if invitation_already_sent_today?
+
+    send_invitation
+  end
+
+  private
+
+  def send_invitation
+    new_invitation = @invitation.dup
+
+    new_invitation.format = @format
     new_invitation.reminder = false
-    new_invitation.valid_until = configuration.number_of_days_before_action_required.days.from_now
-    new_invitation.organisations = invitation.organisations
+    new_invitation.valid_until = @configuration.number_of_days_before_action_required.days.from_now
+    new_invitation.organisations = @invitation.organisations
     new_invitation.uuid = nil
     new_invitation.save!
 
     Invitations::SaveAndSend.call(invitation: new_invitation, check_creneaux_availability: false)
+  end
+
+  def invitation_already_sent_today?
+    @invitation.rdv_context.invitations
+               .where(format: @format)
+               .where("created_at > ?", 24.hours.ago)
+               .any?
   end
 end

--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -8,6 +8,7 @@ class SendPeriodicInvitesJob < ApplicationJob
       .joins(:invitations)
       .preload(invitations: [{ organisations: :configurations }, :user])
       .where(invitations: Invitation.valid)
+      .distinct
       .find_each do |rdv_context|
       send_invite(rdv_context)
     end

--- a/spec/jobs/send_periodic_invite_job_spec.rb
+++ b/spec/jobs/send_periodic_invite_job_spec.rb
@@ -5,9 +5,10 @@ describe SendPeriodicInviteJob do
 
   describe "#perform" do
     subject do
-      described_class.new.perform(invitation.id, configuration.id, "email")
+      described_class.new.perform(invitation.id, configuration.id, format)
     end
 
+    let!(:format) { "email" }
     let!(:organisation) { create(:organisation) }
     let!(:configuration) do
       create(:configuration,
@@ -52,6 +53,15 @@ describe SendPeriodicInviteJob do
         expect(Invitations::SaveAndSend).to receive(:call).once
 
         subject
+      end
+
+      context "when the user has already been invited in this category less than 1 day ago" do
+        let!(:other_invitation) { create(:invitation, rdv_context:, format:, created_at: 2.hours.ago) }
+
+        it "does not send an invitation" do
+          expect(Invitations::SaveAndSend).not_to receive(:call)
+          expect { subject }.not_to change(Invitation, :count)
+        end
       end
     end
   end


### PR DESCRIPTION
Lié à #1785 . 
J'évite les doublons d'envoi d'invitations pour les invitations périodiques.