### PR TITLE
fix(view): Change flash fading delay

### DIFF
--- a/app/javascript/stylesheets/components/_flash.scss
+++ b/app/javascript/stylesheets/components/_flash.scss
@@ -1,5 +1,5 @@
 .flash_message {
-  animation: appear-then-fade 5s both;
+  animation: appear-then-fade 10s both;
 }
 
 .alert {


### PR DESCRIPTION
Lié à https://github.com/betagouv/rdv-insertion/issues/1784

Je double le temps d'apparition des messages flash de succès ou d'info avant qu'ils ne disparaissent.