### PR TITLE
fix(documents): security issue documents url

### DIFF
--- a/app/controllers/users/parcours_documents_controller.rb
+++ b/app/controllers/users/parcours_documents_controller.rb
@@ -1,5 +1,6 @@
 module Users
   class ParcoursDocumentsController < ApplicationController
+    # Needed to generate ActiveStorage urls locally, it sets the host and protocol
     include ActiveStorage::SetCurrent
 
     before_action :set_user

--- a/app/controllers/users/parcours_documents_controller.rb
+++ b/app/controllers/users/parcours_documents_controller.rb
@@ -6,8 +6,8 @@ module Users
     before_action :set_parcours_document, only: [:destroy, :show]
 
     def show
-      authorize @parcours_document, :show?
-      redirect_to @parcours_document.file.url
+      authorize @parcours_document
+      redirect_to @parcours_document.file.url, allow_other_host: true
     end
 
     def create
@@ -25,7 +25,7 @@ module Users
     end
 
     def destroy
-      authorize @parcours_document, :destroy?
+      authorize @parcours_document
 
       if @parcours_document.destroy
         turbo_stream_remove(@parcours_document)

--- a/app/controllers/users/parcours_documents_controller.rb
+++ b/app/controllers/users/parcours_documents_controller.rb
@@ -1,7 +1,14 @@
 module Users
   class ParcoursDocumentsController < ApplicationController
+    include ActiveStorage::SetCurrent
+
     before_action :set_user
-    before_action :set_parcours_document, only: :destroy
+    before_action :set_parcours_document, only: [:destroy, :show]
+
+    def show
+      authorize @parcours_document, :show?
+      redirect_to @parcours_document.file.url
+    end
 
     def create
       @parcours_document = ParcoursDocument.create(parcours_document_params)
@@ -18,6 +25,8 @@ module Users
     end
 
     def destroy
+      authorize @parcours_document, :destroy?
+
       if @parcours_document.destroy
         turbo_stream_remove(@parcours_document)
       else
@@ -36,7 +45,6 @@ module Users
 
     def set_parcours_document
       @parcours_document = ParcoursDocument.find(params[:id])
-      authorize @parcours_document, :destroy?
     end
 
     def set_user

--- a/app/policies/parcours_document_policy.rb
+++ b/app/policies/parcours_document_policy.rb
@@ -4,4 +4,8 @@ class ParcoursDocumentPolicy < ApplicationPolicy
   end
   alias update? edit?
   alias destroy? edit?
+
+  def show?
+    pundit_user.organisations.intersect?(record.user.organisations)
+  end
 end

--- a/app/views/parcours_documents/_document.html.erb
+++ b/app/views/parcours_documents/_document.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag document do %>
  <div class="d-flex mb-1 w-50">
   <div class="w-75">
-    <%= link_to rails_blob_path(document.file), target: :blank, class: "text-decoration-underline document-link" do %>
+    <%= link_to user_parcours_document_path(id: document.id, user_id: document.user_id), target: :blank, class: "text-decoration-underline document-link" do %>
       <i class="fas fa-file-pdf mx-1"></i>
       <%= document.file.filename %>
       <i class="fas mx-1 fa-external-link-alt text-dark-blue"></i>

--- a/app/views/parcours_documents/_document_form.html.erb
+++ b/app/views/parcours_documents/_document_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(:parcours_document, url: user_parcours_documents_path(user_id: user.id), html: { method: :post, data: { controller: "parcours-documents", action: "turbo:submit-start->parcours-documents#spin turbo:submit-end->parcours-documents#stopSpin" }}) do |f| %>
+<%= simple_form_for(:parcours_document, url: user_parcours_documents_path(user_id: user.id), html: { class: "mt-3", method: :post, data: { controller: "parcours-documents", action: "turbo:submit-start->parcours-documents#spin turbo:submit-end->parcours-documents#stopSpin" }}) do |f| %>
   <%= f.hidden_field :type, value: type.camelize %>
   <%= f.file_field(
       :file,

--- a/app/views/parcours_documents/_documents_list.html.erb
+++ b/app/views/parcours_documents/_documents_list.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "documents_list_#{type}" do %>
   <% if user.send(type.pluralize).empty? %>
     <p class="text-dark-grey-alt mb-1">Taille maximale : <%= number_to_human_size(ParcoursDocument::MAX_FILE_SIZE) %></p>
-    <p>Aucun <%= t("activerecord.attributes.parcours_document.type.#{type}") %> renseigné.</p>
+    <span>Aucun <%= t("activerecord.attributes.parcours_document.type.#{type}") %> renseigné.</span>
   <% else %>
     <% user.send(type.pluralize).each do |document| %>
       <%= render "parcours_documents/document", document: %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ module RdvInsertion
     config.i18n.default_locale = :fr
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
     config.exceptions_app = routes
+    config.active_storage.draw_routes = false
 
     # The following keys are generated using the following command:
     # bundle exec rails db:encryption:init

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,7 @@ Rails.application.routes.draw do
   resources :users, module: :users, only: [] do
     resource :parcours, only: [:show]
     resources :orientations, only: [:new, :create, :edit, :update, :destroy]
-    resources :parcours_documents, only: [:create, :destroy]
+    resources :parcours_documents, only: [:show, :create, :destroy]
     resources :rdvs, only: [:new]
   end
 


### PR DESCRIPTION
J'ai du coup bloqué les routes de bases, rajouté une méthode show dans le controller parcours_document avec une vérification de policy sur le fichier. J'ai également corrigé un soucis de marge pour avoir un rendu cohérent avec ou sans document : 

<img width="806" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/100c4aa6-72e4-440d-85a5-c74bbb826142">

Fix https://github.com/betagouv/rdv-insertion/issues/1827