### PR TITLE
ux(user_index): ajust css for long organisations name in user index and centered it.

### DIFF
--- a/app/javascript/stylesheets/components/_title.scss
+++ b/app/javascript/stylesheets/components/_title.scss
@@ -8,6 +8,9 @@
   font-size: 20px;
   font-weight: 600;
   color: $dark-blue;
+  white-space: normal;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 
 .h1-form-title {

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -74,7 +74,7 @@
       <%= image_tag("maps/#{@department.name.parameterize}.svg", alt: @department.name.parameterize, width: 50, height: 50) %>
     <% end %>
     <% if @organisations.length > 1 %>
-      <div class="dropdown">
+      <div class="dropdown text-center">
         <a class="dropdown-toggle text-center department-map-title mb-0" href="#" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
           <%= department_level? ? @department.name : @organisation.name %>
         </a>


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/1096

Le retour à la ligne fait 'perdre' un tout petit peu de hauteur à l'interface mais le cas est je pense suffisamment rare pour que cela reste très marginal. Une autre solution serait de réduire la police après un certains breakpoint mais cela ne réglera pas le problème si le nom de l'organisation est encore plus long.

Avant : 
<img width="1576" alt="Capture d’écran 2024-03-05 à 15 49 51" src="https://github.com/betagouv/rdv-insertion/assets/28594222/2e0357e3-d9cb-4654-84aa-336d345670ca">

Après :
<img width="1576" alt="Capture d’écran 2024-03-05 à 15 47 11" src="https://github.com/betagouv/rdv-insertion/assets/28594222/4763c037-c7ab-49b4-a068-5b0ad00af5b7">
