### PR TITLE
fix(encryption): monkey patch simple form to fix NIR input

### DIFF
--- a/config/initializers/monkey_patch_simple_form.rb
+++ b/config/initializers/monkey_patch_simple_form.rb
@@ -1,0 +1,18 @@
+module SimpleFormEncryptedAttributesExtension
+  private
+
+  def find_attribute_column(attribute_name)
+    if @object.respond_to?(:type_for_attribute) && @object.has_attribute?(attribute_name)
+      @object.type_for_attribute(attribute_name.to_s)
+      detected_type = @object.type_for_attribute(attribute_name.to_s)
+
+      # Some attributes like ActiveRecord::Encryption::EncryptedAttribute are detected
+      # as different type, in that case we need to use the original type
+      detected_type.respond_to?(:cast_type) ? detected_type.cast_type : detected_type
+    elsif @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
+      @object.column_for_attribute(attribute_name)
+    end
+  end
+end
+
+SimpleForm::FormBuilder.prepend(SimpleFormEncryptedAttributesExtension)


### PR DESCRIPTION
Le déploiement de l'encryption à mis en lumière un bug de simple form qui faisait fallback les input encryptés sur des TextArea. 
J'ai patch la Gem ici https://github.com/heartcombo/simple_form/pull/1836

En attendant j'ajoute juste un monkey patch de notre côté
Ce ticket sera également suivi de celui-ci https://github.com/betagouv/rdv-insertion/issues/1842
Où l'on enlevera complètement SimpleForm

Le visuel est bien corrigé 
<img width="618" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/2a68bfe5-5130-4908-86e0-b5a60ef6c7c9">

Fixes https://github.com/betagouv/rdv-insertion/issues/1806