### PR TITLE
fix(creneaux_availability): use zip_codes instead of city_codes (insee)

### DIFF
--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -45,7 +45,7 @@ class NotifyUnavailableCreneauJob < ApplicationJob
       string += " Référents (rdvsp_ids) : #{grouped_invitation_params[:referent_ids].join(', ')}\n"
     end
 
-    string += " **!! L'organisation n'a pas d'email configuré et n'a pas été notifiée !!**\n" if organisation.email.blank?
+    string += " ** L'organisation n'a pas d'email configuré et n'a pas été notifiée !**\n" if organisation.email.blank?
 
     string
   end

--- a/app/jobs/notify_unavailable_creneau_job.rb
+++ b/app/jobs/notify_unavailable_creneau_job.rb
@@ -37,15 +37,15 @@ class NotifyUnavailableCreneauJob < ApplicationJob
       " Motif : #{grouped_invitation_params[:motif_category_name]}\n" \
       " Nombre d'invitations concernées : #{grouped_invitation_params[:invitations_counter]}\n"
 
-    if grouped_invitation_params[:city_codes].present?
-      string += " Codes postaux : #{grouped_invitation_params[:city_codes].join(', ')}\n"
+    if grouped_invitation_params[:zip_codes].present?
+      string += " Codes postaux : #{grouped_invitation_params[:zip_codes].join(', ')}\n"
     end
 
     if grouped_invitation_params[:referent_ids].present?
       string += " Référents (rdvsp_ids) : #{grouped_invitation_params[:referent_ids].join(', ')}\n"
     end
 
-    string += " !! L'organisation n'a pas d'email configuré et n'a pas été notifiée !!\n" if organisation.email.blank?
+    string += " **!! L'organisation n'a pas d'email configuré et n'a pas été notifiée !!**\n" if organisation.email.blank?
 
     string
   end

--- a/app/models/concerns/user/address.rb
+++ b/app/models/concerns/user/address.rb
@@ -14,7 +14,7 @@ module User::Address
   end
 
   def zipcode
-    zipcode_and_city&.match(/^(\d{5})/)&.captures&.first
+    address&.match(/\d{5}/)&.to_s
   end
 
   private

--- a/app/models/concerns/user/address.rb
+++ b/app/models/concerns/user/address.rb
@@ -13,6 +13,10 @@ module User::Address
     split_address.present? ? split_address[2].strip : nil
   end
 
+  def zipcode
+    zipcode_and_city&.match(/^(\d{5})/)&.captures&.first
+  end
+
   private
 
   def split_address

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -26,7 +26,7 @@ module Invitations
 
     def invitations_params
       organisation_valid_invitations.select("DISTINCT ON (rdv_context_id) *").to_a.map do |invitation|
-        invitation.link_params.symbolize_keys
+        invitation.link_params.merge(zip_code: invitation.user.zipcode).symbolize_keys
       end
     end
 
@@ -45,13 +45,13 @@ module Invitations
       @grouped_invitation_params_by_category
     end
 
-    def group_invitation_params_by_category(invitation)
-      motif_category_name = MotifCategory.find_by(short_name: invitation[:motif_category_short_name]).name
-      city_code = invitation[:city_code]
-      referent_ids = invitation[:referent_ids]
+    def group_invitation_params_by_category(invitation_params)
+      motif_category_name = MotifCategory.find_by(short_name: invitation_params[:motif_category_short_name]).name
+      zip_code = invitation_params[:zip_code]
+      referent_ids = invitation_params[:referent_ids]
       category_params_group = find_or_initialize_category_params_group(motif_category_name)
       category_params_group[:invitations_counter] += 1
-      category_params_group[:city_codes].add(city_code) if city_code.present?
+      category_params_group[:zip_codes].add(zip_code) if zip_code.present?
       category_params_group[:referent_ids].merge(referent_ids) if referent_ids.present?
     end
 
@@ -61,7 +61,7 @@ module Invitations
       end
       return category_params_group if category_params_group.present?
 
-      category_params_group = { motif_category_name: motif_category_name, city_codes: Set.new, referent_ids: Set.new,
+      category_params_group = { motif_category_name: motif_category_name, zip_codes: Set.new, referent_ids: Set.new,
                                 invitations_counter: 0 }
       @grouped_invitation_params_by_category << category_params_group
       category_params_group

--- a/app/services/invitations/verify_organisation_creneaux_availability.rb
+++ b/app/services/invitations/verify_organisation_creneaux_availability.rb
@@ -25,7 +25,7 @@ module Invitations
     end
 
     def invitations_params
-      organisation_valid_invitations.select("DISTINCT ON (rdv_context_id) *").to_a.map do |invitation|
+      organisation_valid_invitations.includes(:user).select("DISTINCT ON (rdv_context_id) *").to_a.map do |invitation|
         invitation.link_params.merge(zip_code: invitation.user.zipcode).symbolize_keys
       end
     end

--- a/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
+++ b/app/views/mailers/organisation_mailer/creneau_unavailable.html.erb
@@ -11,9 +11,9 @@
   <div class="margined-paragraph">
     <p><span class="font-weight-bold"><%= grouped_invitation_params[:motif_category_name] %></span></p>
     <p>Nombre d'invitations concernnées : <span class="font-weight-bold"><%= grouped_invitation_params[:invitations_counter] %></span></p>
-    <%= tag.p ("Les codes postaux concernés sont : #{grouped_invitation_params[:city_codes].join(", ")}.*") if grouped_invitation_params[:city_codes].present? %>
+    <%= tag.p ("Les codes postaux concernés sont : #{grouped_invitation_params[:zip_codes].join(", ")}.*") if grouped_invitation_params[:zip_codes].present? %>
     <%= tag.p ("Les email des référents concernés sont : #{Agent.where(rdv_solidarites_agent_id: grouped_invitation_params[:referent_ids]).map(&:email).join(", ")}.") if grouped_invitation_params[:referent_ids].present? %>
-    <%= tag.p tag.span("*Les codes postaux n'ont de l'importance que si la sectorisation est activée.", style: "color: grey;") if grouped_invitation_params[:city_codes].present? %>
+    <%= tag.p tag.span("*Les codes postaux n'ont de l'importance que si la sectorisation est activée.", style: "color: grey;") if grouped_invitation_params[:zip_codes].present? %>
   </div>
 <% end %>
 

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -9,7 +9,9 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
   let!(:organisation_id) { organisation.id }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:rdv_context_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
-  let!(:rdv_context_without_creneau_for_user_without_address) { create(:rdv_context, motif_category: category_rsa_orientation) }
+  let!(:rdv_context_without_creneau_for_user_without_address) do
+    create(:rdv_context, motif_category: category_rsa_orientation)
+  end
   let!(:rdv_context2_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
   let!(:rdv_context_with_creneau) { create(:rdv_context, motif_category: category_rsa_accompagnement_sociopro) }
   let!(:rdv_context_with_referent_without_creneau) do
@@ -174,7 +176,6 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
         end
       end
     end
-
 
     it "is a success" do
       is_a_success

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -9,6 +9,7 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
   let!(:organisation_id) { organisation.id }
   let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
   let!(:rdv_context_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
+  let!(:rdv_context_without_creneau_for_user_without_address) { create(:rdv_context, motif_category: category_rsa_orientation) }
   let!(:rdv_context2_without_creneau) { create(:rdv_context, motif_category: category_rsa_orientation) }
   let!(:rdv_context_with_creneau) { create(:rdv_context, motif_category: category_rsa_accompagnement_sociopro) }
   let!(:rdv_context_with_referent_without_creneau) do
@@ -38,7 +39,35 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
       address: "3 Rue Test 75010 Paris"
     )
   end
+  let!(:user_with_no_address) do
+    create(
+      :user,
+      address: nil
+    )
+  end
 
+  let!(:invitation_with_no_creneau_no_user_address) do
+    create(
+      :invitation,
+      user: user_with_no_address,
+      organisations: [organisation],
+      link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1RueTest&city_code=12255&departement=12&invitation_token=AIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
+      format: "email",
+      rdv_context: rdv_context_without_creneau_for_user_without_address
+    )
+  end
+  let!(:invitation_with_no_creneau_no_user_address_relevant_params) do
+    { :city_code => "12255",
+      :address => "1RueTest",
+      :latitude => "44.0",
+      :longitude => "2.0",
+      :departement => "12",
+      :invitation_token => "AIXR0X2T",
+      :motif_category_short_name => "rsa_orientation",
+      :organisation_ids => [organisation_id.to_s],
+      :street_ban_id => "12255_0070",
+      :zip_code => nil }
+  end
   let!(:invitation_with_no_creneau) do
     create(
       :invitation,
@@ -131,19 +160,21 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
 
   describe "#call" do
     before do
-      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
-        .with(link_params: invitation_with_referent_without_creneau_relevant_params)
-        .and_return(OpenStruct.new(success?: true, creneau_availability: false))
-      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
-        .with(link_params: invitation_with_creneau_relevant_params)
-        .and_return(OpenStruct.new(success?: true, creneau_availability: true))
-      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
-        .with(link_params: invitation2_with_no_creneau_relevant_params)
-        .and_return(OpenStruct.new(success?: true, creneau_availability: false))
-      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call)
-        .with(link_params: invitation_with_no_creneau_relevant_params)
-        .and_return(OpenStruct.new(success?: true, creneau_availability: false))
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call) do |link_params:|
+        case link_params
+        when invitation_with_no_creneau_no_user_address_relevant_params,
+          invitation_with_no_creneau_relevant_params,
+          invitation2_with_no_creneau_relevant_params,
+          invitation_with_referent_without_creneau_relevant_params
+          OpenStruct.new(success?: true, creneau_availability: false)
+        when invitation_with_creneau_relevant_params
+          OpenStruct.new(success?: true, creneau_availability: true)
+        else
+          OpenStruct.new(success?: false)
+        end
+      end
     end
+
 
     it "is a success" do
       is_a_success
@@ -158,7 +189,7 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
             motif_category_name: "RSA orientation",
             zip_codes: Set.new(%w[75007 75015]),
             referent_ids: Set.new([]),
-            invitations_counter: 2
+            invitations_counter: 3
           },
           {
             motif_category_name: "RSA accompagnement socio-pro",

--- a/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
+++ b/spec/services/invitations/verify_organisation_creneaux_availability_spec.rb
@@ -14,10 +14,35 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
   let!(:rdv_context_with_referent_without_creneau) do
     create(:rdv_context, motif_category: category_rsa_accompagnement_social)
   end
+  let!(:user1) do
+    create(
+      :user,
+      address: "1 Rue Test 75007 Paris"
+    )
+  end
+  let!(:user2) do
+    create(
+      :user,
+      address: "1b Rue Test 75015 Paris"
+    )
+  end
+  let!(:user3) do
+    create(
+      :user,
+      address: "2 Rue Test 75020 Paris"
+    )
+  end
+  let!(:user4) do
+    create(
+      :user,
+      address: "3 Rue Test 75010 Paris"
+    )
+  end
 
   let!(:invitation_with_no_creneau) do
     create(
       :invitation,
+      user: user1,
       organisations: [organisation],
       link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1RueTest&city_code=12255&departement=12&invitation_token=XIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
       format: "email",
@@ -33,11 +58,13 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
       :invitation_token => "XIXR0X2T",
       :motif_category_short_name => "rsa_orientation",
       :organisation_ids => [organisation_id.to_s],
-      :street_ban_id => "12255_0070" }
+      :street_ban_id => "12255_0070",
+      :zip_code => "75007" }
   end
   let!(:invitation2_with_no_creneau) do
     create(
       :invitation,
+      user: user2,
       organisations: [organisation],
       link: "https://www.rdv-solidarites.fr/prendre_rdv?address=1bRueTest&city_code=12255&departement=12&invitation_token=ZIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_orientation&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12255_0070",
       format: "email",
@@ -53,11 +80,13 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
       :invitation_token => "ZIXR0X2T",
       :motif_category_short_name => "rsa_orientation",
       :organisation_ids => [organisation_id.to_s],
-      :street_ban_id => "12255_0070" }
+      :street_ban_id => "12255_0070",
+      :zip_code => "75015" }
   end
   let!(:invitation_with_creneau) do
     create(
       :invitation,
+      user: user3,
       organisations: [organisation],
       link: "https://www.rdv-solidarites.fr/prendre_rdv?address=2RueTest&city_code=12000&departement=12&invitation_token=JIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000",
       format: "email",
@@ -73,11 +102,13 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
       :invitation_token => "JIXR0X2T",
       :motif_category_short_name => "rsa_accompagnement_sociopro",
       :organisation_ids => [organisation_id.to_s],
-      :street_ban_id => "12000_0000" }
+      :street_ban_id => "12000_0000",
+      :zip_code => "75020" }
   end
   let!(:invitation_with_referent_without_creneau) do
     create(
       :invitation,
+      user: user4,
       organisations: [organisation],
       link: "https://www.rdv-solidarites.fr/prendre_rdv?address=3RueTest&city_code=10000&departement=12&invitation_token=UIXR0X2T&latitude=44.0&longitude=2.0&motif_category_short_name=rsa_accompagnement_sociopro&organisation_ids%5B%5D=#{organisation_id}&street_ban_id=12000_0000&referent_ids%5B%5D=1",
       format: "email",
@@ -94,7 +125,8 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
       :motif_category_short_name => "rsa_accompagnement_sociopro",
       :organisation_ids => [organisation_id.to_s],
       :street_ban_id => "12000_0000",
-      :referent_ids => ["1"] }
+      :referent_ids => ["1"],
+      :zip_code => "75010" }
   end
 
   describe "#call" do
@@ -124,13 +156,13 @@ describe Invitations::VerifyOrganisationCreneauxAvailability, type: :service do
         excepted_result = [
           {
             motif_category_name: "RSA orientation",
-            city_codes: Set.new(["12255"]),
+            zip_codes: Set.new(%w[75007 75015]),
             referent_ids: Set.new([]),
             invitations_counter: 2
           },
           {
             motif_category_name: "RSA accompagnement socio-pro",
-            city_codes: Set.new(["10000"]),
+            zip_codes: Set.new(["75010"]),
             referent_ids: Set.new(["1"]),
             invitations_counter: 1
           }


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/1779

On utilise les codes postaux des adresses des usagers pour remonter les alertes de créneaux indisponibles plutôt que le code fourni par l'api (code insee) qui ne parle pas aux agents.