### PR TITLE
fix(user): prevent redirect when adding user at department level

### DIFF
--- a/app/controllers/users_organisations_controller.rb
+++ b/app/controllers/users_organisations_controller.rb
@@ -9,8 +9,6 @@ class UsersOrganisationsController < ApplicationController
   def create
     if save_user.success?
       flash.now[:success] = "L'organisation a bien été ajoutée"
-      # in this case we need to refresh the page in case there are new rdv contexts
-      redirect_to_department_user_path if department_level?
     else
       flash.now[:error] = "Une erreur s'est produite lors de l'ajout de l'organisation: #{save_user.errors}"
     end

--- a/app/views/mailers/reply_transfer_mailer/forward_invitation_reply_to_organisation.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_invitation_reply_to_organisation.html.erb
@@ -1,6 +1,6 @@
 <%= render "organisation_email_not_found" if @recipient_email == "support@rdv-insertion.fr" %>
 <h1>Bonjour,</h1>
-<p>Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une invitation :</p>
+<p>Vous trouverez ci-dessous une réponse d'un usager à une invitation :</p>
 <%= render "quote_original_mail" %>
 <p>Merci de ne pas répondre à cet e-mail. Pour contacter la personne, vous pouvez utiliser les informations contenues dans cet e-mail.</p>
 <blockquote>

--- a/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
@@ -1,6 +1,6 @@
 <%= render "organisation_email_not_found" if @recipient_email == "support@rdv-insertion.fr" %>
 <h1>Bonjour,</h1>
-<p>Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une convocation :</p>
+<p>Vous trouverez ci-dessous une réponse d'un usager à une convocation :</p>
 <%= render "quote_original_mail" %>
 <p>Merci de ne pas répondre à cet e-mail. Pour contacter la personne, vous pouvez utiliser les informations contenues dans cet e-mail.</p>
 <blockquote>

--- a/app/views/mailers/reply_transfer_mailer/forward_to_default_mailbox.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_to_default_mailbox.html.erb
@@ -1,5 +1,5 @@
 <h1>Bonjour,</h1>
-<p>Vous trouverez ci-dessous une réponse d'un.e bénéficiaire :</p>
+<p>Vous trouverez ci-dessous une réponse d'un usager :</p>
 <%= render "quote_original_mail" %>
 <p>Vous trouverez ci-dessous les informations nécessaires pour contacter la personne ou transmettre ce mail à un agent en charge de son parcours.</p>
 <blockquote>

--- a/app/views/organisations/user_added_notifications/_form.html.erb
+++ b/app/views/organisations/user_added_notifications/_form.html.erb
@@ -27,7 +27,7 @@
                       class: "form-control",
                       cols: 15,
                       rows: 15,
-                      value: "Le bénéficiaire a #{user} été ajouté à votre organisation #{organisation.name}.\nVous pouvez consulter son profil à l'adresse suivante :\n #{organisation_user_url(id: user.id, organisation_id: organisation.id, host: ENV['HOST'])}"
+                      value: "L'usager #{user} a été ajouté à votre organisation #{organisation.name}.\nVous pouvez consulter son profil à l'adresse suivante :\n #{organisation_user_url(id: user.id, organisation_id: organisation.id, host: ENV['HOST'])}"
                     }
 
             %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
   <%= render "users_list_header" %>
   <div class="row card-white justify-content-center">
     <% if @all_configurations.empty? %>
-      Merci de configurer votre organisation avant de pouvoir inviter des bénéficiaires
+      Merci de configurer votre organisation avant de pouvoir inviter des usagers
     <% else %>
       <%= render "users_list_tabs" %>
       <%= render "users_list_table" %>

--- a/app/views/users_organisations/_users_organisation.html.erb
+++ b/app/views/users_organisations/_users_organisation.html.erb
@@ -17,7 +17,7 @@
                 :submit,
                 "- Retirer",
                 class: "btn btn-danger text-white",
-                data: organisations_count == 1 ? { confirm: "Cette action va supprimer définitivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?" } : {},
+                data: organisations_count == 1 ? { confirm: "Cette action va supprimer définitivement la fiche de l'usager, êtes-vous sûr de vouloir la supprimer ?" } : {},
                 disabled: !removable
               )
           %>

--- a/spec/controllers/users_organisations_controller_spec.rb
+++ b/spec/controllers/users_organisations_controller_spec.rb
@@ -27,17 +27,11 @@ describe UsersOrganisationsController do
         .and_return(OpenStruct.new(success?: true))
     end
 
-    it "redirects with a success message" do
-      subject
-
-      expect(response).to redirect_to(department_user_path(department, user))
-      expect(flash[:success]).to include("L'organisation a bien été ajoutée")
-    end
-
     it "saves the user with the organisation" do
       expect(Users::Save).to receive(:call)
         .with(user: user, organisation: organisation2)
       subject
+      expect(flash[:success]).to include("L'organisation a bien été ajoutée")
     end
 
     context "when the save fails" do

--- a/spec/features/agent_can_add_or_remove_user_from_organisations_spec.rb
+++ b/spec/features/agent_can_add_or_remove_user_from_organisations_spec.rb
@@ -185,7 +185,7 @@ describe "Agents can add or remove user from organisations", :js do
       expect(page).to have_button("- Retirer", disabled: false)
 
       accept_confirm(
-        "Cette action va supprimer définitivement la fiche du bénéficiaire, êtes-vous sûr de vouloir la supprimer ?"
+        "Cette action va supprimer définitivement la fiche de l'usager, êtes-vous sûr de vouloir la supprimer ?"
       ) do
         click_button("- Retirer")
       end

--- a/spec/mailers/reply_transfer_mailer_spec.rb
+++ b/spec/mailers/reply_transfer_mailer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the content" do
-      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une invitation :")
+      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un usager à une invitation :")
       expect(mail.body.encoded).to match("<h4>coucou</h4>")
       expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
       expect(mail.body.encoded).to match("Merci de ne pas répondre à cet e-mail. Pour contacter la personne, ")
@@ -87,7 +87,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the content" do
-      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une invitation :")
+      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un usager à une invitation :")
       expect(mail.body.encoded).to match("<h4>coucou</h4>")
       expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
       expect(mail.body.encoded).to match("Merci de ne pas répondre à cet e-mail. Pour contacter la personne, ")
@@ -121,7 +121,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the content" do
-      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire à une convocation")
+      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un usager à une convocation")
       expect(mail.body.encoded).to match("<h4>coucou</h4>")
       expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
       expect(mail.body.encoded).to match("Merci de ne pas répondre à cet e-mail. Pour contacter la personne, ")
@@ -145,7 +145,7 @@ RSpec.describe ReplyTransferMailer do
       let!(:lieu) { nil }
 
       it "renders the content without the lieu" do
-        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire")
+        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un usager")
         expect(mail.body.encoded).to match("<h4>coucou</h4>")
         expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
         expect(mail.body.encoded).to match("Merci de ne pas répondre à cet e-mail. Pour contacter la personne, ")
@@ -182,7 +182,7 @@ RSpec.describe ReplyTransferMailer do
     end
 
     it "renders the content" do
-      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire")
+      expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un usager")
       expect(mail.body.encoded).to match("<h4>coucou</h4>")
       expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
       expect(mail.body.encoded).to match("Vous trouverez ci-dessous les informations nécessaires pour contacter")
@@ -211,7 +211,7 @@ RSpec.describe ReplyTransferMailer do
       end
 
       it "renders the content" do
-        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un.e bénéficiaire")
+        expect(mail.body.encoded).to match("Vous trouverez ci-dessous une réponse d'un usager")
         expect(mail.body.encoded).to match("<h4>coucou</h4>")
         expect(mail.body.encoded).to match("Je souhaite annuler mon RDV")
         expect(mail.body.encoded).to match("Vous trouverez ci-dessous les informations nécessaires pour contacter")


### PR DESCRIPTION
On enlève cette guard clause de redirection qui n'est plus légitime puisque les rdv_contexts ne sont pas affichés ici.

fix https://github.com/betagouv/rdv-insertion/issues/1768