### PR TITLE
feat(upload): signed_ids for documents

### DIFF
--- a/app/controllers/csv_exports_controller.rb
+++ b/app/controllers/csv_exports_controller.rb
@@ -1,6 +1,6 @@
 class CsvExportsController < ApplicationController
   def show
-    csv_export = CsvExport.find(params[:id])
+    csv_export = CsvExport.find_signed(params[:id].to_s) || CsvExport.find(params[:id])
     authorize csv_export
 
     if csv_export.expired?

--- a/app/controllers/users/parcours_documents_controller.rb
+++ b/app/controllers/users/parcours_documents_controller.rb
@@ -42,7 +42,7 @@ module Users
     end
 
     def set_parcours_document
-      @parcours_document = ParcoursDocument.find(params[:id])
+      @parcours_document = ParcoursDocument.find_signed!(params[:id].to_s)
     end
 
     def set_user

--- a/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
+++ b/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
@@ -2,7 +2,7 @@
 <p>Voici l'export CSV que vous avez demandé sur notre plateforme.</p>
 <p>Ce lien de téléchargement n'est valable que pendant <%= CsvExport::VALIDITY_PERIOD.in_hours.to_i %> heures à partir de l'envoi de ce mail.</p>
 <p class="btn-wrapper">
-  <%= link_to csv_export_url(id: @export.id), class: "btn btn-primary" do %>
+  <%= link_to csv_export_url(id: @export.signed_id), class: "btn btn-primary" do %>
     Télécharger le fichier
   <% end %>
 </p>

--- a/app/views/parcours_documents/_document.html.erb
+++ b/app/views/parcours_documents/_document.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag document do %>
  <div class="d-flex mb-1 w-50">
   <div class="w-75">
-    <%= link_to user_parcours_document_path(id: document.id, user_id: document.user_id), target: "_blank", class: "text-decoration-underline document-link" do %>
+    <%= link_to user_parcours_document_path(id: document.signed_id(expires_in: 1.hour), user_id: document.user_id), target: "_blank", class: "text-decoration-underline document-link" do %>
       <i class="fas fa-file-pdf mx-1"></i>
       <%= document.file.filename %>
       <i class="fas mx-1 fa-external-link-alt text-dark-blue"></i>
@@ -11,7 +11,7 @@
   <div class="w-25 text-end">
     <%= 
       link_to(
-        user_parcours_document_path(id: document.id, user_id: document.user_id),
+        user_parcours_document_path(id: document.signed_id(expires_in: 1.hour), user_id: document.user_id),
         data: {
           turbo_confirm: "Êtes-vous sûr de vouloir supprimer ce document ?",
           turbo_method: :delete,

--- a/spec/features/agent_can_download_csv_from_index_page_spec.rb
+++ b/spec/features/agent_can_download_csv_from_index_page_spec.rb
@@ -72,7 +72,7 @@ describe "Agents can download csv from index page", :js do
     end
 
     it "redirects to actual csv path" do
-      visit csv_export_path(id: export.id)
+      visit csv_export_path(id: export.signed_id)
 
       wait_for_download
       expect(downloads.length).to eq(1)
@@ -86,7 +86,7 @@ describe "Agents can download csv from index page", :js do
       end
 
       it "does not download the file" do
-        visit csv_export_path(id: export.id)
+        visit csv_export_path(id: export.signed_id)
 
         expect(page).to have_current_path(organisation_users_path(organisation))
       end
@@ -98,7 +98,7 @@ describe "Agents can download csv from index page", :js do
       end
 
       it "does not download the file" do
-        visit csv_export_path(id: export.id)
+        visit csv_export_path(id: export.signed_id)
 
         expect(page).to have_current_path(organisation_users_path(organisation))
       end


### PR DESCRIPTION
Afin de sécuriser un peu plus les URLs des documents et exports CSV, je met en place des IDs signés sans expiration pour les exports (déjà restreints via le expired? du model) et avec expiration pour l'index des documents de parcours. 

Pour l'instant je continue à supporter les IDs non signés pour les exports CSV car la feature est en prod et il doit donc se passer au moins 48 heures entre le déploiement de la feature et l'arrêt du support des IDs non signés. 