### PR TITLE
feat(inclusion_connect): use sub for identifying inclusion connected agents and handle francetravail domain migration

### DIFF
--- a/app/services/retrieve_inclusion_connect_agent_infos.rb
+++ b/app/services/retrieve_inclusion_connect_agent_infos.rb
@@ -8,6 +8,7 @@ class RetrieveInclusionConnectAgentInfos < BaseService
     request_token!
     request_agent_info!
     retrieve_agent!
+    # TODO : when we will have update endoint on rdvsp : update agent from rdvi
     retrieve_token_id
   end
 
@@ -46,7 +47,41 @@ class RetrieveInclusionConnectAgentInfos < BaseService
   end
 
   def retrieve_agent!
-    result.agent = Agent.find_by(email: agent_info_body["email"])
+    fail!("Inclusion Connect sub and email mismatch") if agent_mismatch?
+
+    result.agent = found_by_sub || found_by_email
     result.agent.presence || fail!("Agent doesn't exist in rdv-insertion")
+  end
+
+  def found_by_email
+    fail!("Inclusion connect info has a nil mail") if agent_info_body["email"].nil?
+
+    return @found_by_email if defined?(@found_by_email)
+
+    @found_by_email = Agent.find_by(email: agent_info_body["email"])
+
+    unless @found_by_email
+      # Les domaines francetravail.fr et pole-emploi.fr sont équivalents
+      # Enlever cette condition après la dernière vague de migration le 12 avril
+      # Les agents seront mis à jour dans rdvi depuis RDVSP quand ils se connecteront sur rdvsp,
+      # si il reste des agents avec des emails pole-emploi.fr aprés le 12/04 il faudra les mettre à jour manuellement
+      name, domain = agent_info_body["email"].split("@")
+      if domain.in?(["francetravail.fr", "pole-emploi.fr"])
+        acceptable_emails = ["#{name}@francetravail.fr", "#{name}@pole-emploi.fr"]
+        @found_by_email = Agent.find_by(email: acceptable_emails)
+      end
+    end
+
+    @found_by_email
+  end
+
+  def found_by_sub
+    fail!("Inclusion connect info has a nil sub") if agent_info_body["sub"].nil?
+
+    @found_by_sub ||= Agent.find_by(inclusion_connect_open_id_sub: agent_info_body["sub"])
+  end
+
+  def agent_mismatch?
+    found_by_sub && found_by_email && found_by_sub != found_by_email
   end
 end

--- a/app/services/retrieve_inclusion_connect_agent_infos.rb
+++ b/app/services/retrieve_inclusion_connect_agent_infos.rb
@@ -8,7 +8,7 @@ class RetrieveInclusionConnectAgentInfos < BaseService
     request_token!
     request_agent_info!
     retrieve_agent!
-    # TODO : when we will have update endoint on rdvsp : update agent from rdvi
+    # TODO : when we will have update endoint on rdvsp : update agent in rdvi and rdvsp
     retrieve_token_id
   end
 

--- a/db/migrate/20240312170449_add_agents_inclusion_connect_open_id_sub.rb
+++ b/db/migrate/20240312170449_add_agents_inclusion_connect_open_id_sub.rb
@@ -1,0 +1,6 @@
+class AddAgentsInclusionConnectOpenIdSub < ActiveRecord::Migration[7.1]
+  def change
+    add_column :agents, :inclusion_connect_open_id_sub, :string
+    add_index :agents, :inclusion_connect_open_id_sub, unique: true, where: "inclusion_connect_open_id_sub IS NOT NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_05_094354) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_12_170449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,7 +67,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_05_094354) do
     t.datetime "last_webhook_update_received_at"
     t.boolean "super_admin", default: false
     t.datetime "last_sign_in_at"
+    t.string "inclusion_connect_open_id_sub"
     t.index ["email"], name: "index_agents_on_email", unique: true
+    t.index ["inclusion_connect_open_id_sub"], name: "index_agents_on_inclusion_connect_open_id_sub", unique: true, where: "(inclusion_connect_open_id_sub IS NOT NULL)"
     t.index ["rdv_solidarites_agent_id"], name: "index_agents_on_rdv_solidarites_agent_id", unique: true
   end
 

--- a/spec/services/retrieve_inclusion_connect_agent_infos_spec.rb
+++ b/spec/services/retrieve_inclusion_connect_agent_infos_spec.rb
@@ -8,7 +8,12 @@ describe RetrieveInclusionConnectAgentInfos, type: :service do
   let(:token_response) { instance_double("Faraday::Response", success?: true, body: token_body) }
   let(:token_body) { { "id_token" => "test_id_token", "access_token" => "test_access_token" }.to_json }
   let(:agent_info_response) { instance_double("Faraday::Response", success?: true, body: agent_info_body) }
-  let(:agent_info_body) { { "email" => "test@example.com" }.to_json }
+  let(:agent_info_body) do
+    {
+      "email" => "test@example.com",
+      "sub" => "test_sub"
+    }.to_json
+  end
   let!(:agent) { create(:agent, email: "test@example.com") }
 
   before do
@@ -16,11 +21,10 @@ describe RetrieveInclusionConnectAgentInfos, type: :service do
     allow(InclusionConnectClient).to receive(:get_agent_info).with(
       JSON.parse(token_body)["access_token"]
     ).and_return(agent_info_response)
-    allow(Agent).to receive(:find_by).with(email: JSON.parse(agent_info_body)["email"]).and_return(agent)
   end
 
   describe "#call" do
-    context "when the agent is found and email is verified" do
+    context "when the agent is found with email" do
       it "retrieves agent information and returns a successful result" do
         expect(subject).to be_success
         expect(subject.agent).to eq(agent)
@@ -52,6 +56,127 @@ describe RetrieveInclusionConnectAgentInfos, type: :service do
       it "returns a failed result with an error message" do
         expect(subject).to be_failure
         expect(subject.errors).to include("Agent doesn't exist in rdv-insertion")
+      end
+    end
+
+    context "when the agent is found with a sub" do
+      let(:agent_info_body) do
+        {
+          "email" => "test@example.com",
+          "sub" => "test_sub"
+        }.to_json
+      end
+      let!(:agent) { create(:agent, email: "old_email@example.com", inclusion_connect_open_id_sub: "test_sub") }
+
+      it "retrieves agent information and returns a successful result based on sub" do
+        expect(subject).to be_success
+        expect(subject.agent).to eq(agent)
+        expect(subject.inclusion_connect_token_id).to eq(JSON.parse(token_body)["id_token"])
+      end
+    end
+
+    context "when the agent is found with a sub and email" do
+      let(:agent_info_body) do
+        {
+          "email" => "agent_with_email@example.com",
+          "sub" => "test_sub"
+        }.to_json
+      end
+      let!(:agent_with_sub) { create(:agent, inclusion_connect_open_id_sub: "test_sub") }
+      let!(:agent_with_email) { create(:agent, email: "agent_with_email@example.com") }
+
+      it "fail and add error" do
+        expect(subject).to be_failure
+        expect(subject.errors).to include("Inclusion Connect sub and email mismatch")
+      end
+    end
+
+    context "when inclusion connect send a nil email" do
+      let(:agent_info_body) do
+        {
+          "email" => nil,
+          "sub" => "test_sub"
+        }.to_json
+      end
+
+      it "fail and add error" do
+        expect(subject).to be_failure
+        expect(subject.errors).to include("Inclusion connect info has a nil mail")
+      end
+    end
+
+    context "when inclusion connect send a nil sub" do
+      let(:agent_info_body) do
+        {
+          "email" => "test@example.fr",
+          "sub" => nil
+        }.to_json
+      end
+
+      it "fail and add error" do
+        expect(subject).to be_failure
+        expect(subject.errors).to include("Inclusion connect info has a nil sub")
+      end
+    end
+
+    # --------------------------------------------------------------------------------------------
+    # Remove this after france-travail migration is done 12 avril 2024
+    # --------------------------------------------------------------------------------------------
+
+    context "with a francetravail.fr domain" do
+      let(:agent_info_body) do
+        {
+          "given_name" => "Bob",
+          "family_name" => "Eponge",
+          "email" => "bob@francetravail.fr",
+          "sub" => "12345678-90ab-cdef-1234-567890abcdef"
+        }.to_json
+      end
+
+      it "search @francetravail.fr (normal behavior)" do
+        agent = create(:agent, email: "bob@francetravail.fr")
+        expect(subject).to be_success
+        expect(subject.agent).to have_attributes(
+          id: agent.id,
+          email: "bob@francetravail.fr"
+        )
+      end
+
+      it "search @pole-emploi.fr" do
+        agent = create(:agent, email: "bob@pole-emploi.fr")
+        expect(subject).to be_success
+        expect(subject.agent).to have_attributes(
+          id: agent.id,
+          email: "bob@pole-emploi.fr"
+        )
+      end
+    end
+
+    context "with a pole-emploi.fr domain" do
+      let(:agent_info_body) do
+        {
+          "given_name" => "Bob",
+          "family_name" => "Eponge",
+          "email" => "bob@pole-emploi.fr",
+          "sub" => "12345678-90ab-cdef-1234-567890abcdef"
+        }.to_json
+      end
+
+      it "search @pole-emploi.fr (normal behavior)" do
+        agent = create(:agent, email: "bob@pole-emploi.fr")
+        expect(subject).to be_success
+        expect(subject.agent).to have_attributes(
+          id: agent.id,
+          email: "bob@pole-emploi.fr"
+        )
+      end
+
+      it "search @francetravail.fr" do
+        agent = create(:agent, email: "bob@francetravail.fr")
+        expect(agent.reload).to have_attributes(
+          id: agent.id,
+          email: "bob@francetravail.fr"
+        )
       end
     end
   end


### PR DESCRIPTION
close : https://github.com/betagouv/rdv-insertion/issues/1770
Concernant la mise à jour de l'agent dans RDVSP depuis chez nous et l'ouverture d'un endpoint dédié que tu proposes dans le ticket @aminedhobb je pense qu'en terme de délais on sera trop juste. 
La mise à jour des agents FT démarre le 15 mars et se termine le 12 avril. ([planning](https://mattermost.incubateur.net/betagouv/pl/1cqwhktycjb3mcuwxk1imh7boe))
Je propose cette PR qui considère les 2 domaines `pole-emploi.fr` et `francetravail.fr` pour la recherche d'un agent. 
Et je propose que l'on mette à jour manuellement tout les agents restants à la main après le 12 avril dans notre base. Les agents qui se seront connectés sur RDVSP seront déjà à jour chez nous via les webhook car j'ai implémenté l'[update des infos agents à la connexion inclusion connect dans RDVSP](https://github.com/betagouv/rdv-service-public/pull/4125).
Cela nous laisse le temps de travailler sur un endpoint agent coté RDVSP (et les autres modifications de l'api, authentification, versioning...)