### PR TITLE
feat(index): make user line clickable

### DIFF
--- a/app/javascript/controllers/user_link_controller.js
+++ b/app/javascript/controllers/user_link_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    this.userLinkUrl = new URL(window.location.protocol + window.location.host + this.data.get("path"));
+  }
+
+  navigate() {
+    window.location.href = this.userLinkUrl;
+  }
+}

--- a/app/javascript/controllers/user_link_controller.js
+++ b/app/javascript/controllers/user_link_controller.js
@@ -2,7 +2,9 @@ import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
   navigate(event) {
-    if (event.target.tagName === "INPUT" || event.target.tagName === "BUTTON") { return; }
+    if (event.target.tagName === "INPUT" || event.target.tagName === "BUTTON" || event.target.tagName === "I") {
+      return;
+    }
 
     this.userLinkUrl = new URL(window.location.protocol + window.location.host + this.data.get("path"));
     window.location.href = this.userLinkUrl;

--- a/app/javascript/controllers/user_link_controller.js
+++ b/app/javascript/controllers/user_link_controller.js
@@ -1,11 +1,10 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  connect() {
-    this.userLinkUrl = new URL(window.location.protocol + window.location.host + this.data.get("path"));
-  }
+  navigate(event) {
+    if (event.target.tagName === "INPUT" || event.target.tagName === "BUTTON") { return; }
 
-  navigate() {
+    this.userLinkUrl = new URL(window.location.protocol + window.location.host + this.data.get("path"));
     window.location.href = this.userLinkUrl;
   }
 }

--- a/app/javascript/stylesheets/components/_form.scss
+++ b/app/javascript/stylesheets/components/_form.scss
@@ -23,6 +23,11 @@
   padding: 20px;
 }
 
+.invitation-checkbox {
+  width: 18px;
+  height: 18px;
+}
+
 .rdv-insertion-form {
   input, select {
     background-color: $white;

--- a/app/javascript/stylesheets/pages/_users.scss
+++ b/app/javascript/stylesheets/pages/_users.scss
@@ -5,6 +5,10 @@
   }
 }
 
+.clickable {
+  cursor: pointer;
+}
+
 .icon-blue {
   color: $dark-blue;
   font-size: 0.9rem;

--- a/app/views/invitations/_checkbox_form.html.erb
+++ b/app/views/invitations/_checkbox_form.html.erb
@@ -9,7 +9,7 @@
             <i class="fas fa-redo-alt small-wheel"></i>
           <% end %>
         <% end %>
-        <%= f.check_box "#{invitation_format}_invite_for_user_#{user.id}", { class: checked ? "d-none" : "", data: { controller: "invitations-checkbox-form", action: "change->invitations-checkbox-form#submit" } }, false %>
+        <%= f.check_box "#{invitation_format}_invite_for_user_#{user.id}", { class: checked ? "d-none" : "invitation-checkbox", data: { controller: "invitations-checkbox-form", action: "change->invitations-checkbox-form#submit" } }, false %>
       </div>
     </div>
   <% end %>

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -10,7 +10,12 @@
   </thead>
   <tbody class="align-middle">
     <% @users.each do |user| %>
-      <tr <%= "class=table-danger" if user.archived_in?(@department) %>>
+      <tr
+        class="clickable <%= "table-danger" if user.archived_in?(@department) %>"
+        data-controller="user-link"
+        data-user-link-path="<%= structure_user_path(user.id) %>"
+        data-action="click->user-link#navigate"
+      >
         <td><%= display_attribute user.last_name %></td>
         <td><%= display_attribute user.first_name %></td>
         <td><%= display_attribute format_date(user.created_at) %></td>

--- a/app/views/users/_archived_users_table.html.erb
+++ b/app/views/users/_archived_users_table.html.erb
@@ -11,7 +11,12 @@
   </thead>
   <tbody class="align-middle">
     <% @users.each do |user| %>
-      <tr class="table-danger">
+      <tr
+        class="table-danger clickable"
+        data-controller="user-link"
+        data-user-link-path="<%= structure_user_path(user.id) %>"
+        data-action="click->user-link#navigate"
+      >
         <td><%= display_attribute user.last_name %></td>
         <td><%= display_attribute user.first_name %></td>
         <td><%= display_attribute format_date(user.created_at) %></td>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -18,7 +18,12 @@
   <tbody class="align-middle">
     <% @users.each do |user| %>
       <% rdv_context = user.rdv_context_for(@current_motif_category) %>
-      <tr>
+      <tr
+        class="clickable"
+        data-controller="user-link"
+        data-user-link-path="<%= structure_user_path(user.id) %>"
+        data-action="click->user-link#navigate"
+      >
         <td><%= display_attribute user.last_name %></td>
         <td><%= display_attribute user.first_name %></td>
         <% @current_configuration.invitation_formats.each do |invitation_format| %>


### PR DESCRIPTION
closes #1777 

Dans cette PR, je fais en sorte que toute la ligne d'un usager sur les pages index soit cliquable pour se rendre sur son profil (et plus seulement le bouton "gérer").
Finalement @samanthaauffret je trouve que ce n'est pas gênant pour les actions que toute la ligne soit cliquable, avec le curseur qui change je trouve ça assez intuitif de voir si on est sur le bouton ou non. Pour faciliter le clic pour générer les invitations, j'ai légèrement agrandi la checkbox qu'il faut cliquer pour envoyer une invitation.