### PR TITLE
feat(agent_rdvsp_attributes): add inclusion_connect_open_id_sub to rdvsp agents attributes for webhooks

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -1,5 +1,5 @@
 class Agent < ApplicationRecord
-  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:email, :first_name, :last_name].freeze
+  SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [:email, :first_name, :last_name, :inclusion_connect_open_id_sub].freeze
 
   include Agent::RdvSolidaritesClient
 
@@ -16,6 +16,7 @@ class Agent < ApplicationRecord
   has_many :users, through: :referent_assignations
 
   validates :email, presence: true, uniqueness: true
+  validates :inclusion_connect_open_id_sub, uniqueness: true, allow_nil: true
   validates :rdv_solidarites_agent_id, uniqueness: true, allow_nil: true
 
   validate :cannot_save_as_super_admin

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:email) { |n| "agent#{n}@gouv.fr" }
     sequence(:first_name) { |n| "jane#{n}" }
     sequence(:last_name) { |n| "doe#{n}" }
+    sequence(:inclusion_connect_open_id_sub) { SecureRandom.uuid }
     sequence(:rdv_solidarites_agent_id)
 
     transient do

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_job_spec.rb
@@ -6,7 +6,8 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentJob do
   let!(:data) do
     {
       "id" => rdv_solidarites_agent_id,
-      "email" => "linus@linux.com"
+      "email" => "linus@linux.com",
+      "inclusion_connect_open_id_sub" => "1234"
     }.deep_symbolize_keys
   end
 

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_agent_role_job_spec.rb
@@ -13,7 +13,8 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
   end
 
   let!(:agent_attributes) do
-    { id: rdv_solidarites_agent_id, first_name: "Josiane", last_name: "balasko" }
+    { id: rdv_solidarites_agent_id, first_name: "Josiane", last_name: "balasko", email: "josiane.balasko@gmail.com",
+      inclusion_connect_open_id_sub: "1234" }
   end
   let!(:rdv_solidarites_agent_role_id) { 17 }
   let!(:rdv_solidarites_organisation_id) { 222 }
@@ -22,7 +23,11 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
   let!(:organisation) do
     create(:organisation, rdv_solidarites_organisation_id:, id: 923, name: "Pôle Parcours")
   end
-  let!(:agent) { create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id) }
+  let!(:agent) do
+    create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id, first_name: "Josiane", last_name: "balasko",
+                   email: "josiane.balasko@gmail.com",
+                   inclusion_connect_open_id_sub: "1234")
+  end
   let!(:agent_role) do
     create(:agent_role, organisation: organisation, agent: agent, rdv_solidarites_agent_role_id: nil)
   end
@@ -142,6 +147,9 @@ describe InboundWebhooks::RdvSolidarites::ProcessAgentRoleJob do
             { organisation_id: organisation.id, agent_id: agent.id, last_webhook_update_received_at: meta[:timestamp] }
           )
         subject
+        expect(agent).to have_attributes(
+          agent_attributes.except(:id).merge(rdv_solidarites_agent_id: rdv_solidarites_agent_id)
+        )
       end
 
       context "when the agent upsert fails" do

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -19,6 +19,34 @@ describe Agent do
     end
   end
 
+  describe "agent inclusion_connect_open_id_sub uniqueness validation" do
+    context "no collision" do
+      let(:agent) { build(:agent, inclusion_connect_open_id_sub: "test1234") }
+
+      it { expect(agent).to be_valid }
+    end
+
+    context "allow nil value" do
+      let!(:agent_existing) { create(:agent, inclusion_connect_open_id_sub: nil) }
+      let(:agent) { build(:agent, inclusion_connect_open_id_sub: nil) }
+
+      it { expect(agent).to be_valid }
+    end
+
+    context "colliding inclusion_connect_open_id_sub" do
+      let!(:agent_existing) { create(:agent, inclusion_connect_open_id_sub: "test1234") }
+      let(:agent) { build(:agent, inclusion_connect_open_id_sub: "test1234") }
+
+      it "adds errors" do
+        expect(agent).not_to be_valid
+        expect(agent.errors.details).to eq({ inclusion_connect_open_id_sub: [{ error: :taken,
+                                                                               value: "test1234" }] })
+        expect(agent.errors.full_messages.to_sentence)
+          .to include("Inclusion connect open id sub est déjà utilisé")
+      end
+    end
+  end
+
   describe "agent email presence validation" do
     context "with no email" do
       let(:agent) { build(:agent, email: "") }

--- a/spec/services/upsert_record_spec.rb
+++ b/spec/services/upsert_record_spec.rb
@@ -1,106 +1,165 @@
 describe UpsertRecord, type: :service do
-  subject do
-    described_class.call(
-      klass: klass, rdv_solidarites_attributes: rdv_solidarites_attributes,
-      additional_attributes: additional_attributes
-    )
-  end
+  context "for a rdv" do
+    subject do
+      described_class.call(
+        klass: klass, rdv_solidarites_attributes: rdv_solidarites_attributes,
+        additional_attributes: additional_attributes
+      )
+    end
 
-  let!(:klass) { Rdv }
-  let!(:additional_attributes) do
-    {
-      participations_attributes: [
-        {
-          id: nil,
-          status: "unknown",
-          created_by: created_by,
-          user_id: user_id,
-          rdv_solidarites_participation_id: 998,
-          rdv_context_id: rdv_context.id
-        }
-      ],
-      lieu_id: lieu.id,
-      motif_id: motif.id,
-      organisation_id: organisation.id
-    }
-  end
-  let!(:user_id) { 33 }
-  let!(:user_ids) { [user_id] }
-  let!(:organisation) { create(:organisation) }
-  let!(:rdv_solidarites_rdv_id) { 12 }
-  let!(:rdv_solidarites_attributes) do
-    { id: 12, starts_at: starts_at, duration_in_min: duration_in_min,
-      status: status, created_by: created_by }
-  end
-  let!(:user) { create(:user, id: user_id) }
-  let!(:rdv_context) { create(:rdv_context) }
-  let!(:lieu) { create(:lieu) }
-  let!(:motif) { create(:motif) }
-  let!(:starts_at) { Time.zone.parse("2021-09-08 12:00:00") }
-  let!(:duration_in_min) { 45 }
-  let!(:status) { "unknown" }
-  let!(:created_by) { "user" }
+    let!(:klass) { Rdv }
+    let!(:additional_attributes) do
+      {
+        participations_attributes: [
+          {
+            id: nil,
+            status: "unknown",
+            created_by: created_by,
+            user_id: user_id,
+            rdv_solidarites_participation_id: 998,
+            rdv_context_id: rdv_context.id
+          }
+        ],
+        lieu_id: lieu.id,
+        motif_id: motif.id,
+        organisation_id: organisation.id
+      }
+    end
+    let!(:user_id) { 33 }
+    let!(:user_ids) { [user_id] }
+    let!(:organisation) { create(:organisation) }
+    let!(:rdv_solidarites_rdv_id) { 12 }
+    let!(:rdv_solidarites_attributes) do
+      { id: 12, starts_at: starts_at, duration_in_min: duration_in_min,
+        status: status, created_by: created_by }
+    end
+    let!(:user) { create(:user, id: user_id) }
+    let!(:rdv_context) { create(:rdv_context) }
+    let!(:lieu) { create(:lieu) }
+    let!(:motif) { create(:motif) }
+    let!(:starts_at) { Time.zone.parse("2021-09-08 12:00:00") }
+    let!(:duration_in_min) { 45 }
+    let!(:status) { "unknown" }
+    let!(:created_by) { "user" }
 
-  describe "#call" do
-    context "when the record exists" do
-      let!(:rdv) { create(:rdv, rdv_solidarites_rdv_id: rdv_solidarites_rdv_id) }
+    describe "#call" do
+      context "when the record exists" do
+        let!(:rdv) { create(:rdv, rdv_solidarites_rdv_id: rdv_solidarites_rdv_id) }
 
-      it "assigns the attributes" do
-        subject
-        rdv.reload
-        expect(rdv.starts_at).to eq(starts_at)
-        expect(rdv.duration_in_min).to eq(duration_in_min)
-        expect(rdv.status).to eq(status)
-        expect(rdv.created_by).to eq("user")
-        expect(rdv.user_ids).to include(*user_ids)
-        expect(rdv.id).not_to eq(rdv_solidarites_rdv_id)
+        it "assigns the attributes" do
+          subject
+          rdv.reload
+          expect(rdv.starts_at).to eq(starts_at)
+          expect(rdv.duration_in_min).to eq(duration_in_min)
+          expect(rdv.status).to eq(status)
+          expect(rdv.created_by).to eq("user")
+          expect(rdv.user_ids).to include(*user_ids)
+          expect(rdv.id).not_to eq(rdv_solidarites_rdv_id)
 
-        # it also creates a participation in this case
-        participation = Participation.order(:created_at).last
-        expect(participation.user_id).to eq(user.id)
-        expect(participation.rdv_id).to eq(rdv.id)
-        expect(participation.created_by).to eq("user")
-        expect(participation.rdv_context_id).to eq(rdv_context.id)
-      end
-
-      context "when it is an old update" do
-        let!(:additional_attributes) { { last_webhook_update_received_at: "2021-09-08 11:05:00 UTC" } }
-        let!(:rdv) do
-          create(
-            :rdv,
-            rdv_solidarites_rdv_id: rdv_solidarites_rdv_id,
-            last_webhook_update_received_at: "2021-09-08 11:06:00 UTC"
-          )
+          # it also creates a participation in this case
+          participation = Participation.order(:created_at).last
+          expect(participation.user_id).to eq(user.id)
+          expect(participation.rdv_id).to eq(rdv.id)
+          expect(participation.created_by).to eq("user")
+          expect(participation.rdv_context_id).to eq(rdv_context.id)
         end
 
-        it "does not update the rdv" do
+        context "when it is an old update" do
+          let!(:additional_attributes) { { last_webhook_update_received_at: "2021-09-08 11:05:00 UTC" } }
+          let!(:rdv) do
+            create(
+              :rdv,
+              rdv_solidarites_rdv_id: rdv_solidarites_rdv_id,
+              last_webhook_update_received_at: "2021-09-08 11:06:00 UTC"
+            )
+          end
+
+          it "does not update the rdv" do
+            subject
+            expect(rdv.starts_at).not_to eq(starts_at)
+            expect(rdv.duration_in_min).not_to eq(duration_in_min)
+          end
+        end
+      end
+
+      context "when the record does not exist" do
+        let!(:rdv) { create(:rdv, rdv_solidarites_rdv_id: 95) }
+
+        it "creates a new record with the attributes" do
           subject
-          expect(rdv.starts_at).not_to eq(starts_at)
-          expect(rdv.duration_in_min).not_to eq(duration_in_min)
+
+          new_rdv = Rdv.order(:created_at).last
+          expect(new_rdv.id).not_to eq(rdv.id)
+
+          expect(new_rdv.starts_at).to eq(starts_at)
+          expect(new_rdv.duration_in_min).to eq(duration_in_min)
+          expect(new_rdv.status).to eq(status)
+          expect(new_rdv.user_ids).to include(*user_ids)
+          expect(new_rdv.id).not_to eq(rdv_solidarites_rdv_id)
+
+          # it also creates a participation in this case
+          participation = Participation.order(:created_at).last
+          expect(participation.user_id).to eq(user.id)
+          expect(participation.rdv_id).to eq(new_rdv.id)
+          expect(participation.rdv_context_id).to eq(rdv_context.id)
         end
       end
     end
+  end
 
-    context "when the record does not exist" do
-      let!(:rdv) { create(:rdv, rdv_solidarites_rdv_id: 95) }
+  context "for an agent" do
+    subject do
+      described_class.call(klass: klass, rdv_solidarites_attributes: agent_attributes)
+    end
 
-      it "creates a new record with the attributes" do
-        subject
+    let!(:klass) { Agent }
+    let!(:rdv_solidarites_agent_id) { 12 }
+    let!(:agent_attributes) do
+      { id: rdv_solidarites_agent_id, first_name: "Josiane", last_name: "balasko", email: "josiane.balasko@gmail.com",
+        inclusion_connect_open_id_sub: "1234" }
+    end
 
-        new_rdv = Rdv.order(:created_at).last
-        expect(new_rdv.id).not_to eq(rdv.id)
+    describe "#call" do
+      context "when the record exists" do
+        let!(:agent) { create(:agent, rdv_solidarites_agent_id: rdv_solidarites_agent_id) }
 
-        expect(new_rdv.starts_at).to eq(starts_at)
-        expect(new_rdv.duration_in_min).to eq(duration_in_min)
-        expect(new_rdv.status).to eq(status)
-        expect(new_rdv.user_ids).to include(*user_ids)
-        expect(new_rdv.id).not_to eq(rdv_solidarites_rdv_id)
+        it "assigns the attributes" do
+          subject
+          agent.reload
+          expect(agent).to have_attributes(
+            agent_attributes.except(:id).merge(rdv_solidarites_agent_id: rdv_solidarites_agent_id)
+          )
+        end
 
-        # it also creates a participation in this case
-        participation = Participation.order(:created_at).last
-        expect(participation.user_id).to eq(user.id)
-        expect(participation.rdv_id).to eq(new_rdv.id)
-        expect(participation.rdv_context_id).to eq(rdv_context.id)
+        context "when it is an old update" do
+          let!(:additional_attributes) { { last_webhook_update_received_at: "2021-09-08 11:05:00 UTC" } }
+          let!(:agent) do
+            create(
+              :agent,
+              first_name: "Frédéric",
+              rdv_solidarites_agent_id: rdv_solidarites_agent_id,
+              last_webhook_update_received_at: "2021-09-08 11:06:00 UTC"
+            )
+          end
+
+          it "does not update the agent" do
+            subject
+            expect(agent.first_name).not_to eq("Josiane")
+          end
+        end
+      end
+
+      context "when the agent does not exist" do
+        let!(:agent) { create(:agent, rdv_solidarites_agent_id: 95) }
+
+        it "creates a new agent with the attributes" do
+          subject
+
+          new_agent = Agent.last
+          expect(new_agent).to have_attributes(
+            agent_attributes.except(:id).merge(rdv_solidarites_agent_id: rdv_solidarites_agent_id)
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
J'ajoute ici le champ `inclusion_connect_open_id_sub` dans les attributs rdvsp des agents, celui ci sert à l'authentification (clé unique) dans inclusion connect.
Le code est déjà implémenté dans rdvps pour que l'on puisse recevoir le nouveau champ.
J'ai ajouté quelques tests pour être sur que tout est ok.