### PR TITLE
feat(jobs): avoid having to declare environment guard clause in jobs

### DIFF
--- a/app/jobs/designate_on_watch_developer_job.rb
+++ b/app/jobs/designate_on_watch_developer_job.rb
@@ -2,8 +2,6 @@ class DesignateOnWatchDeveloperJob < ApplicationJob
   DEVELOPERS_HANDLE = %w[quentin.blanc amine.dhobb michael.villeneuve].freeze
 
   def perform
-    return unless production_env?
-
     current_on_watch_developer_handle = redis_client.get("current_on_watch_developer_handle")
     new_on_watch_developer_handle = DEVELOPERS_HANDLE[
       (DEVELOPERS_HANDLE.index(current_on_watch_developer_handle) + 1) % DEVELOPERS_HANDLE.length

--- a/app/jobs/monitor_webhook_activity_job.rb
+++ b/app/jobs/monitor_webhook_activity_job.rb
@@ -10,8 +10,6 @@ class MonitorWebhookActivityJob < ApplicationJob
   ].freeze
 
   def perform
-    return if staging_env?
-
     alertable_models = MONITORS.select do |monitor|
       monitor[:model].where("last_webhook_update_received_at > ?", monitor[:acceptable_delay].ago).empty?
     end

--- a/app/jobs/send_convocation_reminders_job.rb
+++ b/app/jobs/send_convocation_reminders_job.rb
@@ -1,7 +1,5 @@
 class SendConvocationRemindersJob < ApplicationJob
   def perform
-    return if staging_env?
-
     NotifyParticipationsJob.perform_async(participations_to_send_reminders_to.ids, "reminder")
     notify_on_mattermost
   end

--- a/app/jobs/send_creneau_availability_alert_job.rb
+++ b/app/jobs/send_creneau_availability_alert_job.rb
@@ -1,7 +1,5 @@
 class SendCreneauAvailabilityAlertJob < ApplicationJob
   def perform
-    return if staging_env?
-
     Department.find_each do |departement|
       departement.organisations.each do |organisation|
         NotifyUnavailableCreneauJob.perform_async(organisation.id)

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -1,7 +1,5 @@
 class SendInvitationRemindersJob < ApplicationJob
   def perform
-    return if staging_env?
-
     @sent_reminders_user_ids = []
 
     rdv_contexts_with_reminder_needed.find_each do |rdv_context|

--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -1,7 +1,5 @@
 class SendPeriodicInvitesJob < ApplicationJob
   def perform
-    return if staging_env?
-
     @sent_invites_user_ids = []
 
     RdvContext

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -34,7 +34,7 @@ designate_on_watch_developer_job:
   cron: "0 10 * * mon" # we designate an on watch developer once a week, monday at 10:00
   class: "DesignateOnWatchDeveloperJob"
   run_only_in_env:
-    - staging
+    - production
 send_creneau_availability_alert_job:
   cron: "0 01 * * *" # we verify organisations creneaux availability once a day, at 01:00
   class: "SendCreneauAvailabilityAlertJob"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,6 +1,8 @@
 monitor_webhook_activity_job:
   cron: "0 0-1,6-23 * * 1-5" # Monitor webhooks activity every hour from Monday to Friday except between 1:00 and 6:00
   class: "MonitorWebhookActivityJob"
+  run_only_in_env:
+    - production
 upsert_global_stats_job:
   cron: "0 22 * * 6" # we compute global stats once a week, the saturday at 22:00
   class: "Stats::GlobalStats::UpsertStatsJob"
@@ -10,21 +12,31 @@ upsert_monthly_stats_job:
 send_periodic_invites_job:
   cron: "0 14 * * *" # we send recurrent invitations X days after the previous one, at 14:00
   class: "SendPeriodicInvitesJob"
+  run_only_in_env:
+    - production
 send_invitation_reminders_job:
   cron: "0 11 * * *" # we send reminders once a day, at 11:00
   class: "SendInvitationRemindersJob"
+  run_only_in_env:
+    - production
 refresh_out_of_date_rdv_context_statuses_job:
   cron: "0 21 * * *" # we refresh out of date statuses once a day, at 21:00
   class: "RefreshOutOfDateRdvContextStatusesJob"
 send_convocation_reminders_job:
   cron: "0 10 * * *" # we send reminders once a day, at 10:00
   class: "SendConvocationRemindersJob"
+  run_only_in_env:
+    - production
 destroy_old_ressources_job:
   cron: "0 0 * * *" # we destroy inactive users and useless ressources once a day, at 00:00
   class: "DestroyOldRessourcesJob"
 designate_on_watch_developer_job:
   cron: "0 10 * * mon" # we designate an on watch developer once a week, monday at 10:00
   class: "DesignateOnWatchDeveloperJob"
+  run_only_in_env:
+    - staging
 send_creneau_availability_alert_job:
   cron: "0 01 * * *" # we verify organisations creneaux availability once a day, at 01:00
   class: "SendCreneauAvailabilityAlertJob"
+  run_only_in_env:
+    - production


### PR DESCRIPTION
Cette PR permet de ne plus avoir à déclarer de guard clause pour éviter de run le job dans l'environment dans lequel il est lancé. De cette façon, les jobs ne seront carrément pas scheduled du tout. 

Je trouve l'idée intéressante mais j'aime pas mettre du code non testé unitairement dans les initializers. 
Pour ceux qui feront la review : je vous invite à run le code en local idéalement avec plusieurs envs histoire qu'on soit serein sur son fonctionnement. 

Fix https://github.com/betagouv/rdv-insertion/issues/1743