### PR TITLE
feat(stats): better way to compute average time between invitation and rdv

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -64,15 +64,6 @@ class Stat < ApplicationRecord
     @invited_users_set ||= users_set.with_sent_invitations.distinct
   end
 
-  # We filter the rdv_contexts to keep those where the users were invited and created a rdv/participation
-  def rdv_contexts_with_invitations_and_participations_set
-    RdvContext.preload(:participations, :invitations)
-              .where(user_id: users_set)
-              .where.associated(:participations)
-              .with_sent_invitations
-              .distinct
-  end
-
   # We filter the users by organisations and retrieve deleted or archived users
   def users_set
     users = User.active.where.not(id: archived_user_ids).preload(:participations)

--- a/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
+++ b/app/services/stats/compute_average_time_between_invitation_and_rdv_in_days.rb
@@ -1,7 +1,7 @@
 module Stats
   class ComputeAverageTimeBetweenInvitationAndRdvInDays < BaseService
-    def initialize(stat:, range: nil)
-      @stat = stat
+    def initialize(structure: nil, range: nil)
+      @structure = structure
       @range = range
     end
 
@@ -12,14 +12,14 @@ module Stats
     private
 
     def structure_filter
-      return "" if @stat.statable_id.nil?
+      return "" if @structure.nil?
 
-      if @stat.statable_type == "Department"
-        "WHERE invitations.department_id = #{@stat.statable_id}"
+      if @structure.is_a?(Department)
+        "WHERE invitations.department_id = #{@structure.id}"
       else
         <<-SQL.squish
           JOIN invitations_organisations io ON invitations.id = io.invitation_id
-          WHERE io.organisation_id = #{@stat.statable_id}
+          WHERE io.organisation_id = #{@structure.id}
         SQL
       end
     end

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -53,9 +53,7 @@ module Stats
       end
 
       def average_time_between_invitation_and_rdv_in_days
-        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(
-          rdv_contexts: @stat.rdv_contexts_with_invitations_and_participations_set
-        ).value
+        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(stat: @stat).value
       end
 
       def rate_of_users_oriented_in_less_than_30_days

--- a/app/services/stats/global_stats/compute.rb
+++ b/app/services/stats/global_stats/compute.rb
@@ -53,7 +53,7 @@ module Stats
       end
 
       def average_time_between_invitation_and_rdv_in_days
-        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(stat: @stat).value
+        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(structure: @stat.statable).value
       end
 
       def rate_of_users_oriented_in_less_than_30_days

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -61,9 +61,7 @@ module Stats
       end
 
       def average_time_between_invitation_and_rdv_in_days_for_focused_month
-        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(
-          rdv_contexts: created_during_focused_month(@stat.rdv_contexts_with_invitations_and_participations_set)
-        ).value.round
+        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(stat: @stat, range: @date.all_month).value.round
       end
 
       def rate_of_users_oriented_in_less_than_30_days_for_focused_month

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -61,7 +61,10 @@ module Stats
       end
 
       def average_time_between_invitation_and_rdv_in_days_for_focused_month
-        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(stat: @stat, range: @date.all_month).value.round
+        ComputeAverageTimeBetweenInvitationAndRdvInDays.call(
+          structure: @stat.statable,
+          range: @date.all_month
+        ).value.round
       end
 
       def rate_of_users_oriented_in_less_than_30_days_for_focused_month

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -156,41 +156,6 @@ describe Stat do
         end
       end
 
-      describe "#rdv_contexts_with_invitations_and_participations_set" do
-        let!(:user3) { create(:user, organisations: [organisation]) }
-        let!(:rdv3) { create(:rdv, organisation: organisation) }
-        let!(:participation3) { create(:participation, rdv: rdv3, rdv_context: rdv_context3) }
-        let!(:rdv_context3) { create(:rdv_context, user: user3) }
-        let!(:user4) { create(:user, organisations: [organisation]) }
-        let!(:invitation4) { create(:invitation, rdv_context: rdv_context4) }
-        let!(:rdv4) { create(:rdv, organisation: organisation) }
-        let!(:participation4) { create(:participation, rdv: rdv4, rdv_context: rdv_context4) }
-        let!(:rdv_context4) { create(:rdv_context, user: user4) }
-        let!(:user5) { create(:user, organisations: [organisation]) }
-        let!(:invitation5) { create(:invitation, rdv_context: rdv_context5) }
-        let!(:rdv_context5) { create(:rdv_context, user: user5) }
-        let!(:user6) do
-          create(:user, organisations: [organisation_with_no_configuration])
-        end
-        let!(:invitation6) { create(:invitation, created_at: date, rdv_context: rdv_context6) }
-        let!(:rdv6) { create(:rdv, organisation: organisation) }
-        let!(:participation6) { create(:participation, rdv: rdv6, rdv_context: rdv_context6) }
-        let!(:rdv_context6) { create(:rdv_context, user: user6) }
-
-        it "scopes the collection to the department" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).to include(rdv_context1)
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context2)
-        end
-
-        it "does not include rdv_contexts with no invitations" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context3)
-        end
-
-        it "does not include rdv_contexts with no rdvs" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context5)
-        end
-      end
-
       describe "#rdvs_non_collectifs_set" do
         let!(:user3) do
           create(:user, organisations: [organisation])
@@ -387,45 +352,6 @@ describe Stat do
         end
       end
 
-      describe "#rdv_contexts_with_invitations_and_participations_set" do
-        let!(:user3) { create(:user, organisations: [organisation]) }
-        let!(:rdv3) { create(:rdv, organisation: organisation) }
-        let!(:participation3) { create(:participation, rdv: rdv3, rdv_context: rdv_context3) }
-        let!(:rdv_context3) { create(:rdv_context, user: user3) }
-        let!(:user4) { create(:user, organisations: [organisation]) }
-        let!(:invitation4) { create(:invitation, rdv_context: rdv_context4) }
-        let!(:rdv4) { create(:rdv, organisation: organisation) }
-        let!(:participation4) { create(:participation, rdv: rdv4, rdv_context: rdv_context4) }
-        let!(:rdv_context4) { create(:rdv_context, user: user4) }
-        let!(:user5) { create(:user, organisations: [organisation]) }
-        let!(:invitation5) { create(:invitation, rdv_context: rdv_context5) }
-        let!(:rdv_context5) { create(:rdv_context, user: user5) }
-        let!(:user6) do
-          create(:user, organisations: [organisation_with_no_configuration])
-        end
-        let!(:invitation6) { create(:invitation, created_at: date, rdv_context: rdv_context6) }
-        let!(:rdv6) { create(:rdv, organisation: organisation) }
-        let!(:participation6) { create(:participation, rdv: rdv6, rdv_context: rdv_context6) }
-        let!(:rdv_context6) { create(:rdv_context, user: user6) }
-
-        it "scopes the collection to the organisation" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).to include(rdv_context1)
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context2)
-        end
-
-        it "does not include rdv_contexts with no invitations" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context3)
-        end
-
-        it "does not include rdv_contexts with no rdvs" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context5)
-        end
-
-        it "does not include the rdv_contexts of users from irrelevant organisations" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).not_to include(rdv_context6)
-        end
-      end
-
       describe "#rdvs_non_collectifs_set" do
         let!(:user3) do
           create(:user, organisations: [organisation])
@@ -549,12 +475,6 @@ describe Stat do
         it "does not scope the collection to the department" do
           expect(stat.agents_set).to include(agent1)
           expect(stat.agents_set).to include(agent2)
-        end
-      end
-
-      describe "#rdv_contexts_with_invitations_and_participations_set" do
-        it "does not scope the collection to the department" do
-          expect(stat.rdv_contexts_with_invitations_and_participations_set).to include(rdv_context2)
         end
       end
 

--- a/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
+++ b/spec/services/stats/compute_average_time_between_invitation_and_rdv_in_days_spec.rb
@@ -1,5 +1,5 @@
 describe Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays, type: :service do
-  subject { described_class.call(stat: stat) }
+  subject { described_class.call(structure: stat.statable) }
 
   let(:date) { Time.zone.parse("17/03/2022 12:00") }
 
@@ -71,7 +71,7 @@ describe Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays, type: :service 
     end
 
     context "when given range" do
-      subject { described_class.call(stat: stat, range: invitation1.created_at.all_month) }
+      subject { described_class.call(structure: stat.statable, range: invitation1.created_at.all_month) }
 
       # Off range, must not be taken into account
       let!(:invitation2) { create(:invitation, created_at: 2.days.ago, rdv_context: rdv_context2) }

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -26,7 +26,6 @@ describe Stats::GlobalStats::Compute, type: :service do
         invitations_set: Invitation.where(id: [invitation1, invitation2]),
         participations_after_invitations_set: Participation.where(id: [participation1]),
         participations_with_notifications_set: Participation.where(id: [participation2]),
-        rdv_contexts_with_invitations_and_participations_set: RdvContext.where(id: [rdv_context1, rdv_context2]),
         users_set: User.where(id: [user1, user2]),
         users_first_orientation_rdv_context: RdvContext.where(id: [rdv_context1, rdv_context2]),
         orientation_rdv_contexts_with_invitations: RdvContext.where(id: [rdv_context1, rdv_context2]),
@@ -123,9 +122,8 @@ describe Stats::GlobalStats::Compute, type: :service do
     end
 
     it "computes the average time between first invitation and first rdv in days" do
-      expect(stat).to receive(:rdv_contexts_with_invitations_and_participations_set)
       expect(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
-        .with(rdv_contexts: [rdv_context1, rdv_context2])
+        .with(stat:)
       subject
     end
 

--- a/spec/services/stats/global_stats/compute_spec.rb
+++ b/spec/services/stats/global_stats/compute_spec.rb
@@ -123,7 +123,7 @@ describe Stats::GlobalStats::Compute, type: :service do
 
     it "computes the average time between first invitation and first rdv in days" do
       expect(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
-        .with(stat:)
+        .with(structure: stat.statable)
       subject
     end
 

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -32,7 +32,6 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
         invitations_set: Invitation.where(id: [invitation1, invitation2]),
         participations_after_invitations_set: Participation.where(id: [participation1]),
         participations_with_notifications_set: Participation.where(id: [participation2]),
-        rdv_contexts_with_invitations_and_participations_set: RdvContext.where(id: [rdv_context1, rdv_context2]),
         users_set: User.where(id: [user1, user2]),
         users_first_orientation_rdv_context: RdvContext.where(id: [rdv_context2]),
         orientation_rdv_contexts_with_invitations: RdvContext.where(id: [rdv_context1, rdv_context2]),
@@ -125,9 +124,8 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
     end
 
     it "computes the average time between first invitation and first rdv in days" do
-      expect(stat).to receive(:rdv_contexts_with_invitations_and_participations_set)
       expect(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
-        .with(stat: stat)
+        .with(stat: stat, range: date.all_month)
       subject
     end
 

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -127,7 +127,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
     it "computes the average time between first invitation and first rdv in days" do
       expect(stat).to receive(:rdv_contexts_with_invitations_and_participations_set)
       expect(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
-        .with(rdv_contexts: [rdv_context1])
+        .with(stat: stat)
       subject
     end
 

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -125,7 +125,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
 
     it "computes the average time between first invitation and first rdv in days" do
       expect(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
-        .with(stat: stat, range: date.all_month)
+        .with(structure: stat.statable, range: date.all_month)
       subject
     end
 


### PR DESCRIPTION
Dans cette PR je change le mode de calcul de la stat `ComputeAverageTimeBetweenInvitationAndRdvInDays` pour le faire en pur SQL. 

La différence est monumentale car on s'évite une N+1 ce qui nous fera au total gagner plusieurs minutes de calcul pour l'ensemble des stats.

Pour info on pourrait faire encore mieux car il est inutile d'itérer sur l'ensemble des mois pour récuperer le résultat, on pourrait tout faire en une seule requête comme effectué ici https://rdv-service-public-metabase.osc-secnum-fr1.scalingo.io/question/74-delai-entre-invitation-et-participation-groupe-par-mois
Si on veut faire ça il faudra revoir l'ensemble des stats pour changer la façon de les calculer. 

Quoi qu'il en soit cela devrait déjà énormément aider ! 