### PR TITLE
fix(inclusion_connect): better message for agent when inclusion connect email doesnt exist in rdvi/rdvsp

### DIFF
--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -63,7 +63,7 @@ class InclusionConnectController < ApplicationController
   end
 
   def handle_failed_authentication(errors)
-    Sentry.capture_message(errors)
+    Sentry.capture_message(errors) unless errors == "Agent doesn't exist in rdv-insertion"
     flash[:error] = case errors
                     when "Agent doesn't exist in rdv-insertion"
                       "Il n'y a pas de compte agent pour l'adresse mail #{inclusion_connect_agent_info['email']}. " \

--- a/app/controllers/inclusion_connect_controller.rb
+++ b/app/controllers/inclusion_connect_controller.rb
@@ -29,6 +29,10 @@ class InclusionConnectController < ApplicationController
     retrieve_inclusion_connect_infos.agent
   end
 
+  def inclusion_connect_agent_info
+    retrieve_inclusion_connect_infos.inclusion_connect_agent_info
+  end
+
   def inclusion_connect_token_id
     retrieve_inclusion_connect_infos.inclusion_connect_token_id
   end
@@ -60,8 +64,17 @@ class InclusionConnectController < ApplicationController
 
   def handle_failed_authentication(errors)
     Sentry.capture_message(errors)
-    flash[:error] = "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse" \
-                    "<rdv-insertion@beta.gouv.fr> si le problème persiste."
+    flash[:error] = case errors
+                    when "Agent doesn't exist in rdv-insertion"
+                      "Il n'y a pas de compte agent pour l'adresse mail #{inclusion_connect_agent_info['email']}. " \
+                      "Vous devez utiliser Inclusion Connect avec l'adresse mail " \
+                      "à laquelle vous avez reçu votre invitation sur RDV Solidarites. " \
+                      "Vous pouvez contacter le support à l'adresse " \
+                      "<rdv-insertion@beta.gouv.fr> si le problème persiste."
+                    else
+                      "Nous n'avons pas pu vous authentifier. Contacter le support à l'adresse" \
+                      "<rdv-insertion@beta.gouv.fr> si le problème persiste."
+                    end
     redirect_to sign_in_path
   end
 

--- a/app/services/retrieve_inclusion_connect_agent_infos.rb
+++ b/app/services/retrieve_inclusion_connect_agent_infos.rb
@@ -43,7 +43,7 @@ class RetrieveInclusionConnectAgentInfos < BaseService
   end
 
   def agent_info_body
-    JSON.parse(agent_info_response.body)
+    result.inclusion_connect_agent_info = JSON.parse(agent_info_response.body)
   end
 
   def retrieve_agent!

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -79,7 +79,13 @@ describe InclusionConnectController do
       expect(Sentry).to receive(:capture_message).with("Agent doesn't exist in rdv-insertion")
       get :callback, params: { state: "a state", code: code }
       expect(response).to redirect_to(sign_in_path)
-      expect_flash_error
+      expect(flash[:error]).to eq(
+        "Il n'y a pas de compte agent pour l'adresse mail patrick@gmail.com. " \
+        "Vous devez utiliser Inclusion Connect avec l'adresse mail " \
+        "à laquelle vous avez reçu votre invitation sur RDV Solidarites. " \
+        "Vous pouvez contacter le support à l'adresse " \
+        "<rdv-insertion@beta.gouv.fr> si le problème persiste."
+      )
     end
 
     it "redirect and returns an error if agent mismatch with email and sub" do

--- a/spec/controllers/inclusion_connect_controller_spec.rb
+++ b/spec/controllers/inclusion_connect_controller_spec.rb
@@ -76,7 +76,6 @@ describe InclusionConnectController do
           sub: "patrick"
         }.to_json, headers: {}
       )
-      expect(Sentry).to receive(:capture_message).with("Agent doesn't exist in rdv-insertion")
       get :callback, params: { state: "a state", code: code }
       expect(response).to redirect_to(sign_in_path)
       expect(flash[:error]).to eq(


### PR DESCRIPTION
Close https://github.com/betagouv/rdv-insertion/issues/1005
C'est l'équivalent de ce qui a été fait pour rdvsp ici https://github.com/betagouv/rdv-service-public/pull/4195
On affiche un message plus compréhensif aux agents.
Je vais ignorer l'erreur dans sentry "Agent doesn't exist in rdv-insertion" sauf gros volume (>50/jour) comme j'ai fait pour RDVSP.