### PR TITLE
feat(batch_actions): mass assign referents

### DIFF
--- a/app/controllers/referent_assignations_controller.rb
+++ b/app/controllers/referent_assignations_controller.rb
@@ -11,7 +11,7 @@ class ReferentAssignationsController < ApplicationController
     respond_to do |format|
       format.turbo_stream { render_result_in_flash }
       format.json do
-        render json: { success: @success, errors: @errors }, status: @success ? :ok : :unprocessable_entity
+        render json: { success: @success, errors: @errors, user: @user }, status: @success ? :ok : :unprocessable_entity
       end
     end
   end

--- a/app/javascript/react/components/user/CreationCell.jsx
+++ b/app/javascript/react/components/user/CreationCell.jsx
@@ -2,39 +2,29 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 import Tippy from "@tippyjs/react";
 
-import handleArchiveDelete from "../../lib/handleArchiveDelete";
-
 import { getFrenchFormatDateString } from "../../../lib/datesHelper";
 
 export default observer(({ user }) => {
   const handleFileReopen = async () => {
-    user.triggers.unarchive = true;
-
-    await handleArchiveDelete(user);
-
-    user.triggers.unarchive = false;
+    user.unarchive();
   };
 
   const handleCreationClick = async () => {
     user.createAccount();
   };
 
-  if (user.errors.includes("createAccount")) {
-    return (
+  return user.errors.includes("createAccount") ? (
       <button type="submit" className="btn btn-danger" onClick={() => handleCreationClick()}>
-        Résoudre les erreurs
+        Afficher les erreurs
       </button>
-    );
-  }
-
-  return user.isArchivedInCurrentDepartment() ? (
+  ) : user.isArchivedInCurrentDepartment() ? (
     <button
       type="submit"
       disabled={user.triggers.unarchive}
       className="btn btn-primary btn-blue"
       onClick={() => handleFileReopen()}
     >
-      Rouvrir le dossier
+      {user.errors.includes("deleteArchive") ? "Afficher les erreurs" : "Rouvrir le dossier"}
     </button>
   ) : user.createdAt ? (
     !user.belongsToCurrentOrg() ? (

--- a/app/javascript/react/components/user/ReferentAssignationCell.jsx
+++ b/app/javascript/react/components/user/ReferentAssignationCell.jsx
@@ -1,32 +1,20 @@
-import React, { useState } from "react";
+import React from "react";
 import { observer } from "mobx-react-lite";
-import Swal from "sweetalert2";
-
-import assignReferent from "../../actions/assignReferent";
+import Tippy from "@tippyjs/react";
 
 export default observer(({ user }) => {
-  const [assignationDone, setAssignationDone] = useState(false);
-
   const handleReferentAssignationClick = async () => {
-    user.triggers.referentAssignation = true;
-
-    const result = await assignReferent(user.id, user.referentEmail);
-    if (result.success) {
-      setAssignationDone(true);
-    } else {
-      Swal.fire(
-        `Impossible d'assigner le référent ${user.referentEmail}`,
-        result.errors[0],
-        "error"
-      );
-    }
-    user.triggers.referentAssignation = false;
+    user.assignReferent();
   };
 
   return (
     <>
-      {assignationDone || user.referentAlreadyAssigned() ? (
-        <i className="fas fa-check" />
+      {user.referentAlreadyAssigned() ? (
+        <Tippy
+          content={`Référent: ${user.referentFullName()}`}
+        >
+          <i className="fas fa-check" />
+        </Tippy>
       ) : (
         <button
           type="submit"

--- a/app/javascript/react/components/users/BatchActionsButtons.jsx
+++ b/app/javascript/react/components/users/BatchActionsButtons.jsx
@@ -12,25 +12,30 @@ export default observer(({ users }) => {
     users.setUsers(users.list.filter((user) => !user.selected));
   };
 
-  const inviteBy = async (format) => {
+  const batchActions = async (actionName, actionArguments = []) => {
     toggle();
     // We need a synchronous loop with await here to avoid sending too many requests at the same time
     // eslint-disable-next-line no-restricted-syntax
     for (const user of users.selectedUsers) {
       // eslint-disable-next-line no-await-in-loop
-      await user.inviteBy(format, { raiseError: false });
+      await user[actionName](...actionArguments, { raiseError: false });
     }
-  };
+  }
 
   const createAccounts = async () => {
     toggle();
-    // We need a synchronous loop here to avoid sending too many requests at the same time
+    // We need a synchronous loop with await here to avoid sending too many requests at the same time
     // eslint-disable-next-line no-restricted-syntax
     for (const user of users.selectedUsers) {
-      // eslint-disable-next-line no-await-in-loop
-      await user.createAccount({ raiseError: false });
+      if (user.isArchivedInCurrentDepartment()) {
+        // eslint-disable-next-line no-await-in-loop
+        await user.unarchive({ raiseError: false });
+      } else {
+        // eslint-disable-next-line no-await-in-loop
+        await user.createAccount({ raiseError: false });
+      }
     }
-  };
+  }
 
   const noUserSelected = !users.list.some((user) => user.selected);
 
@@ -55,13 +60,23 @@ export default observer(({ users }) => {
             <i className="fas fa-user" />
           </button>
         )}
+        {users.showReferentColumn && (
+          <button
+            type="button"
+            className="dropdown-item d-flex justify-content-between align-items-center"
+            onClick={() => batchActions("assignReferent")}
+          >
+            <span>Assigner référent</span>
+            <i className="fas fa-user-friends" />
+          </button>
+        )}
         {users.canBeInvitedBy("sms") && (
           <button
             type="button"
             className="dropdown-item d-flex justify-content-between align-items-center"
-            onClick={() => inviteBy("sms")}
+            onClick={() => batchActions("inviteBy", ["sms"])}
           >
-            <span>Invitation par sms</span>
+            <span>Inviter par sms</span>
             <i className="fas fa-comment" />
           </button>
         )}
@@ -69,9 +84,9 @@ export default observer(({ users }) => {
           <button
             type="button"
             className="dropdown-item d-flex justify-content-between align-items-center"
-            onClick={() => inviteBy("email")}
+            onClick={() => batchActions("inviteBy", ["email"])}
           >
-            <span>Invitation par mail</span>
+            <span>Inviter par mail</span>
             <i className="fas fa-inbox" />
           </button>
         )}
@@ -79,9 +94,9 @@ export default observer(({ users }) => {
           <button
             type="button"
             className="dropdown-item d-flex justify-content-between align-items-center"
-            onClick={() => inviteBy("postal")}
+            onClick={() => batchActions("inviteBy", ["postal"])}
           >
-            <span>Invitation par courrier &nbsp;</span>
+            <span>Inviter par courrier &nbsp;</span>
             <i className="fas fa-envelope" />
           </button>
         )}

--- a/app/javascript/react/components/users/BatchActionsButtons.jsx
+++ b/app/javascript/react/components/users/BatchActionsButtons.jsx
@@ -2,18 +2,26 @@ import React from "react";
 import { observer } from "mobx-react-lite";
 
 export default observer(({ users }) => {
-  const toggle = () => {
-    const dropdown = document.getElementById("batch-actions");
+  const toggleDropdown = (event) => {
+    event.stopPropagation();
+    const dropdown = document.getElementById("batch-actions-menu");
     dropdown.classList.toggle("show");
+    if (dropdown.classList.contains("show")) {
+      window.addEventListener("click", closeDropdown);
+    }
+  };
+
+  const closeDropdown = () => {
+    const dropdown = document.getElementById("batch-actions-menu");
+    dropdown.classList.remove("show");
+    window.removeEventListener("click", closeDropdown);
   };
 
   const deleteAll = () => {
-    toggle();
     users.setUsers(users.list.filter((user) => !user.selected));
   };
 
   const batchActions = async (actionName, actionArguments = []) => {
-    toggle();
     // We need a synchronous loop with await here to avoid sending too many requests at the same time
     // eslint-disable-next-line no-restricted-syntax
     for (const user of users.selectedUsers) {
@@ -23,7 +31,6 @@ export default observer(({ users }) => {
   }
 
   const createAccounts = async () => {
-    toggle();
     // We need a synchronous loop with await here to avoid sending too many requests at the same time
     // eslint-disable-next-line no-restricted-syntax
     for (const user of users.selectedUsers) {
@@ -43,13 +50,14 @@ export default observer(({ users }) => {
     <div style={{ marginRight: 20, position: "relative" }}>
       <button
         type="button"
+        id="batch-actions-button"
         className="btn btn-primary dropdown-toggle"
-        onClick={toggle}
+        onClick={toggleDropdown}
         disabled={noUserSelected}
       >
         Actions pour toute la sélection
       </button>
-      <div className="dropdown-menu" id="batch-actions">
+      <div className="dropdown-menu" id="batch-actions-menu">
         {users.sourcePage === "upload" && (
           <button
             type="button"

--- a/app/javascript/react/lib/handleArchiveDelete.js
+++ b/app/javascript/react/lib/handleArchiveDelete.js
@@ -1,13 +1,15 @@
 import Swal from "sweetalert2";
 import deleteArchive from "../actions/deleteArchive";
 
-const handleArchiveDelete = async (user) => {
+const handleArchiveDelete = async (user, options = { raiseError: true }) => {
   const archiveToDelete = user.archiveInCurrentDepartment();
   const result = await deleteArchive(archiveToDelete.id);
   if (result.success) {
     user.archives = user.archives.filter((archive) => archive.id !== archiveToDelete.id);
-    Swal.fire("Dossier de l'usager rouvert avec succès", "", "info");
-  } else {
+    if (options.raiseError) {
+      Swal.fire("Dossier de l'usager rouvert avec succès", "", "info");
+    }
+  } else if (!result.success && options.raiseError) {
     Swal.fire("Impossible de rouvrir le dossier du bénéficiaire'", result.errors[0], "error");
   }
   return result;

--- a/app/javascript/react/lib/handleReferentAssignation.js
+++ b/app/javascript/react/lib/handleReferentAssignation.js
@@ -1,0 +1,14 @@
+import Swal from "sweetalert2";
+import assignReferent from "../actions/assignReferent";
+
+const handleReferentAssignation = async (user, options = { raiseError: true }) => {
+  const result = await assignReferent(user.id, user.referentEmail);
+  if (result.success) {
+    user.updateWith(result.user);
+  } else if (!result.success && options.raiseError) {
+    Swal.fire(`Impossible d'assigner le référent ${user.referentEmail}`, result.errors[0], "error");
+  }
+  return result;
+};
+
+export default handleReferentAssignation;

--- a/app/javascript/react/models/User.js
+++ b/app/javascript/react/models/User.js
@@ -1,10 +1,14 @@
 import { makeAutoObservable } from "mobx";
+
+import handleUserCreation from "../lib/handleUserCreation";
+import handleUserInvitation from "../lib/handleUserInvitation";
+import handleArchiveDelete from "../lib/handleArchiveDelete";
+import handleUserUpdate from "../lib/handleUserUpdate";
+import handleReferentAssignation from "../lib/handleReferentAssignation";
+
 import formatPhoneNumber from "../../lib/formatPhoneNumber";
 import retrieveLastInvitationDate from "../../lib/retrieveLastInvitationDate";
-import handleUserCreation from "../lib/handleUserCreation";
 import retrieveRelevantOrganisation from "../../lib/retrieveRelevantOrganisation";
-import handleUserInvitation from "../lib/handleUserInvitation";
-import handleUserUpdate from "../lib/handleUserUpdate";
 import { getFrenchFormatDateString } from "../../lib/datesHelper";
 
 const ROLES = {
@@ -204,6 +208,41 @@ export default class User {
     return success;
   }
 
+  async unarchive(options = { raiseError: true }) {
+    this.triggers.unarchive = true;
+
+    const { success } = await handleArchiveDelete(this, { raiseError: options.raiseError });
+    if (!success && !options.raiseError) {
+      this.errors = ["deleteArchive"];
+    } else if (success) {
+      this.resetErrors();
+    }
+
+    this.triggers.unarchive = false;
+  }
+
+  async assignReferent(options = { raiseError: true }) {
+    if (this.referentAlreadyAssigned()) return true;
+
+    if (!this.createdAt || !this.belongsToCurrentOrg()) {
+      const success = await this.createAccount(options);
+      if (!success) return false;
+    }
+
+    this.triggers.referentAssignation = true;
+
+    const { success } = await handleReferentAssignation(this, { raiseError: options.raiseError });
+    if (!success && !options.raiseError) {
+      this.errors = ["referentAssignation"];
+    } else if (success) {
+      this.resetErrors();
+    }
+
+    this.triggers.referentAssignation = false;
+
+    return success;
+  }
+
   resetErrors() {
     this.errors = [];
   }
@@ -393,6 +432,14 @@ export default class User {
       this.referents &&
       this.referents.some((referent) => referent.email === this.referentEmail)
     );
+  }
+
+  referentFullName() {
+    if (this.referentAlreadyAssigned()) {
+      const referent = this.referents.find((agent) => agent.email === this.referentEmail);
+      return `${referent.first_name} ${referent.last_name}`
+    }
+    return "";
   }
 
   archiveInCurrentDepartment() {

--- a/app/javascript/stylesheets/components/_dropdown.scss
+++ b/app/javascript/stylesheets/components/_dropdown.scss
@@ -1,6 +1,13 @@
 .dropdown-menu {
   top: 40px;
+  &#batch-actions-dropdown {
+    width: 260px;
+  }
 }
 .dropdown-toggle:focus {
   box-shadow: none !important;
+}
+
+#batch-actions-menu {
+  width: 260px;
 }

--- a/spec/features/agent_can_invite_users_by_batch_from_index_spec.rb
+++ b/spec/features/agent_can_invite_users_by_batch_from_index_spec.rb
@@ -84,7 +84,7 @@ describe "Agent can invite users by batch from index" do
       expect(page).to have_no_css("i.fas.fa-redo-alt")
 
       click_button("Actions pour toute la sélection", wait: 10)
-      click_button("Invitation par sms", wait: 10)
+      click_button("Inviter par sms", wait: 10)
 
       expect(page).to have_no_content("Inviter par SMS")
       expect(page).to have_css("i.fas.fa-check").exactly(2).times
@@ -144,7 +144,7 @@ describe "Agent can invite users by batch from index" do
       expect(page).to have_no_css("i.fas.fa-redo-alt")
 
       click_button("Actions pour toute la sélection", wait: 10)
-      click_button("Invitation par sms", wait: 10)
+      click_button("Inviter par sms", wait: 10)
 
       expect(page).to have_no_content("Inviter par SMS")
       expect(page).to have_css("i.fas.fa-check").exactly(2).times

--- a/spec/features/agent_can_upload_user_list_spec.rb
+++ b/spec/features/agent_can_upload_user_list_spec.rb
@@ -756,7 +756,7 @@ describe "Agents can upload user list", :js do
           click_button("Actions pour toute la sélection")
           expect(page).to have_no_button("Réinviter par SMS")
 
-          click_button("Invitation par sms")
+          click_button("Inviter par sms")
           expect(page).to have_css("i.fas.fa-check")
           expect(page).to have_css("i.fas.fa-redo-alt")
         end
@@ -780,7 +780,7 @@ describe "Agents can upload user list", :js do
             click_button("Actions pour toute la sélection")
             expect(page).to have_no_css("td i.fas.fa-check")
 
-            click_button("Invitation par sms")
+            click_button("Inviter par sms")
             expect(page).to have_css("tr.table-danger")
           end
         end


### PR DESCRIPTION
closes #1463 

📋 Dans cette PR, je permet l'assignation en masse de référents depuis la page `upload` ou depuis la page `batch_actions` des non-invités.
Le fonctionnement est similaire à celui des invitations en masse : si l'usager n'est pas créé, on tente de le créer avant de lancer l'action, sinon, si l'usager n'est pas déjà assigné à ce référent, on lance l'assignation. Les erreurs sont gérées de la même manière que les autres batch_actions.
\
\
🎉 Je profite de cette PR pour fix trois petites choses :
- on ne pouvait fermer la dropdown des batchActions uniquement en recliquant sur le bouton ou la dropdown ; désormais n'importe quel click sur la page la referme
- la largeur de la dropdown était un peu étroite, elle est désormais égale à celle du bouton
- l'action en masse de création de compte tentait de recréer les usagers archivés, qui existent déjà, et générait des erreurs bizarres. Désormais, si l'usager est archivé et qu'il est sélectionné, l'action en masse rouvre son dossier (on pourrait aussi choisir de ne rien faire, à trancher avec @amaurydubot et @samanthaauffret et l'équipe produit en sprint rétro)
Je fais également quelques modifications mineures de wording pour plus de cohérence (Invitation par... -> Inviter par, car tous les autres boutons utilisent des verbes d'action)