### PR TITLE
fix(documents): prevent non owners from editing document date

### DIFF
--- a/app/views/parcours_documents/_document_date_form.html.erb
+++ b/app/views/parcours_documents/_document_date_form.html.erb
@@ -7,18 +7,20 @@
       <span class="text-dark-grey-alt">Non renseignée</span>
     <% end %>
   </div>
-  <%= form_for(document, as: :parcours_document, url: user_parcours_document_path(id: document.signed_id), remote: true, html: { class: "d-inline" }) do |f| %>
-    <div class="date-update d-flex d-none">
-      <%= f.date_field :document_date, class: "form-control me-1" %>
-      <%= button_tag type: "submit", class: "btn btn-link validate-date-button text-dark-blue" do %>
-        <i class="fas fa-check"></i>
+  <% if policy(document).edit? %>
+    <%= form_for(document, as: :parcours_document, url: user_parcours_document_path(id: document.signed_id), remote: true, html: { class: "d-inline" }) do |f| %>
+      <div class="date-update d-flex d-none">
+        <%= f.date_field :document_date, class: "form-control me-1" %>
+        <%= button_tag type: "submit", class: "btn btn-link validate-date-button text-dark-blue" do %>
+          <i class="fas fa-check"></i>
+        <% end %>
+        <%= button_tag type: "button", class: "btn btn-link text-dark-blue", data: { action: "click->parcours-documents#toggleEditDate" } do %>
+          <i class="fas fa-times"></i>
+        <% end %>
+      </div>
+      <%= button_tag type: "button", class: "btn btn-link edit-date-button text-dark-blue", data: { action: "click->parcours-documents#toggleEditDate" } do %>
+        <i class="fas fa-pencil-alt"></i>
       <% end %>
-      <%= button_tag type: "button", class: "btn btn-link text-dark-blue", data: { action: "click->parcours-documents#toggleEditDate" } do %>
-        <i class="fas fa-times"></i>
-      <% end %>
-    </div>
-    <%= button_tag type: "button", class: "btn btn-link edit-date-button text-dark-blue", data: { action: "click->parcours-documents#toggleEditDate" } do %>
-      <i class="fas fa-pencil-alt"></i>
     <% end %>
-  <% end if policy(document).edit? %>
+  <% end %>
 </div>

--- a/app/views/parcours_documents/_document_date_form.html.erb
+++ b/app/views/parcours_documents/_document_date_form.html.erb
@@ -20,5 +20,5 @@
     <%= button_tag type: "button", class: "btn btn-link edit-date-button text-dark-blue", data: { action: "click->parcours-documents#toggleEditDate" } do %>
       <i class="fas fa-pencil-alt"></i>
     <% end %>
-  <% end %>
+  <% end if policy(document).edit? %>
 </div>

--- a/spec/features/agent_can_upload_documents_for_users_spec.rb
+++ b/spec/features/agent_can_upload_documents_for_users_spec.rb
@@ -95,7 +95,9 @@ describe "Agents can upload documents for users", :js do
       end
 
       context "agent is not the owner" do
-        let!(:document) { create(:parcours_document, user:, agent: other_organisation_agents.first, type: "Diagnostic") }
+        let!(:document) do
+          create(:parcours_document, user:, agent: other_organisation_agents.first, type: "Diagnostic")
+        end
 
         it "cannot update the date" do
           visit organisation_user_path(organisation_id: organisation.id, id: user.id)

--- a/spec/features/agent_can_upload_documents_for_users_spec.rb
+++ b/spec/features/agent_can_upload_documents_for_users_spec.rb
@@ -93,6 +93,18 @@ describe "Agents can upload documents for users", :js do
         expect(find(".document-date-value")).to have_content("20/03/2024")
         expect(document.reload.document_date).to eq(Time.zone.parse("2024-03-20"))
       end
+
+      context "agent is not the owner" do
+        let!(:document) { create(:parcours_document, user:, agent: other_organisation_agents.first, type: "Diagnostic") }
+
+        it "cannot update the date" do
+          visit organisation_user_path(organisation_id: organisation.id, id: user.id)
+          expect(page).to have_content("Parcours")
+
+          click_link("Parcours")
+          expect(page).to have_no_css(".edit-date-button")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Je corrige le bug vu en retro qui permet à n'importe quel agent de voir le bouton d'édition de la date d'un document.