### PR TITLE
fix(upload): prevent processing big files

### DIFF
--- a/app/javascript/controllers/parcours_documents_controller.js
+++ b/app/javascript/controllers/parcours_documents_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
+import Swal from "sweetalert2";
 
 export default class extends Controller {
   fetchFile() {
@@ -6,8 +7,17 @@ export default class extends Controller {
   }
 
   submit(event) {
-    if (event.target.value.length > 0) {
+    const file = event.target.files[0]
+    const maxSize = Number(this.element.dataset.maxSize)
+
+    if (file && file.size < maxSize) {
       window.Turbo.navigator.submitForm(this.element)
+    } else if (file) {
+      Swal.fire({
+        title: "Ce fichier est trop lourd",
+        text: `Veuillez sélectionner un fichier dont la taille ne dépasse pas ${(maxSize / 1000000).toFixed()} Mo`,
+        icon: "warning",
+      })
     }
   }
 

--- a/app/views/parcours_documents/_document_form.html.erb
+++ b/app/views/parcours_documents/_document_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(:parcours_document, url: user_parcours_documents_path(user_id: user.id), html: { class: "mt-3", method: :post, data: { controller: "parcours-documents", action: "turbo:submit-start->parcours-documents#spin turbo:submit-end->parcours-documents#stopSpin" }}) do |f| %>
+<%= simple_form_for(:parcours_document, url: user_parcours_documents_path(user_id: user.id), html: { class: "mt-3", method: :post, data: { controller: "parcours-documents", action: "turbo:submit-start->parcours-documents#spin turbo:submit-end->parcours-documents#stopSpin", max_size: ParcoursDocument::MAX_SIZE }}) do |f| %>
   <%= f.hidden_field :type, value: type.camelize %>
   <%= f.file_field(
       :file,


### PR DESCRIPTION
Cette PR permet d'éviter d'envoyer des gros documents avec un guard clause front (celle du back reste évidemment présente). 
Cela permettra de bloquer directement les gros fichiers sans même les process sur le réseau 

Fix https://github.com/betagouv/rdv-insertion/issues/1823