### PR TITLE
feat(index): allow table sorting by name on index

### DIFF
--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -1,5 +1,21 @@
 module Users::Sortable
+  private
+
   def order_users
+    if sort_by && sort_direction
+      custom_order
+    else
+      default_order
+    end
+  end
+
+  def custom_order
+    return default_order unless sort_direction.in?(%w[asc desc]) && sort_by.in?(%w[first_name last_name])
+
+    @users = @users.order("#{sort_by} #{sort_direction}")
+  end
+
+  def default_order
     if archived_scope?
       archived_order
     elsif @current_motif_category
@@ -7,6 +23,14 @@ module Users::Sortable
     else
       order_by_created_at
     end
+  end
+
+  def sort_direction
+    params[:sort_direction]
+  end
+
+  def sort_by
+    params[:sort_by]
   end
 
   def archived_order

--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -2,7 +2,7 @@ module Users::Sortable
   private
 
   def order_users
-    if sort_by && sort_direction
+    if sort_params? && sort_params_valid?
       custom_order
     else
       default_order
@@ -10,8 +10,6 @@ module Users::Sortable
   end
 
   def custom_order
-    return default_order unless sort_direction.in?(%w[asc desc]) && sort_by.in?(%w[first_name last_name])
-
     @users = @users.order("#{sort_by} #{sort_direction}")
   end
 
@@ -25,12 +23,20 @@ module Users::Sortable
     end
   end
 
+  def sort_by
+    params[:sort_by]
+  end
+
   def sort_direction
     params[:sort_direction]
   end
 
-  def sort_by
-    params[:sort_by]
+  def sort_params?
+    sort_by && sort_direction
+  end
+
+  def sort_params_valid?
+    sort_by.in?(%w[first_name last_name]) && sort_direction.in?(%w[asc desc])
   end
 
   def archived_order

--- a/app/javascript/controllers/index_table_sorting_controller.js
+++ b/app/javascript/controllers/index_table_sorting_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
 
   changeUrlParams(event) {
     const url = new URL(window.location.href);
-    this.newSortBy = event.currentTarget.id.replace("_header", "");
+    this.newSortBy = event.currentTarget.id.replace("js_", "").replace("_header", "");
     // if a column is clicked for the third time, we remove the sorting
     if (this.sortDirection === undefined || this.sortBy !== this.newSortBy) {
       this.newSortDirection = "asc";
@@ -41,7 +41,7 @@ export default class extends Controller {
   }
 
   displaySortingArrow() {
-    const element = document.querySelector(`#${this.sortBy}_header`);
+    const element = document.querySelector(`js_#${this.sortBy}_header`);
     if (element) {
       const html = ` <i class="fas fa-sort-${this.sortDirection === "asc" ? "up mt-2" : "down mb-2"}"></i>`;
       element.insertAdjacentHTML("beforeend", html);

--- a/app/javascript/controllers/index_table_sorting_controller.js
+++ b/app/javascript/controllers/index_table_sorting_controller.js
@@ -43,7 +43,7 @@ export default class extends Controller {
   displaySortingArrow() {
     const element = document.querySelector(`#${this.sortBy}_header`);
     if (element) {
-      const html = `<i class="fas fa-sort-${this.sortDirection === "asc" ? "up mt-2" : "down mb-2"}"></i>`;
+      const html = ` <i class="fas fa-sort-${this.sortDirection === "asc" ? "up mt-2" : "down mb-2"}"></i>`;
       element.insertAdjacentHTML("beforeend", html);
     }
   }

--- a/app/javascript/controllers/index_table_sorting_controller.js
+++ b/app/javascript/controllers/index_table_sorting_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+      this.attachListeners();
+      if (window.location.href.includes("sort_by") && window.location.href.includes("sort_direction")) {
+        this.sortBy = new URL(window.location.href).searchParams.get("sort_by");
+        this.sortDirection = new URL(window.location.href).searchParams.get("sort_direction");
+        this.displaySortingArrow();
+      }
+  }
+
+  attachListeners() {
+    document.querySelectorAll(".sortable-table-header").forEach((element) => {
+      element.addEventListener("click", (event) => {
+        this.changeUrlParams(event);
+      });
+    });
+  }
+
+  changeUrlParams(event) {
+    const url = new URL(window.location.href);
+    this.newSortBy = event.currentTarget.id.replace("_header", "");
+    // if a column is clicked for the third time, we remove the sorting
+    if (this.sortDirection === undefined || this.sortBy !== this.newSortBy) {
+      this.newSortDirection = "asc";
+    } else if (this.sortDirection === "asc") {
+      this.newSortDirection = "desc";
+    } else {
+      this.newSortDirection = undefined;
+    }
+
+    if (this.newSortDirection === undefined) {
+      url.searchParams.delete("sort_by");
+      url.searchParams.delete("sort_direction",);
+    } else {
+      url.searchParams.set("sort_by", this.newSortBy);
+      url.searchParams.set("sort_direction", this.newSortDirection);
+    }
+    window.location.href = url;
+  }
+
+  displaySortingArrow() {
+    const element = document.querySelector(`#${this.sortBy}_header`);
+    if (element) {
+      const html = `<i class="fas fa-sort-${this.sortDirection === "asc" ? "up mt-2" : "down mb-2"}"></i>`;
+      element.insertAdjacentHTML("beforeend", html);
+    }
+  }
+}
+

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "./components/stat";
 @import "./components/table";
 @import "./components/banner";
+@import "./components/icon";
 @import "./components/periodic_invites_form";
 @import "./vendor/inclusion_connect_button";
 @import "./components/rdv_insertion_instance_name";

--- a/app/javascript/stylesheets/components/_icon.scss
+++ b/app/javascript/stylesheets/components/_icon.scss
@@ -1,0 +1,3 @@
+.fa-sort-up, .fa-sort-down {
+  vertical-align: middle;
+}

--- a/app/javascript/stylesheets/components/_table.scss
+++ b/app/javascript/stylesheets/components/_table.scss
@@ -6,3 +6,7 @@ table.table-hover tbody tr:hover {
   background-color: #f1f1f1;
   color: #a6a6a6
 }
+
+.sortable-table-header {
+  cursor: pointer;
+}

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-responsive">
   <thead class="text-dark-blue" data-controller="index-table-sorting">
-    <th scope="col" class="sortable-table-header" id="last_name_header">Nom</th>
-    <th scope="col" class="sortable-table-header" id="first_name_header">Prénom</th>
+    <th scope="col" class="sortable-table-header" id="js_last_name_header">Nom</th>
+    <th scope="col" class="sortable-table-header" id="js_first_name_header">Prénom</th>
     <th scope="col">Date de création</th>
     <% @all_configurations.each do |configuration| %>
       <th scope="col"><%= configuration.motif_category_name %></th>

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-responsive">
-  <thead class="text-dark-blue">
-    <th scope="col">Nom</th>
-    <th scope="col">Prénom</th>
+  <thead class="text-dark-blue" data-controller="index-table-sorting">
+    <th scope="col" class="sortable-table-header" id="last_name_header">Nom</th>
+    <th scope="col" class="sortable-table-header" id="first_name_header">Prénom</th>
     <th scope="col">Date de création</th>
     <% @all_configurations.each do |configuration| %>
       <th scope="col"><%= configuration.motif_category_name %></th>

--- a/app/views/users/_archived_users_table.html.erb
+++ b/app/views/users/_archived_users_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-responsive">
   <thead class="text-dark-blue" data-controller="index-table-sorting">
-    <th scope="col" class="sortable-table-header" id="last_name_header">Nom</th>
-    <th scope="col" class="sortable-table-header" id="first_name_header">Prénom</th>
+    <th scope="col" class="sortable-table-header" id="js_last_name_header">Nom</th>
+    <th scope="col" class="sortable-table-header" id="js_first_name_header">Prénom</th>
     <th scope="col">Date de création</th>
     <th scope="col">Première invitation</th>
     <th scope="col">Dernière invitation</th>

--- a/app/views/users/_archived_users_table.html.erb
+++ b/app/views/users/_archived_users_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-responsive">
-  <thead class="text-dark-blue">
-    <th scope="col">Nom</th>
-    <th scope="col">Prénom</th>
+  <thead class="text-dark-blue" data-controller="index-table-sorting">
+    <th scope="col" class="sortable-table-header" id="last_name_header">Nom</th>
+    <th scope="col" class="sortable-table-header" id="first_name_header">Prénom</th>
     <th scope="col">Date de création</th>
     <th scope="col">Première invitation</th>
     <th scope="col">Dernière invitation</th>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-responsive">
   <thead class="text-dark-blue" data-controller="index-table-sorting">
-    <th scope="col" class="sortable-table-header" id="last_name_header">Nom</th>
-    <th scope="col" class="sortable-table-header" id="first_name_header">Prénom</th>
+    <th scope="col" class="sortable-table-header" id="js_last_name_header">Nom</th>
+    <th scope="col" class="sortable-table-header" id="js_first_name_header">Prénom</th>
     <% @current_configuration.invitation_formats.each do |invitation_format| %>
       <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
     <% end  %>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-responsive">
-  <thead class="text-dark-blue">
-    <th scope="col">Nom</th>
-    <th scope="col">Prénom</th>
+  <thead class="text-dark-blue" data-controller="index-table-sorting">
+    <th scope="col" class="sortable-table-header" id="last_name_header">Nom</th>
+    <th scope="col" class="sortable-table-header" id="first_name_header">Prénom</th>
     <% @current_configuration.invitation_formats.each do |invitation_format| %>
       <th scope="col" class="d-none d-lg-table-cell"><%= t(".#{invitation_format}_column_title") %></th>
     <% end  %>

--- a/spec/features/agent_can_sort_users_on_index_page_spec.rb
+++ b/spec/features/agent_can_sort_users_on_index_page_spec.rb
@@ -14,11 +14,11 @@ describe "Agents can sort users on index page", :js do
 
   shared_examples "a table with a working sorting" do |last_name_default_order, first_name_default_order|
     it "can sort by first name" do
-      test_ordering_for("first_name", 1, first_name_default_order)
+      test_ordering_for(column_name: "first_name", column_index: 1, default_order: first_name_default_order)
     end
 
     it "can sort by last name" do
-      test_ordering_for("last_name", 0, last_name_default_order)
+      test_ordering_for(column_name: "last_name", column_index: 0, default_order: last_name_default_order)
     end
   end
 

--- a/spec/features/agent_can_sort_users_on_index_page_spec.rb
+++ b/spec/features/agent_can_sort_users_on_index_page_spec.rb
@@ -1,0 +1,110 @@
+describe "Agents can sort users on index page", :js do
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:organisation) { create(:organisation) }
+  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", name: "RSA orientation") }
+  let!(:configuration) { create(:configuration, organisation: organisation, motif_category: motif_category) }
+  let!(:motif) { create(:motif, motif_category: motif_category, organisation: organisation) }
+  let!(:user1) { create(:user, first_name: "Bertrand", last_name: "Blier") }
+  let!(:user2) { create(:user, first_name: "Amanda", last_name: "Ajer") }
+  let!(:user3) { create(:user, first_name: "Claire", last_name: "Casubolo") }
+
+  before do
+    setup_agent_session(agent)
+  end
+
+  def check_sorted_table(column_index, expected_order)
+    rows = page.all("tbody tr")
+    rows.each_with_index do |row, index|
+      cells = row.all("td")
+      second_cell = cells[column_index]
+      expect(second_cell).to have_content(expected_order[index])
+    end
+  end
+
+  shared_examples "a table with a working sorting" do |last_name_default_order, first_name_default_order|
+    it "can sort by first name" do
+      check_sorted_table(1, first_name_default_order)
+
+      find_by_id("first_name_header").click
+      expect(page).to have_current_path(/sort_by=first_name/)
+      expect(page).to have_current_path(/sort_direction=asc/)
+      check_sorted_table(1, first_name_default_order.sort)
+
+      find_by_id("first_name_header").click
+      expect(page).to have_current_path(/sort_by=first_name/)
+      expect(page).to have_current_path(/sort_direction=desc/)
+      check_sorted_table(1, first_name_default_order.sort.reverse)
+
+      find_by_id("first_name_header").click
+      expect(page).to have_no_current_path(/sort_by/)
+      check_sorted_table(1, first_name_default_order)
+    end
+
+    it "can sort by last name" do
+      check_sorted_table(0, last_name_default_order)
+
+      find_by_id("last_name_header").click
+      expect(page).to have_current_path(/sort_by=last_name/)
+      expect(page).to have_current_path(/sort_direction=asc/)
+      check_sorted_table(0, last_name_default_order.sort)
+
+      find_by_id("last_name_header").click
+      expect(page).to have_current_path(/sort_by=last_name/)
+      expect(page).to have_current_path(/sort_direction=desc/)
+      check_sorted_table(0, last_name_default_order.sort.reverse)
+
+      find_by_id("last_name_header").click
+      expect(page).to have_no_current_path(/sort_by/)
+      check_sorted_table(0, last_name_default_order)
+    end
+  end
+
+  context "on 'Tous les contacts' tab" do
+    # on "Tous les contacts", users are sorted by user_org creation date by default
+    let!(:users_organisation1) do
+      create(:users_organisation, user: user1, organisation: organisation, created_at: Time.zone.now)
+    end
+    let!(:users_organisation2) do
+      create(:users_organisation, user: user2, organisation: organisation, created_at: 1.day.ago)
+    end
+    let!(:users_organisation3) do
+      create(:users_organisation, user: user3, organisation: organisation, created_at: 2.days.ago)
+    end
+
+    before do
+      visit organisation_users_path(organisation)
+    end
+
+    it_behaves_like "a table with a working sorting", %w[Blier Ajer Casubolo], %w[Bertrand Amanda Claire]
+  end
+
+  context "on motif_category tab" do
+    # on motif_category tab, users are sorted by rdv_contexts creation date by default
+    let!(:organisation) { create(:organisation, users: [user1, user2, user3]) }
+    let!(:rdv_context1) { create(:rdv_context, user: user1, motif_category: motif_category, created_at: Time.zone.now) }
+    let!(:rdv_context2) { create(:rdv_context, user: user2, motif_category: motif_category, created_at: 1.day.ago) }
+    let!(:rdv_context3) { create(:rdv_context, user: user3, motif_category: motif_category, created_at: 2.days.ago) }
+
+    before do
+      visit organisation_users_path(organisation, motif_category_id: motif_category.id)
+    end
+
+    # on "Tous les contacts", users are sorted by user_org creation date by default
+    it_behaves_like "a table with a working sorting", %w[Blier Ajer Casubolo], %w[Bertrand Amanda Claire]
+  end
+
+  context "on archived users tab" do
+    # on archived users tab, users are sorted by archives creation date by default
+    let!(:organisation) { create(:organisation, users: [user1, user2, user3]) }
+    let!(:archive1) { create(:archive, user: user1, created_at: Time.zone.now) }
+    let!(:archive2) { create(:archive, user: user2, created_at: 1.day.ago) }
+    let!(:archive3) { create(:archive, user: user3, created_at: 2.days.ago) }
+
+    before do
+      visit organisation_users_path(organisation, users_scope: "archived")
+    end
+
+    # on "Tous les contacts", users are sorted by user_org creation date by default
+    it_behaves_like "a table with a working sorting", %w[Blier Ajer Casubolo], %w[Bertrand Amanda Claire]
+  end
+end

--- a/spec/features/agent_can_sort_users_on_index_page_spec.rb
+++ b/spec/features/agent_can_sort_users_on_index_page_spec.rb
@@ -12,50 +12,13 @@ describe "Agents can sort users on index page", :js do
     setup_agent_session(agent)
   end
 
-  def check_sorted_table(column_index, expected_order)
-    rows = page.all("tbody tr")
-    rows.each_with_index do |row, index|
-      cells = row.all("td")
-      second_cell = cells[column_index]
-      expect(second_cell).to have_content(expected_order[index])
-    end
-  end
-
   shared_examples "a table with a working sorting" do |last_name_default_order, first_name_default_order|
     it "can sort by first name" do
-      check_sorted_table(1, first_name_default_order)
-
-      find_by_id("first_name_header").click
-      expect(page).to have_current_path(/sort_by=first_name/)
-      expect(page).to have_current_path(/sort_direction=asc/)
-      check_sorted_table(1, first_name_default_order.sort)
-
-      find_by_id("first_name_header").click
-      expect(page).to have_current_path(/sort_by=first_name/)
-      expect(page).to have_current_path(/sort_direction=desc/)
-      check_sorted_table(1, first_name_default_order.sort.reverse)
-
-      find_by_id("first_name_header").click
-      expect(page).to have_no_current_path(/sort_by/)
-      check_sorted_table(1, first_name_default_order)
+      test_ordering_for("first_name", 1, first_name_default_order)
     end
 
     it "can sort by last name" do
-      check_sorted_table(0, last_name_default_order)
-
-      find_by_id("last_name_header").click
-      expect(page).to have_current_path(/sort_by=last_name/)
-      expect(page).to have_current_path(/sort_direction=asc/)
-      check_sorted_table(0, last_name_default_order.sort)
-
-      find_by_id("last_name_header").click
-      expect(page).to have_current_path(/sort_by=last_name/)
-      expect(page).to have_current_path(/sort_direction=desc/)
-      check_sorted_table(0, last_name_default_order.sort.reverse)
-
-      find_by_id("last_name_header").click
-      expect(page).to have_no_current_path(/sort_by/)
-      check_sorted_table(0, last_name_default_order)
+      test_ordering_for("last_name", 0, last_name_default_order)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
   config.include JsonRequestHelper
   config.include MotifCategoriesHelper
   config.include NirHelper
+  config.include SortingHelper
   config.include StubHelper
   config.include UploadHelper
   config.include DownloadHelper

--- a/spec/support/sorting_helper.rb
+++ b/spec/support/sorting_helper.rb
@@ -3,25 +3,25 @@ module SortingHelper
     rows = page.all("tbody tr")
     rows.each_with_index do |row, index|
       cells = row.all("td")
-      second_cell = cells[column_index]
-      expect(second_cell).to have_content(expected_order[index])
+      targeted_cell = cells[column_index]
+      expect(targeted_cell).to have_content(expected_order[index])
     end
   end
 
-  def test_ordering_for(column_name, column_index, default_order) # rubocop:disable Metrics/AbcSize
+  def test_ordering_for(column_name:, column_index:, default_order:) # rubocop:disable Metrics/AbcSize
     check_sorted_table(column_index, default_order)
 
-    find_by_id("#{column_name}_header").click
+    find_by_id("js_#{column_name}_header").click
     expect(page).to have_current_path(/sort_by=#{column_name}/)
     expect(page).to have_current_path(/sort_direction=asc/)
     check_sorted_table(column_index, default_order.sort)
 
-    find_by_id("#{column_name}_header").click
+    find_by_id("js_#{column_name}_header").click
     expect(page).to have_current_path(/sort_by=#{column_name}/)
     expect(page).to have_current_path(/sort_direction=desc/)
     check_sorted_table(column_index, default_order.sort.reverse)
 
-    find_by_id("#{column_name}_header").click
+    find_by_id("js_#{column_name}_header").click
     expect(page).to have_no_current_path(/sort_by/)
     check_sorted_table(column_index, default_order)
   end

--- a/spec/support/sorting_helper.rb
+++ b/spec/support/sorting_helper.rb
@@ -1,0 +1,28 @@
+module SortingHelper
+  def check_sorted_table(column_index, expected_order)
+    rows = page.all("tbody tr")
+    rows.each_with_index do |row, index|
+      cells = row.all("td")
+      second_cell = cells[column_index]
+      expect(second_cell).to have_content(expected_order[index])
+    end
+  end
+
+  def test_ordering_for(column_name, column_index, default_order) # rubocop:disable Metrics/AbcSize
+    check_sorted_table(column_index, default_order)
+
+    find_by_id("#{column_name}_header").click
+    expect(page).to have_current_path(/sort_by=#{column_name}/)
+    expect(page).to have_current_path(/sort_direction=asc/)
+    check_sorted_table(column_index, default_order.sort)
+
+    find_by_id("#{column_name}_header").click
+    expect(page).to have_current_path(/sort_by=#{column_name}/)
+    expect(page).to have_current_path(/sort_direction=desc/)
+    check_sorted_table(column_index, default_order.sort.reverse)
+
+    find_by_id("#{column_name}_header").click
+    expect(page).to have_no_current_path(/sort_by/)
+    check_sorted_table(column_index, default_order)
+  end
+end


### PR DESCRIPTION
closes #1836

J'ai privilégié une implémentation avec reload de la page au moment du tri afin que les params soient présents dans l'url du navigateur, ce qui permet de les "mémorizer" lorsque l'on se rend sur une fiche bénéficiaire et que l'on utilise le bouton "retour au suivi", par exemple.