### PR TITLE
fix(invitations): block invitations when rdv pending taken today

### DIFF
--- a/app/services/invitations/validate.rb
+++ b/app/services/invitations/validate.rb
@@ -43,7 +43,7 @@ module Invitations
     end
 
     def validate_no_rdv_pending_taken_today
-      return if rdv_context.rdvs.where(rdvs: { status: 0 }).where("rdvs.created_at > ?", Time.zone.today).blank?
+      return if rdv_context.rdvs.unknown.where("rdvs.created_at > ?", Time.zone.today).blank?
 
       result.errors << "Cet usager a déjà pris un rendez-vous aujourd'hui"
     end

--- a/spec/features/agent_can_invite_users_from_index_page_spec.rb
+++ b/spec/features/agent_can_invite_users_from_index_page_spec.rb
@@ -106,7 +106,7 @@ describe "Agents can invite from index page", :js do
   end
 
   context "when there are rdvs" do
-    let!(:rdv) { create(:rdv) }
+    let!(:rdv) { create(:rdv, created_at: 4.days.ago) }
     let!(:participation) do
       create(
         :participation,


### PR DESCRIPTION
closes #1889 

Pour éviter que deux invitations envoyées à quelques minutes d'écart avec un rdv pris par l'utilisateur entre les deux bloque le statut d'un `rdv_context` sur `Invitation en attente de réponse`, je bloque l'envoi d'invitation si un rdv avec un statut `unknown` (donc à venir) a été pris le jour même. L'erreur remontée ressemble à la capture ci-dessous ; l'agent pourra ensuite facilement vérifier en consultant la show de l'usager si tout est en ordre.

![Capture d’écran 2024-03-27 à 22 02 23](https://github.com/betagouv/rdv-insertion/assets/46218316/b361b3ac-6a34-4049-9e1f-b341928b93e8)
