### PR TITLE
feat(filters): UX improvements

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -25,7 +25,7 @@ module UsersHelper
     ordered_statuses_count(statuses_count).map do |status, count|
       next if count.nil?
 
-      ["#{I18n.t("activerecord.attributes.rdv_context.statuses.#{status}")} (#{count})", status]
+      ["Statut \"#{I18n.t("activerecord.attributes.rdv_context.statuses.#{status}")}\" (#{count})", status]
     end.compact
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -25,7 +25,7 @@ module UsersHelper
     ordered_statuses_count(statuses_count).map do |status, count|
       next if count.nil?
 
-      ["Statut \"#{I18n.t("activerecord.attributes.rdv_context.statuses.#{status}")}\" (#{count})", status]
+      ["Statut : \"#{I18n.t("activerecord.attributes.rdv_context.statuses.#{status}")}\" (#{count})", status]
     end.compact
   end
 

--- a/app/javascript/stylesheets/components/_index_filters.scss
+++ b/app/javascript/stylesheets/components/_index_filters.scss
@@ -18,3 +18,11 @@
     background: -webkit-linear-gradient(top, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100%);
   }
 }
+
+.invitations-date-filter-content {
+  p {
+    &:last-child {
+      margin: 0;
+    }
+  }
+}

--- a/app/views/creation_dates_filterings/new.html.erb
+++ b/app/views/creation_dates_filterings/new.html.erb
@@ -9,6 +9,7 @@
       <%= form.text_field :creation_date_after,
         class: "w-50 form-control bg-white text-center",
         placeholder: "du",
+        value: params[:creation_date_after],
         data: {
           controller: "flatpickr",
           flatpickr_date_format: "d-m-Y",
@@ -18,6 +19,7 @@
       <%= form.text_field :creation_date_before,
         class: "w-50 form-control bg-white text-center",
         placeholder: "au",
+        value: params[:creation_date_before],
         data: {
           controller: "flatpickr",
           flatpickr_date_format: "d-m-Y",

--- a/app/views/invitation_dates_filterings/new.html.erb
+++ b/app/views/invitation_dates_filterings/new.html.erb
@@ -9,6 +9,7 @@
       <%= form.text_field :first_invitation_date_after,
         class: "w-50 form-control bg-white text-center",
         placeholder: "du",
+        value: params[:first_invitation_date_after],
         data: {
           controller: "flatpickr",
           flatpickr_date_format: "d-m-Y",
@@ -18,6 +19,7 @@
       <%= form.text_field :first_invitation_date_before,
         class: "w-50 form-control bg-white text-center",
         placeholder: "au",
+        value: params[:first_invitation_date_before],
         data: {
           controller: "flatpickr",
           flatpickr_date_format: "d-m-Y",
@@ -30,6 +32,7 @@
       <%= form.text_field :last_invitation_date_after,
         class: "w-50 form-control bg-white text-center",
         placeholder: "du",
+        value: params[:last_invitation_date_after],
         data: {
           controller: "flatpickr",
           flatpickr_date_format: "d-m-Y",
@@ -39,6 +42,7 @@
       <%= form.text_field :last_invitation_date_before,
         class: "w-50 form-control bg-white text-center",
         placeholder: "au",
+        value: params[:last_invitation_date_before],
         data: {
           controller: "flatpickr",
           flatpickr_date_format: "d-m-Y",

--- a/app/views/users/_filter_by_creation_dates_button.html.erb
+++ b/app/views/users/_filter_by_creation_dates_button.html.erb
@@ -5,7 +5,7 @@
         <% if params[:creation_date_after].present? %>
           Créés entre le <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> et le <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %>
         <% elsif params[:creation_date_before].present? %>
-          Créés après le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %>
+          Créés avant le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %>
         <% else %>
           Filtrer par date de création
         <% end %>

--- a/app/views/users/_filter_by_creation_dates_button.html.erb
+++ b/app/views/users/_filter_by_creation_dates_button.html.erb
@@ -3,7 +3,7 @@
     <%= link_to(new_creation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
       <button class="btn btn-grey w-100">
         <% if params[:creation_date_after].present? %>
-          Créés du <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> au <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %>
+          Créés entre le <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> et le <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %>
         <% elsif params[:creation_date_before].present? %>
           Créés après le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %>
         <% else %>

--- a/app/views/users/_filter_by_creation_dates_button.html.erb
+++ b/app/views/users/_filter_by_creation_dates_button.html.erb
@@ -1,7 +1,15 @@
 <div class="mb-1">
   <div class="w-100">
     <%= link_to(new_creation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
-      <button class="btn btn-grey w-100">Filtrer par date de création</button>
+      <button class="btn btn-grey w-100">
+        <% if params[:creation_date_after].present? %>
+          Créés du <%= params[:creation_date_after].to_date.strftime("%d/%m/%Y") %> au <%= (params[:creation_date_before]&.to_date || Time.zone.now).strftime("%d/%m/%Y") %>
+        <% elsif params[:creation_date_before].present? %>
+          Créés après le <%= params[:creation_date_before].to_date.strftime("%d/%m/%Y") %>
+        <% else %>
+          Filtrer par date de création
+        <% end %>
+      </button>
     <% end %>
   </div>
 </div>

--- a/app/views/users/_filter_by_invitations_dates_button.html.erb
+++ b/app/views/users/_filter_by_invitations_dates_button.html.erb
@@ -1,7 +1,24 @@
 <div class="mb-1">
   <div class="w-100">
-    <%= link_to(new_invitation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }) do %>
-      <button class="btn btn-grey w-100">Filtrer par date d'invitation</button>
+    <%= link_to(new_invitation_dates_filtering_path(url_params), data: { turbo_frame: 'remote_modal' }, class: 'btn btn-grey w-100 d-flex align-items-center justify-content-between') do %>
+      <% if params[:first_invitation_date_before] || params[:first_invitation_date_after] || params[:last_invitation_date_before] || params[:last_invitation_date_after] %>
+          <div class="invitations-date-filter-content">
+            <% if params[:first_invitation_date_after].present? %>
+              <p>Première invitation entre le <%= format_date(params[:first_invitation_date_after].to_date) %> et le <%= format_date((params[:first_invitation_date_before]&.to_date || Time.zone.now)) %></p>
+            <% elsif params[:first_invitation_date_before].present? %>
+              <p>Première invitation avant le <%= format_date(params[:first_invitation_date_before].to_date) %></p>
+            <% end %>
+              
+            <% if params[:last_invitation_date_after].present? %>
+              <p>Dernière invitation entre le <%= format_date(params[:last_invitation_date_after].to_date) %> et le <%= format_date((params[:last_invitation_date_before]&.to_date || Time.zone.now)) %></p>
+            <% elsif params[:last_invitation_date_before].present? %>
+              <p>Dernière invitation avant le <%= format_date(params[:last_invitation_date_before].to_date) %></p>
+            <% end %>
+          </div>
+          <i class="fas fa-pencil-alt text-dark-blue"></i>
+      <% else %>
+        <span class="w-100">Filtrer par date d'invitation</span>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -16,7 +16,7 @@
         select(
           "user",
           "referent_id",
-          @referents_list.map { |agent| [agent.to_s, agent.id]},
+          @referents_list.map { |agent| ["Suivis par #{agent.to_s}", agent.id] },
           { prompt: "Filtrer par référent" },
           class: "text-center form-select js-referent-selector"
         )


### PR DESCRIPTION
Cette PR améliore l'UX de l'état actif des filtres en affichant l'information plus clairement. 
<img width="561" alt="Screenshot 2024-04-02 at 12 03 25" src="https://github.com/betagouv/rdv-insertion/assets/4990201/5a0757f4-3267-4d04-9f3f-b76d02860b13">
<img width="664" alt="Screenshot 2024-04-02 at 12 02 51" src="https://github.com/betagouv/rdv-insertion/assets/4990201/e29e5dd7-2cf2-4049-b6c4-f3edfcd6c169">

Je me suis permis quelques petits améliorations de wording par rapport à la maquette, notamment sur le filtre par date de création de l'usager, plutôt que juste "Du X au X" j'ai mis "Créée entre le X et le X"


Fix https://github.com/betagouv/rdv-insertion/issues/1853