### PR TITLE
fix(invitations): always block when participation pending in rdv_context

### DIFF
--- a/app/services/invitations/validate.rb
+++ b/app/services/invitations/validate.rb
@@ -43,7 +43,7 @@ module Invitations
     end
 
     def validate_no_rdv_pending_taken_today
-      return if rdv_context.participations.status("unknown").joins(:rdv).where("starts_at > ?", Time.zone.now).blank?
+      return if rdv_context.reload.participations.none?(&:pending?)
 
       result.errors << "Cet usager a déjà un rendez-vous à venir pour ce motif"
     end

--- a/app/services/invitations/validate.rb
+++ b/app/services/invitations/validate.rb
@@ -43,9 +43,9 @@ module Invitations
     end
 
     def validate_no_rdv_pending_taken_today
-      return if rdv_context.rdvs.unknown.where("rdvs.created_at > ?", Time.zone.today).blank?
+      return if rdv_context.participations.status("unknown").joins(:rdv).where("starts_at > ?", Time.zone.now).blank?
 
-      result.errors << "Cet usager a déjà pris un rendez-vous aujourd'hui"
+      result.errors << "Cet usager a déjà un rendez-vous à venir pour ce motif"
     end
 
     def validate_it_expires_in_more_than_5_days

--- a/spec/services/invitations/validate_spec.rb
+++ b/spec/services/invitations/validate_spec.rb
@@ -73,13 +73,13 @@ describe Invitations::Validate, type: :service do
     end
 
     context "when a rdv pending has been taken today" do
-      let!(:rdv) { create(:rdv, participations: [participation], status: "unknown", created_at: Time.zone.now) }
+      let!(:rdv) { create(:rdv, participations: [participation], status: "unknown", starts_at: 2.days.from_now) }
 
       it("is a failure") { is_a_failure }
 
       it "stores an error message" do
         expect(subject.errors).to include(
-          "Cet usager a déjà pris un rendez-vous aujourd'hui"
+          "Cet usager a déjà un rendez-vous à venir pour ce motif"
         )
       end
     end

--- a/spec/services/invitations/validate_spec.rb
+++ b/spec/services/invitations/validate_spec.rb
@@ -74,7 +74,11 @@ describe Invitations::Validate, type: :service do
       end
     end
 
-    context "when a rdv pending has been taken today" do
+    context "when a participation is pending" do
+      before do
+        rdv_context.reload
+      end
+
       let!(:rdv) { create(:rdv, participations: [participation], status: "unknown", starts_at: 2.days.from_now) }
 
       it("is a failure") { is_a_failure }

--- a/spec/services/invitations/validate_spec.rb
+++ b/spec/services/invitations/validate_spec.rb
@@ -22,7 +22,9 @@ describe Invitations::Validate, type: :service do
 
   let!(:participation) { create(:participation, rdv_context: rdv_context, user: user) }
 
-  let!(:rdv) { create(:rdv, participations: [participation], status: "unknown", created_at: 3.days.ago) }
+  let!(:rdv) do
+    create(:rdv, participations: [participation], status: "unknown", created_at: 3.days.ago, starts_at: 2.days.ago)
+  end
 
   let!(:organisation) do
     create(:organisation, motifs: [motif])


### PR DESCRIPTION
Corrige et améliore [cette PR](https://github.com/betagouv/rdv-insertion/pull/1902), à la suite d'une remarque d'@aminedhobb 

Bloquer l'envoi d'invit quand un rdv a été créé le même jour peut poser problème, car le rdv peut avoir été créé un jour précédent, et/ou son statut peut être mis à jour sans être en lien avec le bénéficiaire directement.
Nous avons donc décidé de nous baser plutôt sur la participation, et d'élargir le blocage à toutes les participations `pending` (donc `unknown` + dans le futur).