### PR TITLE
feat(app): avoid duplicates

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,10 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   include Serializable
+
+  def self.squish_normalizes(*attributes)
+    attributes.each do |attribute|
+      class_eval { normalizes attribute, with: ->(a) { a.squish } }
+    end
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,7 +3,7 @@ class ApplicationRecord < ActiveRecord::Base
 
   include Serializable
 
-  def self.squish_normalizes(*attributes)
+  def self.squishes(*attributes)
     attributes.each do |attribute|
       class_eval { normalizes attribute, with: ->(a) { a.squish } }
     end

--- a/app/models/concerns/user/address.rb
+++ b/app/models/concerns/user/address.rb
@@ -2,7 +2,7 @@ module User::Address
   extend ActiveSupport::Concern
 
   included do
-    normalizes :address, with: ->(address) { address.squish }
+    squish_normalizes :address
   end
 
   def street_address

--- a/app/models/concerns/user/address.rb
+++ b/app/models/concerns/user/address.rb
@@ -2,7 +2,7 @@ module User::Address
   extend ActiveSupport::Concern
 
   included do
-    squish_normalizes :address
+    squishes :address
   end
 
   def street_address

--- a/app/models/concerns/user/text_helper.rb
+++ b/app/models/concerns/user/text_helper.rb
@@ -4,9 +4,7 @@ module User::TextHelper
   end
 
   def to_s
-    return "" if first_name.blank? || last_name.blank?
-
-    "#{first_name.capitalize} #{last_name.capitalize}"
+    "#{first_name&.capitalize} #{last_name&.capitalize}".strip
   end
 
   def short_title

--- a/app/models/concerns/user/text_helper.rb
+++ b/app/models/concerns/user/text_helper.rb
@@ -4,6 +4,8 @@ module User::TextHelper
   end
 
   def to_s
+    return "" if first_name.blank? || last_name.blank?
+
     "#{first_name.capitalize} #{last_name.capitalize}"
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
   }
   scope :with_sent_invitations, -> { where.associated(:invitations) }
 
-  squish_normalizes :department_internal_id, :affiliation_number
+  squishes :department_internal_id, :affiliation_number
 
   def participation_for(rdv)
     participations.to_a.find { |participation| participation.rdv_id == rdv.id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,7 +66,7 @@ class User < ApplicationRecord
   }
   scope :with_sent_invitations, -> { where.associated(:invitations) }
 
-  squishes :department_internal_id, :affiliation_number
+  squishes :first_name, :last_name, :department_internal_id, :affiliation_number
 
   def participation_for(rdv)
     participations.to_a.find { |participation| participation.rdv_id == rdv.id }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,8 @@ class User < ApplicationRecord
   }
   scope :with_sent_invitations, -> { where.associated(:invitations) }
 
+  squish_normalizes :department_internal_id, :affiliation_number
+
   def participation_for(rdv)
     participations.to_a.find { |participation| participation.rdv_id == rdv.id }
   end

--- a/app/services/users/save.rb
+++ b/app/services/users/save.rb
@@ -6,16 +6,22 @@ module Users
     end
 
     def call
-      User.transaction do
-        assign_organisation if @organisation.present?
-        validate_user!
-        save_record!(@user)
-        sync_with_rdv_solidarites
-      end
+      save_user
       result.user = @user
     end
 
     private
+
+    def save_user
+      User.with_advisory_lock "saving_user_#{@user}" do
+        User.transaction do
+          assign_organisation if @organisation.present?
+          validate_user!
+          save_record!(@user)
+          sync_with_rdv_solidarites
+        end
+      end
+    end
 
     def assign_organisation
       @user.organisations = (@user.organisations.to_a + [@organisation]).uniq

--- a/app/services/users/save.rb
+++ b/app/services/users/save.rb
@@ -13,7 +13,7 @@ module Users
     private
 
     def save_user
-      User.with_advisory_lock "saving_user_#{@user}" do
+      User.with_advisory_lock "saving_user_#{lock_key}" do
         User.transaction do
           assign_organisation if @organisation.present?
           validate_user!
@@ -21,6 +21,10 @@ module Users
           sync_with_rdv_solidarites
         end
       end
+    end
+
+    def lock_key
+      @user.to_s.presence || SecureRandom.uuid
     end
 
     def assign_organisation


### PR DESCRIPTION
Lié à #1832 

## Contexte

Ici je fais en sorte d'empêcher les doublons lorsque: 
* les données d'identifications (numéro CAF, id interne ou nom prénom) sont mal formattés
* lorsqu'on envoie deux mêmes requêtes en même temps (race condition)

Dans le ticket je parle aussi de certains doublons qui ont été récupérés via webhooks. Vu la faible occurence de ces cas et la potentielle complexité de cet ajout je décide de ne pas le prendre en compte ici. 

## Formattage des données

J'introduis une méthode de classe `squishes` qui peut être utilisée sur tous les modèles `ActiveRecord`, qui permet de normaliser les attributs qu'on lui passe en les "squishant". Cette méthode s'appuie sur la nouvelle méthode `normalizes` de Rails 7. Je l'utilise donc pour squisher le nom, le prénom, l'id interne et le numéro CAF des usagers.

## Prévenir les race conditions

Je fais en sorte qu'on ne puisse pas sauver en même temps deux usager ayant le même prénom-nom pour éviter les race conditions au moment de la création et modification d'un usager.
