### PR TITLE
refactor(navigation): Change url when navigating between frames

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,7 @@
 <div class="container text-dark-blue h4-as-labels mt-4">
   <%= render "user_page_header" %>
 
-  <%= turbo_frame_tag "user_page_body" do %>
+  <%= turbo_frame_tag "user_page_body", data: { turbo_action: "advance" } do %>
 
     <%= render "user_tabs", user: @user, tab: "infos" %>
 


### PR DESCRIPTION
L'utilisation des turbo frames sur la page `users#show` permet de naviguer d'onglets en onglets sans un full reload de la page pour une navigation plus agréable.
Cependant ça avait l'inconvénient que l'url n'était pas changé entre les pages et que donc on pouvait difficilement partager l'url d'une page "parcours", "rendez-vous" ou bien même "edit".

Je change ce comportement en changeant l'url lorsqu'on change de frame en settant l'attribute `data-turbo-action = "advance"` (le lien de la documentation est [ici](https://github.com/hotwired/turbo-site/blob/main/_source/handbook/04_frames.md#promoting-a-frame-navigation-to-a-page-visit) pour + d'infos).
