### PR TITLE
fix(tags): tags case not working

### DIFF
--- a/app/javascript/react/models/User.js
+++ b/app/javascript/react/models/User.js
@@ -461,7 +461,7 @@ export default class User {
   }
 
   get tagsAsJson() {
-    const matchingTags = this.availableTags.filter((tag) => this.tags.includes(tag.value.toLowerCase()));
+    const matchingTags = this.availableTags.filter((tag) => this.tags.map(t => t.toLowerCase()).includes(tag.value.toLowerCase()));
 
     return matchingTags.map((tag) => ({ tag_id: tag.id }));
   }

--- a/spec/features/agent_can_edit_uploaded_user_list_spec.rb
+++ b/spec/features/agent_can_edit_uploaded_user_list_spec.rb
@@ -33,6 +33,7 @@ describe "Agents can upload user list", :js do
     setup_agent_session(agent)
     stub_user_creation(rdv_solidarites_user_id)
     organisation.tags << create(:tag, value: "Gentils")
+    organisation.tags << create(:tag, value: "cool")
   end
 
   context "at organisation level" do
@@ -68,7 +69,7 @@ describe "Agents can upload user list", :js do
           modal.click_button("Ajouter")
           modal.click_button("Fermer")
 
-          expect(column).to have_content("Gentils")
+          expect(column).to have_content("Gentils, cool")
         else
           column
             .double_click
@@ -82,6 +83,7 @@ describe "Agents can upload user list", :js do
 
       expect(User.last.first_name).to eq("hello")
       expect(User.last.last_name).to eq("hello")
+      expect(User.last.tags.pluck(:value)).to eq(%w[Gentils cool])
     end
   end
 end


### PR DESCRIPTION
Cette PR corrige un bug qui empêche d'affecter des tags depuis un fichier xls lorsque le tag en base de données contient des majuscules

Fix https://github.com/betagouv/rdv-insertion/issues/1923