### PR TITLE
fix(organisation): Allow safir code update

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,7 +1,7 @@
 class OrganisationsController < ApplicationController
   PERMITTED_PARAMS = [
     :name, :phone_number, :email, :slug, :independent_from_cd, :logo_filename, :rdv_solidarites_organisation_id,
-    :department_id
+    :department_id, :safir_code
   ].freeze
 
   before_action :set_organisation, :set_department, :authorize_organisation_configuration, only: [:show, :edit, :update]

--- a/spec/features/agent_can_edit_organisation_spec.rb
+++ b/spec/features/agent_can_edit_organisation_spec.rb
@@ -1,0 +1,28 @@
+describe "Agents can edit organisation", :js do
+  let!(:agent) { create(:agent) }
+  let!(:organisation) { create(:organisation) }
+  let!(:configuration) { create(:configuration, organisation: organisation) }
+  let!(:agent_role) { create(:agent_role, organisation: organisation, agent: agent, access_level: 1) }
+
+  let(:tag_value) { "prout" }
+
+  before do
+    setup_agent_session(agent)
+    stub_request(:patch,
+                 "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/organisations/#{organisation.rdv_solidarites_organisation_id}")
+      .to_return(status: 200, body: { organisation: { id: organisation.rdv_solidarites_organisation_id } }.to_json)
+  end
+
+  context "organisation edit" do
+    it "allows to set a code safir" do
+      visit organisation_configurations_path(organisation)
+      click_link("Modifier", href: edit_organisation_path(organisation))
+
+      page.fill_in "organisation_safir_code", with: "153425"
+      click_button "Enregistrer"
+
+      expect(page).to have_content("153425")
+      expect(organisation.reload.safir_code).to eq("153425")
+    end
+  end
+end


### PR DESCRIPTION
Le renseignement du code safir ne marchait pas car il n'était pas listé dans les paramètres permis par `OrganisationsController::PERMITTED_PARAMS`.
Je le fais ici et j'en profite pour ajouter un test de feature.