### PR TITLE
fix(index): never display configure organisation when basic agent role

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -281,7 +281,8 @@ class UsersController < ApplicationController
 
   def set_current_agent_roles
     @current_agent_roles = AgentRole.where(
-      department_level? ? { organisation: @organisations } : { organisation: @organisation }, agent: current_agent
+      agent: current_agent,
+      organisation: department_level? ? @organisations : @organisation
     )
   end
 


### PR DESCRIPTION
closes #1925 

la variable `@current_agent_roles` ne scopait pas correctement les agent_roles (c'est l'écriture ternaire de la condition qui rendait le scope défectueux). Cela ne posait cependant pas de problème de sécurité, seulement d'affichage, car l'accès à la page était ensuite authorizée correctement.
Cette PR résout ce problème.