### PR TITLE
fix(parcours): alert when destroy orientation

### DIFF
--- a/app/views/orientations/_orientation.html.erb
+++ b/app/views/orientations/_orientation.html.erb
@@ -1,26 +1,37 @@
-<div class="d-flex justify-content-between align-items-center my-4" id="<%= dom_id(orientation) %>">
-  <div class="w-100">
+<tr id="<%= dom_id(orientation) %>">
+  <td>
     <% if orientation.current? %>
-      Du <%= format_date(orientation.starts_at) %> à <strong>aujourd'hui</strong>&nbsp;:
+      Du <%= format_date(orientation.starts_at) %> à <strong>aujourd'hui</strong>
     <% else %>
-      Du <%= format_date(orientation.starts_at) %> au <%= format_date(orientation.ends_at) %>&nbsp;:
+      Du <%= format_date(orientation.starts_at) %> au <%= format_date(orientation.ends_at) %>
     <% end %>
-  </div>
-  <div class="w-100">
-    Orientation <strong><%= I18n.t("activerecord.attributes.orientation.orientation_types.#{orientation.orientation_type}") %></strong>
-  </div>
-  <div class="w-100">Structure <strong><%= orientation.organisation.name %></strong></div>
-  <% if orientation.agent_id? %>
-    <div class="w-100">Référent unique <strong><%= orientation.agent.to_s %></strong></div>
-  <% else %>
-    <div class="w-100">Référent unique <em>non renseigné</em></div>
-  <% end %>
-  <div class="w-100 text-end">
+  </td>
+
+  <td>
+    <strong><%= I18n.t("activerecord.attributes.orientation.orientation_types.#{orientation.orientation_type}") %></strong>
+  </td>
+
+  <td>
+    <%= orientation.organisation.name %>
+  </td>
+
+  <td>
+    <% if orientation.agent_id? %>
+      <%= orientation.agent.to_s %>
+    <% else %>
+      <em>non renseigné</em>
+    <% end %>
+  </td>
+
+  <td>
     <%= link_to edit_user_orientation_path(id: orientation.id, user_id: orientation.user_id), data: { turbo_frame: 'remote_modal' } do %>
       <i class="fas fa-pencil-alt text-dark-blue"></i>
     <% end %>
-    <%= link_to user_orientation_path(id: orientation.id, user_id: orientation.user_id), method: :delete do %>
+  </td>
+
+  <td>
+    <%= link_to user_orientation_path(id: orientation.id, user_id: orientation.user_id), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cette orientation ?" } do %>
       <i class="fas fa-trash text-dark-blue"></i>
     <% end %>
-  </div>
-</div>
+  </td>
+</tr>

--- a/app/views/orientations/_orientations_list.html.erb
+++ b/app/views/orientations/_orientations_list.html.erb
@@ -2,7 +2,7 @@
   <% if orientations.empty? %>
     <p id="no-orientation-text">Pas d'orientation renseignée</p>
   <% else %>
-    <table class="table table-hover table-responsive">
+    <table class="table table-hover table-responsive my-4">
         <thead class="text-dark-blue">
           <th scope="col">Dates</th>
           <th scope="col">Type d'orientation</th>

--- a/app/views/orientations/_orientations_list.html.erb
+++ b/app/views/orientations/_orientations_list.html.erb
@@ -2,8 +2,18 @@
   <% if orientations.empty? %>
     <p id="no-orientation-text">Pas d'orientation renseignée</p>
   <% else %>
-    <% orientations.each do |orientation| %>
-      <%= render "orientations/orientation", orientation:  %>
-    <% end %>
+    <table class="table table-hover table-responsive">
+        <thead class="text-dark-blue">
+          <th scope="col">Dates</th>
+          <th scope="col">Type d'orientation</th>
+          <th scope="col">Structure</th>
+          <th scope="col">Référent unique</th>
+        </thead>
+        <tbody class="align-middle">
+          <% orientations.each do |orientation| %>
+            <%= render "orientations/orientation", orientation: %>
+          <% end %>
+        </tbody>
+    </table>
   <% end %>
 <% end %>

--- a/spec/features/agent_can_add_user_orientations_spec.rb
+++ b/spec/features/agent_can_add_user_orientations_spec.rb
@@ -59,9 +59,9 @@ describe "Agents can add user orientation", :js do
 
       expect(page).to have_no_content("Pas d'orientation renseignée")
       expect(page).to have_content("Du 03/07/2023 à aujourd'hui")
-      expect(page).to have_content("Orientation Sociale")
-      expect(page).to have_content("Structure CD 26")
-      expect(page).to have_content("Référent unique Kad Merad")
+      expect(page).to have_content("Sociale")
+      expect(page).to have_content("CD 26")
+      expect(page).to have_content("Kad Merad")
 
       # orientation without agent
       click_button("Ajouter une orientation")
@@ -78,14 +78,14 @@ describe "Agents can add user orientation", :js do
       click_button "Enregistrer"
 
       expect(page).to have_content("Du 03/07/2023 au 03/10/2023")
-      expect(page).to have_content("Orientation Sociale")
-      expect(page).to have_content("Structure CD 26")
-      expect(page).to have_content("Référent unique Kad Merad")
+      expect(page).to have_content("Sociale")
+      expect(page).to have_content("CD 26")
+      expect(page).to have_content("Kad Merad")
 
       expect(page).to have_content("Du 03/10/2023 à aujourd'hui")
-      expect(page).to have_content("Orientation Professionnelle")
-      expect(page).to have_content("Structure Asso 26")
-      expect(page).to have_content("Référent unique non renseigné")
+      expect(page).to have_content("Professionnelle")
+      expect(page).to have_content("Asso 26")
+      expect(page).to have_content("non renseigné")
     end
   end
 end


### PR DESCRIPTION
closes #1887 

Dans cette PR, je fais en sorte d'espacer les boutons de modif et de suppresion d'une orientation, + j'ajoute une popin de confirmation avant le destroy.

Vu avec @samanthaauffret : j'en profite également pour transformer en tableau (screen 1) cette petite liste dont la lisibilité n'était pas optimale (screen 2), en particulier dès qu'il y avait plus d'un item (répétition des "header" comme `Structure`, `Référent unique`, `Orientation` ; beaucoup d'infos sur une même ligne)

![Screenshot 2024-04-09 at 15-21-35 rdv-insertion](https://github.com/betagouv/rdv-insertion/assets/46218316/698ba702-68ce-4a88-ab09-700fb0ce511d)
![Screenshot 2024-04-09 at 15-35-51 rdv-insertion](https://github.com/betagouv/rdv-insertion/assets/46218316/513ea5c3-9fcc-4e78-9c08-c7a5ea14be1f)