### PR TITLE
fix(status): prevent dropdown from showing up unwillingly 

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -5,6 +5,7 @@ export default class extends Controller {
     this.button = this.element.querySelector("button")
     this.menu = this.element.querySelector(".dropdown-menu")
     this.input = this.element.querySelector("#participation_status")
+    this.clickOutsideHandlerListener = this.clickOutsideHandler.bind(this)
     this.visible = false
 
     this.button.addEventListener("click", () => {
@@ -26,9 +27,9 @@ export default class extends Controller {
     this.visible = !this.visible
 
     if (this.visible) {
-      document.addEventListener("click", (e) => this.clickOutsideHandler(e))
+      document.addEventListener("click", this.clickOutsideHandlerListener)
     } else {
-      document.removeEventListener("click", (e) => this.clickOutsideHandler(e))
+      document.removeEventListener("click", this.clickOutsideHandlerListener)
     }
   }
 


### PR DESCRIPTION
Dans cette PR je fix un listener qui n'était pas proprement supprimé car la signature de la méthode qui lui était donné n'était pas identique (() => {} !== () => {})
Pour le fixer je suis obligé de mettre dans une variable la méthode à appeler à laquelle je bind this pour être sur que la signature donné à removeEventListener soit similaire

Fix https://github.com/betagouv/rdv-insertion/issues/1938