### PR TITLE
feat(orientation): automatically add user to the org

### DIFF
--- a/app/services/orientations/save.rb
+++ b/app/services/orientations/save.rb
@@ -10,7 +10,7 @@ module Orientations
         update_previous_orientation_ends_at if previous_orientation_without_end_date.present?
         fill_current_orientation_ends_at if @orientation.ends_at.nil? && posterior_orientations.any?
         validate_no_orientations_overlap
-        add_user_to_organisation if @orientation.user.organisation_ids.exclude?(@orientation.organisation)
+        add_user_to_organisation if @orientation.user.organisation_ids.exclude?(@orientation.organisation_id)
         save_record!(@orientation)
       end
     end

--- a/app/services/orientations/save.rb
+++ b/app/services/orientations/save.rb
@@ -5,16 +5,21 @@ module Orientations
     end
 
     def call
-      Orientation.transaction do
+      ActiveRecord::Base.transaction do
         validate_starts_at_presence
         update_previous_orientation_ends_at if previous_orientation_without_end_date.present?
         fill_current_orientation_ends_at if @orientation.ends_at.nil? && posterior_orientations.any?
         validate_no_orientations_overlap
+        add_user_to_organisation if @orientation.user.organisation_ids.exclude?(@orientation.organisation)
         save_record!(@orientation)
       end
     end
 
     private
+
+    def add_user_to_organisation
+      @orientation.user.organisations << @orientation.organisation
+    end
 
     def other_user_orientations
       @other_user_orientations ||= @orientation.user.orientations.reject do |orientation|

--- a/spec/services/orientations/save_spec.rb
+++ b/spec/services/orientations/save_spec.rb
@@ -4,7 +4,9 @@ describe Orientations::Save, type: :service do
   end
 
   let!(:user) { create(:user) }
-  let!(:orientation) { build(:orientation, user:, starts_at:, ends_at:) }
+  let!(:orientation) { build(:orientation, user:, starts_at:, ends_at:, organisation:) }
+
+  let(:organisation) { create(:organisation) }
 
   let!(:starts_at) { Date.parse("12/12/2022") }
   let!(:ends_at) { Date.parse("22/12/2022") }
@@ -151,6 +153,14 @@ describe Orientations::Save, type: :service do
         it "does not set the previous ends_at" do
           subject
           expect(second_orientation.reload.ends_at).to be_nil
+        end
+      end
+
+      context "when user is not part of the organisation" do
+        it "adds the user to the organisation" do
+          expect(user.organisations).not_to include(organisation)
+          subject
+          expect(user.organisations.reload).to include(orientation.organisation)
         end
       end
 


### PR DESCRIPTION
Dans cette PR j'assigne automatiquement l'organisation associée à l'orientation à créer si l'usager n'y est pas déjà rattaché.

Fix https://github.com/betagouv/rdv-insertion/issues/1947