### PR TITLE
fix(show): fix statuses display in dropdown of change rdv status

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -95,17 +95,16 @@ module UsersHelper
     "text-danger"
   end
 
-  def human_available_status(participation, status)
+  def human_available_status(status)
     return I18n.t("activerecord.attributes.rdv.statuses.#{status}") unless status == "unknown"
 
-    participation.human_status
+    I18n.t("activerecord.attributes.rdv.unknown_statuses.pending")
   end
 
-  def human_available_detailed_status(participation, status)
+  def human_available_detailed_status(status)
     return I18n.t("activerecord.attributes.rdv.statuses.detailed.#{status}") unless status == "unknown"
 
-    temporal_unknown_status = participation.in_the_future? ? "pending" : "needs_status_update"
-    I18n.t("activerecord.attributes.rdv.unknown_statuses.detailed.#{temporal_unknown_status}")
+    I18n.t("activerecord.attributes.rdv.unknown_statuses.detailed.pending")
   end
 
   def display_context_status(context, number_of_days_before_action_required)

--- a/app/views/participations/_participation_status.html.erb
+++ b/app/views/participations/_participation_status.html.erb
@@ -11,9 +11,9 @@
             <%= link_to "#", class: "dropdown-item", data: { value: status } do %>
               <span class="bold">
                 <i class="fa fa-circle me-1 <%= text_class_for_participation_status(status) %>"></i>
-                <%= human_available_status(participation, status) %>
+                <%= human_available_status(status) %>
               </span><br>
-              <span><%= human_available_detailed_status(participation, status) %></span>
+              <span><%= human_available_detailed_status(status) %></span>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
closes #1898 

la liste des status sélectionnables ne s'affichait pas correctement dans la dropdown : lorsque le rendez-vous avait été annulé avant sa tenue, le statut `unknwown`, qui aurait du s'afficher comme l'option `Rdv à venir`, présentait le texte du statut d'annulation qui avait été choisie.