### PR TITLE
fix(upload): reset errors when editing field

### DIFF
--- a/app/javascript/react/models/User.js
+++ b/app/javascript/react/models/User.js
@@ -257,13 +257,17 @@ export default class User {
       this.triggers[`${attribute}Update`] = true;
       const result = await handleUserUpdate(this.currentOrganisation.id, this, this.asJson());
 
-      if (!result.success) {
+      if (result.success) {
+        this.resetErrors();
+      } else {
         this[attribute] = previousValue;
       }
 
       this.triggers[`${attribute}Update`] = false;
       return result.success;
-    }
+    } 
+      this.resetErrors();
+    
     return true;
   }
 


### PR DESCRIPTION
Cette PR corrige un problème lors de la modification d'une colonne depuis la page upload. Une fois modifiée, le bouton "Afficher les erreurs" ne devrait plus apparaître comme "Afficher les erreurs" sachant que l'erreur a potentiellement été résolue par la modification.
Pour corriger ça j'ai donc fait en sorte de réinitialiser les erreurs d'un usager une fois la colonne éditée

Fix https://github.com/betagouv/rdv-insertion/issues/1954