### PR TITLE
feat(exports): add context of export in mail

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -113,8 +113,8 @@ class UsersController < ApplicationController
       @users.map(&:id),
       department_level? ? "Department" : "Organisation",
       department_level? ? @department.id : @organisation.id,
-      @current_motif_category&.id,
-      current_agent.id
+      current_agent.id,
+      request.query_parameters
     )
   end
 

--- a/app/mailers/csv_export_mailer.rb
+++ b/app/mailers/csv_export_mailer.rb
@@ -1,6 +1,68 @@
 class CsvExportMailer < ApplicationMailer
-  def notify_csv_export(email, export)
+  def notify_csv_export(email, export, request_params)
     @export = export
-    mail(to: email, subject: "[RDV-Insertion] Voici l'export CSV que vous avez demandé")
+    @request_params = request_params
+    set_filters
+    mail(to: email, subject: "[rdv-insertion] Voici l'export CSV que vous avez demandé")
+  end
+
+  private
+
+  def set_filters
+    set_organisations_filter
+    set_status_filter
+    set_referent_filter
+    set_creation_dates_filter
+    set_invitation_dates_filter
+    set_tags_filter
+    set_motif_category_filter
+    set_action_required_filter
+    set_search_query_filter
+  end
+
+  def set_organisations_filter
+    @organisations_filter =
+      if @export.structure_type == "organisation"
+        [Organisation.find(@export.structure_id)]
+      else
+        Agent.find(@export.agent_id).organisations.where(department: @export.structure_id)
+      end
+  end
+
+  def set_status_filter
+    @status_filter = @request_params[:status]
+  end
+
+  def set_referent_filter
+    @referent_filter = @request_params[:referent_id].present? ? Agent.find_by(id: @request_params[:referent_id]) : nil
+  end
+
+  def set_creation_dates_filter
+    @creation_date_before = @request_params[:creation_date_before]
+    @creation_date_after = @request_params[:creation_date_after]
+  end
+
+  def set_invitation_dates_filter
+    @first_invitation_date_before = @request_params[:first_invitation_date_before]
+    @first_invitation_date_after = @request_params[:first_invitation_date_after]
+    @last_invitation_date_before = @request_params[:last_invitation_date_before]
+    @last_invitation_date_after = @request_params[:last_invitation_date_after]
+  end
+
+  def set_tags_filter
+    @tags_filter = @request_params[:tag_ids].present? ? Tag.where(id: @request_params[:tag_ids]).sort_by(&:value) : nil
+  end
+
+  def set_motif_category_filter
+    @motif_category_filter =
+      @request_params[:motif_category_id].present? ? MotifCategory.find(@request_params[:motif_category_id]) : nil
+  end
+
+  def set_action_required_filter
+    @action_required_filter = @request_params[:action_required]
+  end
+
+  def set_search_query_filter
+    @search_query_filter = @request_params[:search_query]
   end
 end

--- a/app/mailers/csv_export_mailer.rb
+++ b/app/mailers/csv_export_mailer.rb
@@ -3,7 +3,7 @@ class CsvExportMailer < ApplicationMailer
     @export = export
     @request_params = request_params
     set_filters
-    mail(to: email, subject: "[rdv-insertion] Voici l'export CSV que vous avez demandé")
+    mail(to: email, subject: "[rdv-insertion] Export CSV")
   end
 
   private
@@ -22,7 +22,7 @@ class CsvExportMailer < ApplicationMailer
 
   def set_organisations_filter
     @organisations_filter =
-      if @export.structure_type == "organisation"
+      if @export.structure_type == "Organisation"
         [Organisation.find(@export.structure_id)]
       else
         Agent.find(@export.agent_id).organisations.where(department: @export.structure_id)

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -3,10 +3,10 @@ module Exporters
   class GenerateUsersCsv < Csv
     attr_reader :agent
 
-    def initialize(user_ids:, agent:, structure: nil, motif_category: nil)
+    def initialize(user_ids:, agent:, structure: nil, motif_category_id: nil)
       @user_ids = user_ids
       @structure = structure
-      @motif_category = motif_category
+      @motif_category = motif_category_id.present? ? MotifCategory.find(motif_category_id) : nil
       @agent = agent
     end
 

--- a/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
+++ b/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
@@ -1,6 +1,58 @@
 <h1>Bonjour</h1>
 <p>Voici l'export CSV que vous avez demandé sur notre plateforme.</p>
 <p>Ce lien de téléchargement n'est valable que pendant <%= CsvExport::VALIDITY_PERIOD.in_hours.to_i %> heures à partir de l'envoi de ce mail.</p>
+<p>L'export a été réalisé à partir des critères suivants&nbsp;:</p>
+<ul>
+  <li><strong>Type d'export</strong>&nbsp;:
+    <%= @export.kind == "users_csv" ? "export des usagers" : "export des rendez-vous des usagers" %>
+  </li>
+  <% if @motif_category_filter %>
+    <li><strong>Catégorie</strong>&nbsp;: <%= @motif_category_filter.name %></li>
+  <% end %>
+  <li><strong>Périmètre</strong>&nbsp;: <%= @organisations_filter.map(&:name).join(", ") %></li>
+  <% if @status_filter %>
+    <li><strong>Statut</strong>&nbsp;: <%= I18n.t("activerecord.attributes.follow_up.statuses.#{@status_filter}") %></li>
+  <% end %>
+  <% if @referent_filter %>
+    <li><strong>Référent</strong>&nbsp;: <%= @referent_filter.to_s %></li>
+  <% end %>
+  <% if @creation_dates_before || @creation_dates_after %>
+    <li><strong>Date de création</strong>&nbsp;:
+      <% if @creation_dates_after %>
+        entre <%= @creation_dates_after.to_date&.strftime("%d/%m/%Y") %> et le <%= (@creation_dates_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
+      <% else %>
+        avant le <%= @creation_dates_before.to_date&.strftime("%d/%m/%Y") %>
+      <% end %>
+    </li>
+  <% end %>
+  <% if @first_invitation_date_after || @first_invitation_date_before %>
+    <li><strong>Date de première invitation</strong>&nbsp;:
+      <% if @first_invitation_date_after %>
+        entre <%= @first_invitation_date_after.to_date&.strftime("%d/%m/%Y") %> et le <%= (@first_invitation_date_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
+      <% else %>
+        avant le <%= @first_invitation_date_before.to_date&.strftime("%d/%m/%Y") %>
+      <% end %>
+    </li>
+  <% end %>
+  <% if @last_invitation_date_after || @last_invitation_date_before %>
+    <li><strong>Date de dernière invitation</strong>&nbsp;:
+      <% if @last_invitation_date_after %>
+        entre <%= @last_invitation_date_after.to_date&.strftime("%d/%m/%Y") %> et le <%= (@last_invitation_date_before&.to_date&.strftime("%d/%m/%Y") || Time.zone.now&.strftime("%d/%m/%Y")) %>
+      <% elsif @last_invitation_date_before %>
+        avant le <%= @last_invitation_date_before.to_date&.strftime("%d/%m/%Y") %>
+      <% end %>
+    </li>
+  <% end %>
+  <% if @action_required_filter %>
+    <li><strong>Usagers avec intervention nécessaire</strong>&nbsp;: Oui</li>
+  <% end %>
+  <% if @search_query_filter %>
+    <li><strong>Champ de recherche libre</strong>&nbsp;: <%= @search_query_filter %></li>
+  <% end %>
+  <% if @tags_filter %>
+    <li><strong>Tags</strong>&nbsp;: <%= @tags_filter.join(", ") %></li>
+  <% end %>
+</ul>
 <p class="btn-wrapper">
   <%= link_to csv_export_url(id: @export.signed_id), class: "btn btn-primary" do %>
     Télécharger le fichier

--- a/db/migrate/20240412105200_remove_motif_cateogry_id_to_csv_export_and_add_request_fullpath.rb
+++ b/db/migrate/20240412105200_remove_motif_cateogry_id_to_csv_export_and_add_request_fullpath.rb
@@ -1,0 +1,5 @@
+class RemoveMotifCateogryIdToCsvExportAndAddRequestFullpath < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :csv_exports, :motif_category_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_03_125856) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_12_105200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -120,7 +120,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_125856) do
     t.bigint "agent_id", null: false
     t.string "structure_type", null: false
     t.bigint "structure_id", null: false
-    t.integer "motif_category_id"
     t.datetime "purged_at"
     t.string "kind"
     t.datetime "created_at", null: false

--- a/spec/mailers/csv_export_mailer_spec.rb
+++ b/spec/mailers/csv_export_mailer_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe CsvExportMailer do
+  let!(:department) { create(:department) }
+  let!(:organisation1) { create(:organisation, department: department) }
+  let!(:organisation2) { create(:organisation, department: department) }
+  let!(:agent) { create(:agent, organisations: [organisation1, organisation2]) }
+  let!(:export) do
+    create(:csv_export, structure_type: "Organisation", structure_id: organisation1.id, kind: "users_csv",
+                        agent_id: agent.id)
+  end
+  let!(:request_params) { { organisation_id: organisation1.id } }
+
+  describe "#notify_csv_export" do
+    subject do
+      described_class.notify_csv_export(agent.email, export, request_params)
+    end
+
+    it "renders the headers" do
+      expect(subject.to).to eq([agent.email])
+      expect(subject.subject).to eq("[rdv-insertion] Export CSV")
+    end
+
+    it "renders the body" do
+      body_string = unescape_html(subject.body.encoded)
+      expect(body_string).to match("Voici l'export CSV que vous avez demandé sur notre plateforme.")
+      expect(body_string).to match(
+        "Ce lien de téléchargement n'est valable que pendant 48 heures à partir de l'envoi de ce mail."
+      )
+      expect(body_string).to match("L'export a été réalisé à partir des critères suivants")
+      expect(body_string).to match("<strong>Type d'export</strong>&nbsp;:")
+      expect(body_string).to match("export des usagers")
+      expect(body_string).to match("<strong>Périmètre</strong>&nbsp;:")
+      expect(body_string).to match(organisation1.name)
+      expect(body_string).not_to match(organisation2.name)
+    end
+
+    context "when the export is for a department" do
+      let!(:export) do
+        create(:csv_export, structure_type: "Department", structure_id: department.id, kind: "users_csv",
+                            agent_id: agent.id)
+      end
+
+      it "renders the body" do
+        body_string = unescape_html(subject.body.encoded)
+        expect(body_string).to match(organisation1.name)
+        expect(body_string).to match(organisation2.name)
+      end
+    end
+
+    context "when the export is for participations" do
+      before do
+        export.update(kind: "users_participations_csv")
+      end
+
+      it "renders the body" do
+        body_string = unescape_html(subject.body.encoded)
+        expect(body_string).to match("export des rendez-vous des usagers")
+      end
+    end
+
+    context "when different filters are set" do
+      let!(:motif_category) { create(:motif_category) }
+      let!(:tag) { create(:tag) }
+      let!(:request_params) do
+        {
+          action_required: "true", first_invitation_date_before: "15-04-2024",
+          last_invitation_date_after: "01-01-2024", last_invitation_date_before: "02-04-2024",
+          motif_category_id: motif_category.id.to_s,
+          referent_id: agent.id.to_s, search_query: "Bacri", status: "invitation_pending",
+          tag_ids: [tag.id.to_s], organisation_id: organisation1.id.to_s
+        }
+      end
+
+      it "renders the body" do
+        body_string = unescape_html(subject.body.encoded)
+        expect(body_string).to match("Catégorie")
+        expect(body_string).to match(motif_category.name)
+        expect(body_string).to match("Statut")
+        expect(body_string).to match("Invitation en attente de réponse")
+        expect(body_string).to match("Référent")
+        expect(body_string).to match(agent.to_s)
+        expect(body_string).to match("Date de première invitation")
+        expect(body_string).to match("avant le 15/04/2024")
+        expect(body_string).to match("Date de dernière invitation")
+        expect(body_string).to match("entre 01/01/2024 et le 02/04/2024")
+        expect(body_string).to match("Usagers avec intervention nécessaire")
+        expect(body_string).to match("Champ de recherche libre")
+        expect(body_string).to match("Bacri")
+        expect(body_string).to match("Tags")
+        expect(body_string).to match(tag.value)
+      end
+    end
+  end
+end

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -1,5 +1,5 @@
 describe Exporters::GenerateUsersCsv, type: :service do
-  subject { described_class.call(user_ids: users.ids, structure:, motif_category:, agent:) }
+  subject { described_class.call(user_ids: users.ids, structure:, motif_category_id: motif_category.id, agent:) }
 
   let!(:now) { Time.zone.parse("22/06/2022") }
   let!(:timestamp) { now.to_i }
@@ -261,7 +261,7 @@ describe Exporters::GenerateUsersCsv, type: :service do
       end
 
       context "when no motif category is passed" do
-        subject { described_class.call(user_ids: users.ids, structure: structure, motif_category: nil, agent:) }
+        subject { described_class.call(user_ids: users.ids, structure: structure, motif_category_id: nil, agent:) }
 
         it "is a success" do
           expect(subject.success?).to eq(true)

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -1,5 +1,5 @@
 describe Exporters::GenerateUsersParticipationsCsv, type: :service do
-  subject { described_class.call(user_ids: users.ids, structure: structure, motif_category: motif_category, agent:) }
+  subject { described_class.call(user_ids: users.ids, structure: structure, motif_category_id: motif_category.id, agent:) }
 
   let!(:now) { Time.zone.parse("22/06/2022") }
   let!(:timestamp) { now.to_i }
@@ -189,7 +189,7 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
       end
 
       context "when no motif category is passed" do
-        subject { described_class.call(user_ids: users.ids, structure: structure, motif_category: nil, agent:) }
+        subject { described_class.call(user_ids: users.ids, structure: structure, motif_category_id: nil, agent:) }
 
         it "is a success" do
           expect(subject.success?).to eq(true)


### PR DESCRIPTION
closes #1924 

Dans cette PR, j'ajoute dans le mail permettant de télécharger l'export tous les filtres qui ont été utilisés pour le générer.
Quelques très légères déviations par rapport à la maquette : 
- je n'affiche que la liste des filtres actifs (+ lisible)
- dans "Périmètre", j'affiche systématiquement la liste de toutes les orgas concernées : soit une seule, soit plusieurs. Pas une bonne idée de mettre "département machin" ou "toutes les orgas du département machin", parce que ce sera toutes les orgas auquel a accès l'agent, donc ça me paraît plus clair de mettre la liste exacte
- ajout de certains filtres non pris en compte dans la maquette : intervention nécessaire + le champ de recherche textuelle "libre"

<img width="780" alt="Capture d’écran 2024-04-15 à 09 35 27" src="https://github.com/betagouv/rdv-insertion/assets/46218316/ed77b711-5e96-4c39-aec4-581299931873">
