### PR TITLE
feat(security): Add content security policy headers

### DIFF
--- a/app/views/static_pages/welcome.html.erb
+++ b/app/views/static_pages/welcome.html.erb
@@ -42,7 +42,7 @@
   <div class="row d-flex justify-content-center card-demo">
     <h3 class="col-10 text-center mb-5 text-dark-blue">Et ça ressemble à quoi ?</h3>
     <div class="col-10 col-md-8">
-      <video controls width="100%" src="https://github-production-user-asset-6210df.s3.amazonaws.com/118368758/266281628-49ee911c-d100-4055-ba1f-e76056db243b.mp4"></video>
+      <video controls width="100%" src="https://rdv-insertion-medias-production.s3.fr-par.scw.cloud/assets/rdv_insertion_landing.mp4"></video>
     </div>
   </div>
   <div class="row justify-content-center background-dark-blue text-white">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,16 +4,22 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+s3_bucket = "rdv-insertion-medias-production.s3.fr-par.scw.cloud"
+rdv_solidarites = ENV["RDV_SOLIDARITES_URL"]
+
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data, s3_bucket
+  policy.media_src :self, s3_bucket
+  policy.frame_src :self
+  policy.object_src  :none
+  policy.script_src  :self, :https
+  policy.style_src   :self, :unsafe_inline
+  policy.connect_src :self, rdv_solidarites
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
Je mets en place ici des content security policy headers pour avoir + de protection contre certaines attaques (+ d'infos [ici](https://guides.rubyonrails.org/security.html#content-security-policy-header)) .

J'en profite pour: 
* Hoster la vidéo de la landing sur notre bucket scaleway
* Ajouter `force_ssl` au niveau de l'application (on l'a au niveau de scalingo donc todo bien mais c'est + robuste au niveau de l'appli)