### PR TITLE
fix(form): set back array input in forms

### DIFF
--- a/app/javascript/controllers/array_fields_input_controller.js
+++ b/app/javascript/controllers/array_fields_input_controller.js
@@ -13,12 +13,15 @@ export default class extends Controller {
   add(event) {
     event.preventDefault();
     // if there was only one row, we reactivate the remove button
-    this.element.previousElementSibling.childNodes[3].removeAttribute("style");
-    // we duplicate the last array input field
-    const newRow = this.element.previousElementSibling.cloneNode(true);
-    // we clear the field value
-    newRow.childNodes[1].value = "";
-    this.element.before(newRow);
+    this.element.previousElementSibling
+      .querySelector(".text-array__remove")
+      .classList.remove("d-none");
+    const newRow = this.element.previousElementSibling
+      .querySelector(".text-array__row")
+      .cloneNode(true);
+
+    newRow.querySelector(".array-input").value = "";
+    this.element.previousElementSibling.appendChild(newRow);
   }
 
   // We need to hide the remove button when there's only one row, otherwise there would be nothing to clone
@@ -26,7 +29,7 @@ export default class extends Controller {
     document.querySelectorAll(".text-array").forEach((el) => {
       const rows = el.querySelectorAll(".text-array__row");
       if (rows.length === 1) {
-        rows[0].querySelector(".text-array__remove").style.display = "none";
+        rows[0].querySelector(".text-array__remove").classList.add("d-none");
       }
     });
   }

--- a/app/views/common/_attribute_input.html.erb
+++ b/app/views/common/_attribute_input.html.erb
@@ -40,7 +40,7 @@
       <% end %>
     </p>
   <% elsif local_assigns[:as] == :array %>
-    <p><%= f.text_field attribute %></p>
+    <p><%= render "common/array_fields/input", attribute_name: attribute, f: %></p>
   <% elsif local_assigns[:as] == :boolean %>
     <div class="mt-3 mb-4 input radio_buttons optional configuration_convene_user field_without_errors">
       <span class="radio">

--- a/app/views/common/array_fields/_add_new_row_button.html.erb
+++ b/app/views/common/array_fields/_add_new_row_button.html.erb
@@ -1,5 +1,0 @@
-<button class="btn-sm btn-blue px-2 text-array__add"
-        data-controller="array-fields-input"
-        data-action="click->array-fields-input#add">
-  Ajouter une ligne
-</button>

--- a/app/views/common/array_fields/_input.html.erb
+++ b/app/views/common/array_fields/_input.html.erb
@@ -2,7 +2,7 @@
 <% if attribute_list.blank? %>
     <div class="text-array">
       <div class="text-array__row d-flex justify-content-between">
-        <%= f.text_field attribute_name, class: "array-input", name: "#{f.object.class.name.underscore}[#{attribute_name}][]" %>
+        <%= f.text_field attribute_name, class: "array-input", name: field_name(f.object.class.name.underscore, attribute_name, multiple: true) %>
         <div class="text-array__remove"
           data-controller="array-fields-input"
           data-action="click->array-fields-input#remove">
@@ -14,7 +14,7 @@
   <div class="text-array">
     <% attribute_list.each_with_index do |attribute, index| %>
       <div class="text-array__row d-flex justify-content-between">
-        <%= f.text_field attribute_name, class: "array-input", name: "#{f.object.class.name.underscore}[#{attribute_name}][]", value: attribute %>
+        <%= f.text_field attribute_name, class: "array-input", name: field_name(f.object.class.name.underscore, attribute_name, multiple: true), value: attribute %>
         <div class="text-array__remove"
           data-controller="array-fields-input"
           data-action="click->array-fields-input#remove">

--- a/app/views/common/array_fields/_input.html.erb
+++ b/app/views/common/array_fields/_input.html.erb
@@ -1,8 +1,31 @@
-<div class="text-array__row d-flex justify-content-between">
-  <input class="array-input" type="text" value="<%= array_el %>" name="<%= object_name %>[<%= attribute_name %>][]" id="<%= object_name %>_">
-  <div class="text-array__remove"
-       data-controller="array-fields-input"
-       data-action="click->array-fields-input#remove">
-    <i class="fas fa-trash" ></i>
+<% attribute_list = f.object.send(attribute_name) %>
+<% if attribute_list.blank? %>
+    <div class="text-array">
+      <div class="text-array__row d-flex justify-content-between">
+        <%= f.text_field attribute_name, class: "array-input", name: "#{f.object.class.name.underscore}[#{attribute_name}][]" %>
+        <div class="text-array__remove"
+          data-controller="array-fields-input"
+          data-action="click->array-fields-input#remove">
+          <i class="fas fa-trash" ></i>
+        </div>
+      </div>
+    </div>
+<% else %>
+  <div class="text-array">
+    <% attribute_list.each_with_index do |attribute, index| %>
+      <div class="text-array__row d-flex justify-content-between">
+        <%= f.text_field attribute_name, class: "array-input", name: "#{f.object.class.name.underscore}[#{attribute_name}][]", value: attribute %>
+        <div class="text-array__remove"
+          data-controller="array-fields-input"
+          data-action="click->array-fields-input#remove">
+          <i class="fas fa-trash" ></i>
+        </div>
+      </div>
+    <% end %>
   </div>
-</div>
+<% end %>
+<button class="btn-sm btn-blue px-2 text-array__add"
+        data-controller="array-fields-input"
+        data-action="click->array-fields-input#add">
+  Ajouter une ligne
+</button>


### PR DESCRIPTION
Suite au retrait de Simple form (#1872), le type d'input spécifique aux array mis en place par @qblanc dans #859 avait disparu.
Je le remets ici en faisant en sorte de ne pas changer l'API pour utiliser ce type d'input  (en spécifiant l'option `as: :array` à l'`attribute_input`).