### PR TITLE
fix(security): Add matomo and sentry to content security policy

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -47,7 +47,7 @@ if (process.env.RAILS_ENV === "production") {
 
     // We recommend adjusting this value in production, or using tracesSampler
     // for finer control
-    tracesSampleRate: 0.5,
+    tracesSampleRate: 0.1,
   });
 }
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,6 +6,8 @@
 
 s3_bucket = "rdv-insertion-medias-production.s3.fr-par.scw.cloud"
 rdv_solidarites = ENV["RDV_SOLIDARITES_URL"]
+matomo = "matomo.inclusion.beta.gouv.fr"
+sentry = "sentry.incubateur.net"
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https
@@ -16,7 +18,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.object_src  :none
   policy.script_src  :self, :https, :unsafe_inline
   policy.style_src   :self, :https, :unsafe_inline
-  policy.connect_src :self, rdv_solidarites
+  policy.connect_src :self, rdv_solidarites, sentry, matomo
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"
 end


### PR DESCRIPTION
On a encore des erreurs en console à cause des nouvelles content security policy, notamment lorsqu'on envoie des requêtes à matomo et sentry.
Je règle ça ici et j'en profite pour baisser le taux de transactions sentry envoyé via l'app js: on en récupère beaucoup sur sentry et elles sont rarement interprétables ce qui crée du bruit.