### PR TITLE
feat(letters): rebrand letters and add qr code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "phonelib"
 gem "groupdate"
 gem "chartkick"
 
+# generate QR codes
+gem "rqrcode", "~> 2.0"
+
 # gem needed to be defined explicitely with ruby 3
 gem "rexml"
 gem "addressable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       xpath (~> 3.2)
     chartkick (5.0.5)
     choice (0.2.0)
+    chunky_png (1.4.0)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crack (0.4.5)
@@ -365,6 +366,10 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    rqrcode (2.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -562,6 +567,7 @@ DEPENDENCIES
   redis (~> 4.0)
   responders
   rexml
+  rqrcode (~> 2.0)
   rspec-rails
   rswag
   rubocop

--- a/app/javascript/stylesheets/pdf.scss
+++ b/app/javascript/stylesheets/pdf.scss
@@ -56,19 +56,13 @@ u {
   width: 100%;
 }
 
-.invitation-token {
-  background-color: #083b66;
-  color: white;
-  vertical-align: middle;
+.img-wrapper {
   text-align: center;
-  padding: 10px;
-  border-radius: 3px;
-  width: 35%;
-  margin: 0 auto 30px;
-  font-weight: bold;
-  font-size: 1.5rem;
-}
+  img {
+    display: inline-block;
 
+  }
+}
 .rdv-address {
   padding: 10px;
   border: 1px solid;

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -1,5 +1,7 @@
 module Invitations
   class GenerateLetter < BaseService
+    require "rqrcode"
+
     include Messengers::GenerateLetter
 
     def initialize(invitation:)
@@ -42,12 +44,22 @@ module Invitations
         punishable_warning: @invitation.punishable_warning,
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
-        custom_sentence: @invitation.custom_sentence
+        custom_sentence: @invitation.custom_sentence,
+        invitation_url: invitation_url,
+        qr_code: qr_code
       }
     end
 
     def organisation
       (@invitation.user.organisations & @invitation.organisations).last
+    end
+
+    def qr_code
+      RQRCode::QRCode.new(invitation_url).as_png
+    end
+
+    def invitation_url
+      "#{ENV['RDV_SOLIDARITES_URL'].gsub('https://', '')}/i/r/#{@invitation.uuid}"
     end
   end
 end

--- a/app/views/letters/_footer.html.erb
+++ b/app/views/letters/_footer.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
   <div>
-    <%= image_tag("logos/rdv-insertion.png") %>
+    <%= image_tag("logos/rdv-solidarites.png") %>
   </div>
   <% if display_department_logo %>
     <div id="department-logo">

--- a/app/views/letters/invitations/atelier.html.erb
+++ b/app/views/letters/invitations/atelier.html.erb
@@ -12,8 +12,8 @@
   <p><%= user.title.capitalize %>,</p>
   <p>Vous êtes <%= user_designation %> et bénéficiez d'un accompagnement. Pour en profiter au mieux, nous vous invitons à vous inscrire directement et librement aux ateliers et formations de votre choix.</p>
   <p>Pour faciliter votre inscription, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de vous inscrire vous-même.</span></p>
-  <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
-  <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
+  <p>Pour choisir un créneau à votre convenance, rendez-vous <span class="bold-blue">sur <u><%= invitation_url %></u></span> ou scannez le QR code ci-dessous&nbsp;:</p>
+  <div class="img-wrapper"><%= image_tag(qr_code.to_data_url) %></div>
   <%= tag.p tag.span(mandatory_warning, class: "bold-blue") if mandatory_warning %>
   <%= tag.p tag.span("En l'absence d'action de votre part, #{punishable_warning}.", class: "bold-blue") if punishable_warning.present? %>
   <%= render "letters/invitations/help_message", invitation: invitation, help_address: help_address %>

--- a/app/views/letters/invitations/atelier_enfants_ados.html.erb
+++ b/app/views/letters/invitations/atelier_enfants_ados.html.erb
@@ -9,8 +9,11 @@
   <p>Tu es <%= user.conjugate('invité') %> à participer à un atelier organisé par le département.</p>
   <p>Nous te proposons de découvrir le programme.</p>
   <p><%= sender_name.capitalize %> a mis en place <span class="bold-blue">une plateforme te permettant de t'inscrire.</span></p>
-  <p>Pour choisir ton créneau, saisis le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suis les instructions présentes à l'écran :</p>
+  <p>Pour choisir ton créneau, saisis le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV["RDV_SOLIDARITES_URL"] %>/i/r/<%= invitation.uuid %></u></span>, puis suis les instructions présentes à l'écran :</p>
   <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
+  <p>Pour choisir ton créneau, va <span class="bold-blue">sur <u><%= invitation_url %></u></span> ou scanne le QR code ci-dessous&nbsp;:</p>
+  <div class="img-wrapper"><%= image_tag(qr_code.to_data_url) %></div>
+
   <div class="letter-signature">
     <%= render "common/organisation_signature", signature_lines: signature_lines, department: department %>
   </div>

--- a/app/views/letters/invitations/short.html.erb
+++ b/app/views/letters/invitations/short.html.erb
@@ -12,8 +12,8 @@
   <p><%= user.title.capitalize %>,</p>
   <p>Vous êtes <%= user.conjugate('invité') %> pour un <%= rdv_title %>.</p>
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
-  <p>Pour choisir un créneau à votre convenance, saisissez le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
-  <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
+  <p>Pour choisir un créneau à votre convenance, rendez-vous <span class="bold-blue">sur <u><%= invitation_url %></u></span> ou scannez le QR code ci-dessous&nbsp;:</p>
+  <div class="img-wrapper"><%= image_tag(qr_code.to_data_url) %></div>
   <%= tag.p tag.span(mandatory_warning, class: "bold-blue") if mandatory_warning %>
   <%= tag.p tag.span("En l'absence d'action de votre part, #{punishable_warning}.", class: "bold-blue") if punishable_warning.present? %>
   <%= render "letters/invitations/help_message", invitation: invitation, help_address: help_address %>

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -13,8 +13,8 @@
   <p>Vous êtes <%= user_designation %> et à ce titre vous êtes <%= user.conjugate('invité') %> à participer à un <%= rdv_title %> afin de <%= rdv_purpose %>.</p>
   <%= tag.p(custom_sentence) if custom_sentence %>
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
-  <p>Pour choisir un créneau à votre convenance, saisissez dans un délai de <%= Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER %> jours à réception de ce courrier le code d’invitation ci-dessous <span class="bold-blue">sur <u><%= ENV['HOST'] %>/invitation</u></span>, puis suivez les instructions présentes à l'écran :</p>
-  <div class="invitation-token">Mon code d'invitation<br/><%= invitation.uuid %></div>
+  <p>Pour choisir un créneau à votre convenance, rendez-vous dans un délai de <%= Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER %> jours à réception de ce courrier à l'adresse <span class="bold-blue">sur <u><%= invitation_url %></u></span> ou scannez le QR code ci-dessous&nbsp;:</p>
+  <div class="img-wrapper"><%= image_tag(qr_code.to_data_url) %></div>
   <%= tag.p tag.span(mandatory_warning, class: "bold-blue") if mandatory_warning %>
   <%= tag.p tag.span("En l'absence d'action de votre part, #{punishable_warning}.", class: "bold-blue") if punishable_warning.present? %>
   <%= render "letters/invitations/help_message", invitation: invitation, help_address: help_address %>


### PR DESCRIPTION
closes #1974 

Dans cette PR, je fais en sorte de gommer toute "trace" de rdv-insertion dans les courriers pour n'afficher que Rdv Solidarites. J'ajoute également un QR code à scanner pour se rendre à l'adresse permettant de prendre rendez-vous.