### PR TITLE
feat(navigation): Add link to partner page

### DIFF
--- a/app/javascript/stylesheets/_fonts.scss
+++ b/app/javascript/stylesheets/_fonts.scss
@@ -10,7 +10,3 @@
 .bold {
   font-weight: 700;
 }
-
-.text-align-right {
-  text-align: right !important;
-}

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -25,6 +25,7 @@
 @import "./components/periodic_invites_form";
 @import "./vendor/inclusion_connect_button";
 @import "./components/rdv_insertion_instance_name";
+@import "./components/text";
 @import "./fontawesome_imports";
 @import "tippy.js/dist/tippy.css";
 

--- a/app/javascript/stylesheets/components/_text.scss
+++ b/app/javascript/stylesheets/components/_text.scss
@@ -1,0 +1,7 @@
+.text-align-right {
+  text-align: right !important;
+}
+
+.text-underline {
+  text-decoration: underline;
+}

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_user_profile_job.rb
@@ -49,11 +49,11 @@ module InboundWebhooks
       end
 
       def attach_user_to_org
-        user.organisations << organisation unless user.reload.organisation_ids.include?(organisation.id)
+        user.organisations << organisation unless user.reload.belongs_to_org?(organisation.id)
       end
 
       def remove_user_from_organisation
-        user.delete_organisation(organisation) if user.reload.organisation_ids.include?(organisation.id)
+        user.delete_organisation(organisation) if user.reload.belongs_to_org?(organisation.id)
         SoftDeleteUserJob.perform_async(rdv_solidarites_user_id) if user.reload.organisations.empty?
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,23 @@ class User < ApplicationRecord
     organisations.map(&:department_id).uniq.length > 1
   end
 
+  def belongs_to_org?(organisation_id)
+    organisation_ids.include?(organisation_id)
+  end
+
+  def partner
+    return if role.blank? || affiliation_number.blank?
+
+    User.find_by(role: opposite_role, affiliation_number:)
+  end
+
   private
+
+  def opposite_role
+    return if role.blank?
+
+    role == "demandeur" ? "conjoint" : "demandeur"
+  end
 
   def follow_up_category_handled_already?(follow_up_attributes)
     follow_up_attributes.deep_symbolize_keys[:motif_category_id]&.to_i.in?(motif_categories.map(&:id))

--- a/app/services/orientations/save.rb
+++ b/app/services/orientations/save.rb
@@ -10,7 +10,7 @@ module Orientations
         update_previous_orientation_ends_at if previous_orientation_without_end_date.present?
         fill_current_orientation_ends_at if @orientation.ends_at.nil? && posterior_orientations.any?
         validate_no_orientations_overlap
-        add_user_to_organisation if @orientation.user.organisation_ids.exclude?(@orientation.organisation_id)
+        add_user_to_organisation unless @orientation.user.belongs_to_org?(@orientation.organisation_id)
         save_record!(@orientation)
       end
     end

--- a/app/views/common/_attribute_display.html.erb
+++ b/app/views/common/_attribute_display.html.erb
@@ -39,7 +39,7 @@
   <% elsif record[attribute].in? [true, false] %>
     <p><%= display_attribute I18n.t("boolean.#{record[attribute]}") %></p>
   <% else %>
-    <p><%= display_attribute record[attribute] %></p>
+    <p class="<%= local_assigns[:html_class] %>"><%= display_attribute record[attribute] %></p>
   <% end %>
 
   <%= yield if block_given? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,7 +20,15 @@
         <%= render "common/attribute_display", record: @user, attribute: :first_name %>
         <%= render "common/attribute_display", record: @user, attribute: :last_name %>
         <%= render "common/attribute_display", record: @user, attribute: :title %>
-        <%= render "common/attribute_display", record: @user, attribute: :role %>
+        <%= render "common/attribute_display", record: @user, attribute: :role, html_class: "m-0 p-0" do %>
+          <% if @user.partner && @user.partner.belongs_to_org?(@organisation.id) %>
+            <div class="mb-3 mt-1">
+              <%= link_to structure_user_path(@user.partner.id), target: "_blank", class: "text-dark-blue text-underline small" do %>
+                <p>Voir le <%= @user.partner.role %>  <i class="fas ms-2 fa-external-link-alt"></i></p>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
         <%= render "common/attribute_display", record: @user, attribute: :affiliation_number %>
         <%= render "common/attribute_display", record: @user, attribute: :department_internal_id, tooltip: true %>
         <%= render "common/attribute_display", record: @user, attribute: :nir %>

--- a/app/views/users_organisations/index.html.erb
+++ b/app/views/users_organisations/index.html.erb
@@ -1,6 +1,6 @@
 <%= render "common/remote_modal", title: "Choisissez les organisations à assigner" do %>
   <% @organisations.each do |organisation| %>
-    <%= render "users_organisation", department: @department, organisation: organisation, user: @user, belongs_to_org: @user.organisation_ids.include?(organisation.id), removable: current_agent.organisation_ids.include?(organisation.id), organisations_count: @user.organisation_ids.length %>
+    <%= render "users_organisation", department: @department, organisation: organisation, user: @user, belongs_to_org: @user.belongs_to_org?(organisation.id), removable: current_agent.organisation_ids.include?(organisation.id), organisations_count: @user.organisation_ids.length %>
   <% end %>
 <% end %>
 

--- a/spec/features/agent_can_navigate_to_partner_page_spec.rb
+++ b/spec/features/agent_can_navigate_to_partner_page_spec.rb
@@ -1,0 +1,59 @@
+describe "Agents can navigate to partner page", :js do
+  let!(:agent) { create(:agent) }
+  let!(:organisation) { create(:organisation, agents: [agent]) }
+  let!(:user) do
+    create(
+      :user,
+      organisations: [organisation], affiliation_number: "1122233", role: "demandeur"
+    )
+  end
+
+  before { setup_agent_session(agent) }
+
+  context "when the user does not have a partner" do
+    it "does not show a link to the partner page" do
+      visit organisation_user_path(user, organisation_id: organisation.id)
+
+      expect(page).to have_content(user.affiliation_number)
+      expect(page).to have_content(user.role)
+
+      expect(page).to have_no_content("Voir le conjoint")
+    end
+  end
+
+  context "when the user has a partner" do
+    let!(:conjoint) do
+      create(:user, affiliation_number: "1122233", role: "conjoint", organisations: [organisation])
+    end
+
+    it "shows a link to the partner page" do
+      visit organisation_user_path(user, organisation_id: organisation.id)
+
+      expect(page).to have_content(user.affiliation_number)
+      expect(page).to have_content(user.role)
+
+      expect(page).to have_link("Voir le conjoint")
+      new_window = window_opened_by { click_link("Voir le conjoint") }
+      within_window new_window do
+        expect(page).to have_content(conjoint.first_name)
+        expect(page).to have_content(conjoint.last_name)
+        expect(page).to have_link("Voir le demandeur")
+      end
+    end
+
+    context "when the partner does not belong to user org" do
+      let!(:conjoint) do
+        create(:user, affiliation_number: "1122233", role: "conjoint", organisations: [create(:organisation)])
+      end
+
+      it "does not show a link to the partner page" do
+        visit organisation_user_path(user, organisation_id: organisation.id)
+
+        expect(page).to have_content(user.affiliation_number)
+        expect(page).to have_content(user.role)
+
+        expect(page).to have_no_content("Voir le conjoint")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1964 
Lorsqu'un demandeur a son conjoint géré dans l'appli (et vice versa), un lien vers la fiche du partenaire est affiché sur la page show.

### Previews 📸 

![image](https://github.com/betagouv/rdv-insertion/assets/7602809/4c930dbc-08a8-4b56-b138-ebc5485c4529)
