### PR TITLE
ux(pagination): set same margin regarless number of pages

### DIFF
--- a/app/javascript/stylesheets/components/_pagination.scss
+++ b/app/javascript/stylesheets/components/_pagination.scss
@@ -46,3 +46,8 @@
     }
   }
 }
+
+.pagination > * {
+  margin-left: 0.6rem;
+  margin-right: 0.6rem;
+}

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination justify-content-between" role="navigation" aria-label="pager">
+  <nav class="pagination justify-content-center" role="navigation" aria-label="pager">
     <%= first_page_tag %>
     <%= prev_page_tag %>
     <% each_page do |page| -%>


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/1998
On a le même espacement entre les éléments, peu importe le nombre de page... Le centrage reste dynamique.

<img width="1019" alt="Capture d’écran 2024-05-02 à 12 15 16" src="https://github.com/betagouv/rdv-insertion/assets/28594222/3899af95-acef-4eeb-8dea-abfe5777a4ee">
<img width="895" alt="Capture d’écran 2024-05-02 à 12 14 41" src="https://github.com/betagouv/rdv-insertion/assets/28594222/8d9dbc0f-77e6-4e8c-8c38-180a2336bea5">
<img width="895" alt="Capture d’écran 2024-05-02 à 12 13 33" src="https://github.com/betagouv/rdv-insertion/assets/28594222/be9cb57b-9cb5-4232-afa1-bce7cbeb81bb">
