### PR TITLE
fix(csv): Restrict csv exort informations

### DIFF
--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -56,13 +56,12 @@ module Exporters
         end
     end
 
-    def headers # rubocop:disable Metrics/AbcSize
+    def headers
       [User.human_attribute_name(:title),
        User.human_attribute_name(:last_name),
        User.human_attribute_name(:first_name),
        User.human_attribute_name(:affiliation_number),
        User.human_attribute_name(:department_internal_id),
-       User.human_attribute_name(:nir),
        User.human_attribute_name(:france_travail_id),
        User.human_attribute_name(:email),
        User.human_attribute_name(:address),
@@ -98,7 +97,6 @@ module Exporters
        user.first_name,
        user.affiliation_number,
        user.department_internal_id,
-       user.nir,
        user.france_travail_id,
        user.email,
        user.address,
@@ -124,8 +122,8 @@ module Exporters
        user.archive_for(department_id)&.archiving_reason,
        user.referents.map(&:email).join(", "),
        user.organisations.to_a.count,
-       user.organisations.map(&:name).join(", "),
-       user.tags.pluck(:value).join(", ")]
+       display_organisation_names(user.organisations),
+       scoped_user_tags(user.tags).pluck(:value).join(", ")]
     end
 
     def human_last_participation_status(user)
@@ -209,6 +207,29 @@ module Exporters
       return "" if last_rdv(user).blank?
 
       last_rdv(user).collectif? ? "collectif" : "individuel"
+    end
+
+    def display_organisation_names(organisations)
+      organisations.map do |organisation|
+        display_organisation_name(organisation)
+      end.join(", ")
+    end
+
+    def display_organisation_name(organisation)
+      if organisation.department_id == department_id
+        organisation.name
+      else
+        "#{organisation.name} (Organisation d'un autre départment : " \
+          "#{organisation.department.number} - #{organisation.department.name})"
+      end
+    end
+
+    def scoped_user_tags(tags)
+      if department_level?
+        tags.joins(:organisations).where(organisations: { id: @agent.organisation_ids, department_id: })
+      else
+        tags.joins(:organisations).where(organisations: @structure)
+      end
     end
 
     def orientation_date(user)

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -50,7 +50,6 @@ module Exporters
        User.human_attribute_name(:first_name),
        User.human_attribute_name(:affiliation_number),
        User.human_attribute_name(:department_internal_id),
-       User.human_attribute_name(:nir),
        User.human_attribute_name(:france_travail_id),
        User.human_attribute_name(:email),
        User.human_attribute_name(:address),
@@ -76,13 +75,12 @@ module Exporters
        rdv_taken_in_autonomy?(participation),
        human_status(participation),
        user.referents.map(&:email).join(", "),
-       participation.organisation.name,
+       display_organisation_name(participation.organisation),
        user.title,
        user.last_name,
        user.first_name,
        user.affiliation_number,
        user.department_internal_id,
-       user.nir,
        user.france_travail_id,
        user.email,
        user.address,
@@ -95,7 +93,7 @@ module Exporters
        participation.agent_prescripteur&.first_name,
        participation.agent_prescripteur&.last_name,
        participation.agent_prescripteur&.email,
-       user.tags.pluck(:value).join(", ")]
+       scoped_user_tags(user.tags).pluck(:value).join(", ")]
     end
 
     def resource_human_name

--- a/spec/factories/agent.rb
+++ b/spec/factories/agent.rb
@@ -3,8 +3,9 @@ FactoryBot.define do
     sequence(:email) { |n| "agent#{n}@gouv.fr" }
     sequence(:first_name) { |n| "jane#{n}" }
     sequence(:last_name) { |n| "doe#{n}" }
-    sequence(:inclusion_connect_open_id_sub) { SecureRandom.uuid }
-    sequence(:rdv_solidarites_agent_id)
+
+    rdv_solidarites_agent_id { rand(1..10_000_000_000) }
+    inclusion_connect_open_id_sub { SecureRandom.uuid }
 
     transient do
       basic_role_in_organisations { [] }

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -112,7 +112,6 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
         expect(csv).to include("Prénom")
         expect(csv).to include("Numéro CAF")
         expect(csv).to include("ID interne au département")
-        expect(csv).to include("Numéro de sécurité sociale")
         expect(csv).to include("ID France Travail")
         expect(csv).to include("ID interne au département")
         expect(csv).to include("Email")
@@ -149,7 +148,6 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
           expect(csv).to include("Jane")
           expect(csv).to include("12345") # affiliation_number
           expect(csv).to include("33333") # department_internal_id
-          expect(csv).to include(nir)
           expect(csv).to include("DDAAZZ") # france_travail_id
           expect(csv).to include("20 avenue de Ségur 75OO7 Paris")
           expect(csv).to include("jane@doe.com")
@@ -176,6 +174,11 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
 
         it "displays the referent emails" do
           expect(csv).to include("monreferent@gouv.fr")
+        end
+
+        it "does not display the user nir" do
+          expect(subject.csv).not_to include("Numéro de sécurité sociale")
+          expect(csv).not_to include(user1.nir)
         end
       end
 
@@ -206,6 +209,76 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
         it "generates headers" do
           expect(csv).to start_with("\uFEFF")
           expect(csv).not_to include("Statut de la catégorie de motifs")
+        end
+      end
+    end
+
+    context "when the user has multiple rdvs in multiple orgs" do
+      let!(:other_organisation) { create(:organisation, department:, users: [user1]) }
+      let!(:other_rdv) do
+        create(:rdv, starts_at: Time.zone.parse("2022-01-22"),
+                     created_by: "user",
+                     organisation: other_organisation)
+      end
+      let!(:other_participation) { create(:participation, rdv: other_rdv, user: user1) }
+
+      context "when the agent belongs to the other org" do
+        before do
+          agent.organisations << other_organisation
+        end
+
+        it "displays the rdv" do
+          expect(subject.csv).to include("22/01/2022")
+        end
+
+        context "when the org is in a different department" do
+          let!(:other_organisation) do
+            create(:organisation, department: other_department, name: "CD 01", users: [user1])
+          end
+          let!(:other_department) { create(:department, name: "Ain", number: "01") }
+
+          it "displays the rdv" do
+            expect(subject.csv).to include("22/01/2022")
+          end
+
+          it "precises the org is in another department" do
+            expect(subject.csv).to include("CD 01 (Organisation d'un autre départment : 01 - Ain)")
+          end
+        end
+      end
+
+      context "when the agent does not belong to the other org" do
+        it "does not display the rdv" do
+          expect(subject.csv).not_to include("22/08/2022")
+        end
+      end
+    end
+
+    context "when the user has multiple tags in different organisations" do
+      let!(:tag) { create(:tag, value: "cacahuète", users: [user1], organisations: [organisation]) }
+      let!(:other_tag) { create(:tag, value: "pistache", users: [user1], organisations: [other_organisation]) }
+      let!(:other_organisation) { create(:organisation, department:, users: [user1]) }
+
+      context "at organisation level" do
+        it "displays the user organisation tags" do
+          expect(subject.csv).to include("cacahuète")
+          expect(subject.csv).not_to include("pistache")
+        end
+      end
+
+      context "at department level" do
+        let!(:structure) { department }
+        let!(:other_organisation_with_agent) { create(:organisation, department:, users: [user1]) }
+        let!(:new_tag) do
+          create(:tag, value: "chips", users: [user1], organisations: [other_organisation_with_agent])
+        end
+
+        before { agent.organisations << other_organisation_with_agent }
+
+        it "displays the tags the agent has access to" do
+          expect(subject.csv).to include("cacahuète")
+          expect(subject.csv).not_to include("pistache")
+          expect(subject.csv).to include("chips")
         end
       end
     end


### PR DESCRIPTION
closes #1983 #1981 #1988

Je change la façon dont on gère les exports csv pour: 

* Ne plus mettre le NIR dans ces exports
* Mentionner les organisations auxquelles appartient l'usager qui ne font pas partie du département de l'export
* Ne pas renseigner que les tags que l'agent a le droit de voir