### PR TITLE
fix(webhooks): Handle deleted users webhooks

### DIFF
--- a/app/models/rdv_solidarites/rdv.rb
+++ b/app/models/rdv_solidarites/rdv.rb
@@ -13,7 +13,7 @@ module RdvSolidarites
     end
 
     def users
-      @attributes[:users].map { RdvSolidarites::User.new(_1) }
+      @attributes[:users].map { RdvSolidarites::User.new(_1) }.reject(&:deleted?)
     end
 
     def participations

--- a/app/models/rdv_solidarites/user.rb
+++ b/app/models/rdv_solidarites/user.rb
@@ -6,13 +6,8 @@ module RdvSolidarites
     ].freeze
     attr_reader(*RECORD_ATTRIBUTES)
 
-    def augmented_attributes
-      payload = rdvi_user.nil? ? ::User.new.as_json.merge(@attributes) : rdvi_user.as_json.merge(@attributes)
-      payload.except(:updated_at, :created_through, :follow_ups, :organisations, :archives)
-    end
-
-    def rdvi_user
-      @rdvi_user ||= ::User.find_by(rdv_solidarites_user_id: @id)
+    def deleted?
+      email&.end_with?("@deleted.rdv-solidarites.fr")
     end
   end
 end

--- a/app/models/rdv_solidarites/user.rb
+++ b/app/models/rdv_solidarites/user.rb
@@ -7,7 +7,7 @@ module RdvSolidarites
     attr_reader(*RECORD_ATTRIBUTES)
 
     def deleted?
-      email&.end_with?("@deleted.rdv-solidarites.fr")
+      email&.ends_with?("@deleted.rdv-solidarites.fr")
     end
   end
 end


### PR DESCRIPTION
On a eu des erreurs sentry sur des usagers ne pouvant pas être créés au process du webhook de rdv parce que leur numéro de téléphone est invalide: 
* Sentry: https://sentry.incubateur.net/organizations/betagouv/issues/92857/?project=16&query=is%3Aunresolved&referrer=issue-stream
* Sidekiq: https://www.rdv-insertion.fr/sidekiq/retries/1715058417.887419-1eed3aa36c94299da33fa7b9

En creusant il apparaît qu'il s'agit en fait d'usagers qui ont été supprimés et donc le numéro de téléphone était `[valeur anonymisé]` ce qui faisait que le job échouait.

J'ai fait un fix ici pour ne pas prendre en compte les usagers supprimés dans les webhooks de rdvs. 
Ceci dit je me demande @Holist si ce serait pas plutôt côté rdv-s où on voudrait filtrer les usagers supprimés des rdvs ?