### PR TITLE
fix(filters): alternative label colors

### DIFF
--- a/app/javascript/stylesheets/components/_form.scss
+++ b/app/javascript/stylesheets/components/_form.scss
@@ -100,3 +100,17 @@
 .small-wheel {
   font-size: 0.9em;
 }
+
+.label-alt {
+  width: calc(100% - 2px);
+  height: calc(100% - 10px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  i {
+    position: absolute;
+    right: 15px;
+    top: 5px;
+  }
+}

--- a/app/views/users/_users_list_header.html.erb
+++ b/app/views/users/_users_list_header.html.erb
@@ -6,16 +6,17 @@
           select(
             "user", "status", options_for_select_status(@statuses_count),
             { prompt: "Filtrer par statut" },
-            class: "text-white form-select js-status-selector"
+            class: "form-select js-status-selector"
           )
         %>
         <% selected_status = options_for_select_status(@statuses_count).find { |statut| statut[1] == params[:status] }%>
-        <span class="status-label-alt position-absolute bg-white pe-none">
+        <span class="label-alt status-label-alt position-absolute bg-white pe-none">
           <% if selected_status.present? %>
             Statut : <%= selected_status[0] %>
           <% else %>
             Filtrer par statut
           <% end %>
+          <i class="fas fa-angle-down"></i>
         </span>
       </div>
     <% end %>
@@ -26,16 +27,17 @@
           "referent_id",
           options_for_select_referent(@referents_list),
           { prompt: "Filtrer par référent" },
-          class: "text-white form-select js-referent-selector"
+          class: "form-select js-referent-selector"
         )
       %>
       <% selected_referent = @referents_list.find { |referent| referent.id == params[:referent_id].to_i }%>
-      <span class="referent-label-alt position-absolute bg-white pe-none">
+      <span class="label-alt referent-label-alt position-absolute bg-white pe-none">
         <% if selected_referent.present? %>
           Suivis par : <%= selected_referent %>
         <% else %>
           Filtrer par référent
         <% end %>
+        <i class="fas fa-angle-down"></i>
       </span>
     </div>
     <%= render "filter_by_creation_dates_button" if @current_category_configuration.nil? %>


### PR DESCRIPTION
Cette PR fixe un bug d'affichage des filtres sur windows. Le contenu des filtres apparaissait en blanc car windows prend visiblement en compte l'attribut color sur leur modal système 🤷‍♂️ 

Pour fixer ça de manière moins hacky, plutôt qu'un simple texte noir sur texte blanc, j'overlay carrément le select, j'enlève la couleur blanche du select, et je fais en sorte que le label custom alternatif remplisse tout l'espace en mettant du coup une arrow-down custom à droite. 
Voici le rendu sur mac chrome : 
<img width="516" alt="Screenshot 2024-05-07 at 16 06 07" src="https://github.com/betagouv/rdv-insertion/assets/4990201/2f2081a4-4c3a-4944-9916-093367c2a0b0">
<img width="495" alt="Screenshot 2024-05-07 at 16 06 02" src="https://github.com/betagouv/rdv-insertion/assets/4990201/36bc6a79-0fc0-4b01-8d47-848c50136011">


Et sur windows (mes icônes sont pétées en local car j'ai une conf chelou en mode VM mais le problème est bien corrigé) : 
<img width="355" alt="Screenshot 2024-05-07 at 16 04 53" src="https://github.com/betagouv/rdv-insertion/assets/4990201/99b9c3fe-742a-46ac-b3a6-ea8f86bef049">
<img width="298" alt="Screenshot 2024-05-07 at 16 04 50" src="https://github.com/betagouv/rdv-insertion/assets/4990201/9d02a721-82a6-4467-81ea-abf1ab4daa77">

