### PR TITLE
fix(mailers): invitation link in mailers

### DIFF
--- a/app/controllers/previews/invitations_controller.rb
+++ b/app/controllers/previews/invitations_controller.rb
@@ -108,7 +108,7 @@ module Previews
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
         custom_sentence: @invitation.custom_sentence,
-        invitation_url: @invitation.rdv_solidarites_public_url,
+        invitation_url: @invitation.short_rdv_solidarites_public_url,
         qr_code: @invitation.qr_code
       }
     end

--- a/app/controllers/previews/invitations_controller.rb
+++ b/app/controllers/previews/invitations_controller.rb
@@ -108,7 +108,7 @@ module Previews
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
         custom_sentence: @invitation.custom_sentence,
-        invitation_url: @invitation.short_rdv_solidarites_public_url,
+        invitation_url: @invitation.rdv_solidarites_public_url(with_protocol: false),
         qr_code: @invitation.qr_code
       }
     end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -78,8 +78,12 @@ class Invitation < ApplicationRecord
     Rack::Utils.parse_nested_query(uri.query)
   end
 
+  def short_rdv_solidarites_public_url
+    rdv_solidarites_public_url.gsub("https://", "").gsub("www.", "")
+  end
+
   def rdv_solidarites_public_url
-    "#{ENV['RDV_SOLIDARITES_URL'].gsub('www.', '').gsub('https://', '')}/i/r/#{uuid}"
+    "#{ENV['RDV_SOLIDARITES_URL']}/i/r/#{uuid}"
   end
 
   def qr_code

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -78,12 +78,10 @@ class Invitation < ApplicationRecord
     Rack::Utils.parse_nested_query(uri.query)
   end
 
-  def short_rdv_solidarites_public_url
-    rdv_solidarites_public_url.gsub("https://", "").gsub("www.", "")
-  end
+  def rdv_solidarites_public_url(with_protocol: true)
+    url = "#{ENV['RDV_SOLIDARITES_URL']}/i/r/#{uuid}"
 
-  def rdv_solidarites_public_url
-    "#{ENV['RDV_SOLIDARITES_URL']}/i/r/#{uuid}"
+    with_protocol ? url : url.gsub("https://", "").gsub("www.", "")
   end
 
   def qr_code

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -12,7 +12,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user.conjugate('invité')} à prendre un #{rdv_title}." \
         " Pour choisir la date du RDV, " \
         "cliquez sur ce lien: " \
-        "#{@invitation.rdv_solidarites_public_url}\n" \
+        "#{@invitation.short_rdv_solidarites_public_url}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -22,7 +22,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user_designation} et êtes #{user.conjugate('invité')} à" \
         " participer à un #{rdv_title}. Pour choisir la date du RDV, " \
         "cliquez sur ce lien dans les #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours: " \
-        "#{@invitation.rdv_solidarites_public_url}\n" \
+        "#{@invitation.short_rdv_solidarites_public_url}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -40,7 +40,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user_designation} et bénéficiez d'un accompagnement. " \
         "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
         "librement, dans la limite des places disponibles, en cliquant sur ce lien:" \
-        " #{@invitation.rdv_solidarites_public_url}\n" \
+        " #{@invitation.short_rdv_solidarites_public_url}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -50,7 +50,7 @@ module Invitations
       "#{user},\nTu es #{user.conjugate('invité')} à participer à un atelier organisé par le département. " \
         "Nous te proposons de cliquer ci-dessous pour découvrir le programme. " \
         "Si tu es #{user.conjugate('intéressé')} pour participer, tu n’auras qu’à cliquer et t’inscrire en ligne" \
-        " avec le lien suivant: #{@invitation.rdv_solidarites_public_url}\n" \
+        " avec le lien suivant: #{@invitation.short_rdv_solidarites_public_url}\n" \
         "En cas de problème, tu peux contacter le #{formatted_phone_number}."
     end
 
@@ -61,7 +61,7 @@ module Invitations
         "vous invitant à prendre un #{rdv_title}." \
         " Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{@invitation.rdv_solidarites_public_url}\n" \
+        "#{@invitation.short_rdv_solidarites_public_url}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -72,7 +72,7 @@ module Invitations
         "vous invitant à prendre RDV au créneau de votre choix afin de #{rdv_purpose}." \
         " Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{@invitation.rdv_solidarites_public_url}\n" \
+        "#{@invitation.short_rdv_solidarites_public_url}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -92,7 +92,7 @@ module Invitations
         "t'invitant à participer à un #{rdv_title}." \
         " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{@invitation.rdv_solidarites_public_url}\n" \
+        "#{@invitation.short_rdv_solidarites_public_url}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, tu peux contacter le #{formatted_phone_number}."

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -12,7 +12,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user.conjugate('invité')} à prendre un #{rdv_title}." \
         " Pour choisir la date du RDV, " \
         "cliquez sur ce lien: " \
-        "#{@invitation.short_rdv_solidarites_public_url}\n" \
+        "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -22,7 +22,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user_designation} et êtes #{user.conjugate('invité')} à" \
         " participer à un #{rdv_title}. Pour choisir la date du RDV, " \
         "cliquez sur ce lien dans les #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours: " \
-        "#{@invitation.short_rdv_solidarites_public_url}\n" \
+        "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -40,7 +40,7 @@ module Invitations
       "#{user.full_name},\nVous êtes #{user_designation} et bénéficiez d'un accompagnement. " \
         "Vous pouvez consulter le(s) atelier(s) et formation(s) proposé(s) et vous y inscrire directement et " \
         "librement, dans la limite des places disponibles, en cliquant sur ce lien:" \
-        " #{@invitation.short_rdv_solidarites_public_url}\n" \
+        " #{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -50,7 +50,7 @@ module Invitations
       "#{user},\nTu es #{user.conjugate('invité')} à participer à un atelier organisé par le département. " \
         "Nous te proposons de cliquer ci-dessous pour découvrir le programme. " \
         "Si tu es #{user.conjugate('intéressé')} pour participer, tu n’auras qu’à cliquer et t’inscrire en ligne" \
-        " avec le lien suivant: #{@invitation.short_rdv_solidarites_public_url}\n" \
+        " avec le lien suivant: #{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "En cas de problème, tu peux contacter le #{formatted_phone_number}."
     end
 
@@ -61,7 +61,7 @@ module Invitations
         "vous invitant à prendre un #{rdv_title}." \
         " Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{@invitation.short_rdv_solidarites_public_url}\n" \
+        "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -72,7 +72,7 @@ module Invitations
         "vous invitant à prendre RDV au créneau de votre choix afin de #{rdv_purpose}." \
         " Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{@invitation.short_rdv_solidarites_public_url}\n" \
+        "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, contactez le #{formatted_phone_number}."
@@ -92,7 +92,7 @@ module Invitations
         "t'invitant à participer à un #{rdv_title}." \
         " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
         "jours: " \
-        "#{@invitation.short_rdv_solidarites_public_url}\n" \
+        "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
         "En cas de problème, tu peux contacter le #{formatted_phone_number}."

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -45,7 +45,7 @@ module Invitations
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
         custom_sentence: @invitation.custom_sentence,
-        invitation_url: @invitation.rdv_solidarites_public_url,
+        invitation_url: @invitation.short_rdv_solidarites_public_url,
         qr_code: @invitation.qr_code
       }
     end

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -45,7 +45,7 @@ module Invitations
         rdv_purpose: @invitation.rdv_purpose,
         rdv_subject: @invitation.rdv_subject,
         custom_sentence: @invitation.custom_sentence,
-        invitation_url: @invitation.short_rdv_solidarites_public_url,
+        invitation_url: @invitation.rdv_solidarites_public_url(with_protocol: false),
         qr_code: @invitation.qr_code
       }
     end


### PR DESCRIPTION
dans la PR #1993, j'ai profité de l'introduction de la méthode `rdv_solidarites_public_url` pour supprimer le `RdvSolidaritesMailerHelper`. Le problème c'est que cette méthode renvoie une url sans protocole, ce qui pose souci dans les mails (le lien n'est plus généré correctement). Je transforme donc cette méthode en `short_rdv_solidarites_public_url`, et rajoute une méthode `rdv_solidarites_public_url` qui renvoie la même url avec le protocole.