### PR TITLE
fix(modals): avoid plain html tags in error modals

### DIFF
--- a/app/views/common/_error_list.html.erb
+++ b/app/views/common/_error_list.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "error_list" do  %>
   <ul>
     <% errors.each do |error| %>
-      <p>❌ <%= error %></p>
+      <p>❌ <%= raw(error) %></p>
     <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
Avec la suppression de React pour l'invitation block dans #1990, la modal d'erreur laissait apparaître des tags html provenant des messages d'erreur, au lieu de formatter le dit-message (cf capture d'écran). Ce petit fix permet de résoudre ce problème.
\
Avant
![Screenshot 2024-05-15 at 23-11-26 rdv-insertion](https://github.com/betagouv/rdv-insertion/assets/46218316/b897f5bf-cc6a-4cc5-8844-7afbd021ec38)
\
Après
![Screenshot 2024-05-15 at 23-37-21 rdv-insertion](https://github.com/betagouv/rdv-insertion/assets/46218316/05c4c86c-97bd-45c0-8d67-1aecdbc9e55f)
