### PR TITLE
feat(tech): replace reminder boolean with trigger enum - reminder, manual (default) and periodic values

### DIFF
--- a/app/jobs/send_invitation_reminder_job.rb
+++ b/app/jobs/send_invitation_reminder_job.rb
@@ -19,7 +19,7 @@ class SendInvitationReminderJob < ApplicationJob
 
   def invitation
     @invitation ||= Invitation.new(
-      reminder: true,
+      trigger: "reminder",
       user: @user,
       department: first_invitation.department,
       organisations: first_invitation.organisations,

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -39,7 +39,7 @@ class SendInvitationRemindersJob < ApplicationJob
                 .where(
                   format: %w[email sms],
                   created_at: Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.all_day,
-                  trigger: %w[manual periodic]
+                  trigger: Invitation::NOT_REMINDER_TRIGGERS
                 )
   end
 

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -38,9 +38,9 @@ class SendInvitationRemindersJob < ApplicationJob
       Invitation.where("valid_until > ?", 2.days.from_now)
                 .where(
                   format: %w[email sms],
-                  created_at: Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.all_day,
-                  trigger: Invitation::NOT_REMINDER_TRIGGERS
+                  created_at: Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.all_day
                 )
+                .not_reminder
   end
 
   def invitation_sent_3_days_ago?(invitation)

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -39,7 +39,7 @@ class SendInvitationRemindersJob < ApplicationJob
                 .where(
                   format: %w[email sms],
                   created_at: Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER.days.ago.all_day,
-                  reminder: false
+                  trigger: %w[manual periodic]
                 )
   end
 

--- a/app/jobs/send_periodic_invite_job.rb
+++ b/app/jobs/send_periodic_invite_job.rb
@@ -15,7 +15,7 @@ class SendPeriodicInviteJob < ApplicationJob
     new_invitation = @invitation.dup
 
     new_invitation.format = @format
-    new_invitation.reminder = false
+    new_invitation.trigger = "periodic"
     new_invitation.valid_until = @category_configuration.number_of_days_before_action_required.days.from_now
     new_invitation.organisations = @invitation.organisations
     new_invitation.uuid = nil

--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -53,7 +53,9 @@ module Invitable
   end
 
   def last_invitation_sent_manually
-    invitations.reject(&:reminder?).max_by(&:created_at)
+    invitations.select do |invitation|
+      invitation.trigger == "manual" || invitation.trigger == "periodic"
+    end.max_by(&:created_at)
   end
 
   def invited_before_time_window?(number_of_days_before_action_required)

--- a/app/models/concerns/invitable.rb
+++ b/app/models/concerns/invitable.rb
@@ -53,9 +53,8 @@ module Invitable
   end
 
   def last_invitation_sent_manually
-    invitations.select do |invitation|
-      invitation.trigger == "manual" || invitation.trigger == "periodic"
-    end.max_by(&:created_at)
+    invitations.reject { |invitation| invitation.trigger == "reminder" }
+               .max_by(&:created_at)
   end
 
   def invited_before_time_window?(number_of_days_before_action_required)

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -34,7 +34,7 @@ class FollowUp < ApplicationRecord
   scope :invited_before_time_window, lambda { |number_of_days_before_action_required|
     where.not(
       id: joins(:invitations).where("invitations.created_at > ?", number_of_days_before_action_required.days.ago)
-                             .where(invitations: { trigger: %w[manual periodic] })
+                             .where(invitations: { trigger: Invitation::NOT_REMINDER_TRIGGERS })
                              .pluck(:follow_up_id)
     )
   }

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -34,7 +34,7 @@ class FollowUp < ApplicationRecord
   scope :invited_before_time_window, lambda { |number_of_days_before_action_required|
     where.not(
       id: joins(:invitations).where("invitations.created_at > ?", number_of_days_before_action_required.days.ago)
-                             .where(invitations: { reminder: false })
+                             .where(invitations: { trigger: %w[manual periodic] })
                              .pluck(:follow_up_id)
     )
   }

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -34,7 +34,7 @@ class FollowUp < ApplicationRecord
   scope :invited_before_time_window, lambda { |number_of_days_before_action_required|
     where.not(
       id: joins(:invitations).where("invitations.created_at > ?", number_of_days_before_action_required.days.ago)
-                             .where(invitations: { trigger: Invitation::NOT_REMINDER_TRIGGERS })
+                             .where.not(invitations: Invitation.reminder)
                              .pluck(:follow_up_id)
     )
   }

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -24,6 +24,7 @@ class Invitation < ApplicationRecord
   delegate :model, to: :template, prefix: true
 
   enum format: { sms: "sms", email: "email", postal: "postal" }, _prefix: :format
+  enum trigger: { manual: "manual", reminder: "reminder", periodic: "periodic" }
 
   before_create :assign_uuid
   after_commit :set_follow_up_status
@@ -31,7 +32,6 @@ class Invitation < ApplicationRecord
   scope :sent_in_time_window, lambda { |number_of_days_before_action_required|
     where("created_at > ?", number_of_days_before_action_required.days.ago)
   }
-  scope :reminder, ->(reminder = true) { where(reminder: reminder) }
   scope :valid, -> { where("valid_until > ?", Time.zone.now) }
 
   def send_to_user

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,5 @@
 class Invitation < ApplicationRecord
   NUMBER_OF_DAYS_BEFORE_REMINDER = 3
-  NOT_REMINDER_TRIGGERS = %w[manual periodic].freeze
 
   include HasCurrentCategoryConfiguration
   include Templatable

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,5 +1,6 @@
 class Invitation < ApplicationRecord
   NUMBER_OF_DAYS_BEFORE_REMINDER = 3
+  NOT_REMINDER_TRIGGERS = %w[manual periodic].freeze
 
   include HasCurrentCategoryConfiguration
   include Templatable

--- a/db/migrate/20240523142208_add_trigger_to_invitations.rb
+++ b/db/migrate/20240523142208_add_trigger_to_invitations.rb
@@ -11,7 +11,7 @@ class AddTriggerToInvitations < ActiveRecord::Migration[7.1]
   def down
     add_column :invitations, :reminder, :boolean, default: false
 
-    Invitation.where(trigger: "reminder").update_all(reminder: true)
+    Invitation.reminder.update_all(reminder: true)
 
     remove_column :invitations, :trigger, :string
   end

--- a/db/migrate/20240523142208_add_trigger_to_invitations.rb
+++ b/db/migrate/20240523142208_add_trigger_to_invitations.rb
@@ -1,0 +1,18 @@
+class AddTriggerToInvitations < ActiveRecord::Migration[7.1]
+  def up
+    add_column :invitations, :trigger, :string, null: false, default: "manual"
+
+    # migrate existing invitations reminder boolean to trigger 'reminder'
+    Invitation.where(reminder: true).update_all(trigger: "reminder")
+
+    remove_column :invitations, :reminder, :boolean
+  end
+
+  def down
+    add_column :invitations, :reminder, :boolean, default: false
+
+    Invitation.where(trigger: "reminder").update_all(reminder: true)
+
+    remove_column :invitations, :trigger, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_02_092936) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_23_142208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -195,9 +195,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_02_092936) do
     t.bigint "rdv_solidarites_lieu_id"
     t.bigint "follow_up_id"
     t.datetime "valid_until"
-    t.boolean "reminder", default: false
     t.string "uuid"
     t.boolean "rdv_with_referents", default: false
+    t.string "trigger", default: "manual", null: false
     t.index ["department_id"], name: "index_invitations_on_department_id"
     t.index ["follow_up_id"], name: "index_invitations_on_follow_up_id"
     t.index ["user_id"], name: "index_invitations_on_user_id"

--- a/spec/jobs/send_invitation_reminder_job_spec.rb
+++ b/spec/jobs/send_invitation_reminder_job_spec.rb
@@ -43,7 +43,7 @@ describe SendInvitationReminderJob do
   it "instanciates an invitation with attributes from the first one" do
     expect(Invitation).to receive(:new)
       .with(
-        reminder: true,
+        trigger: "reminder",
         user: user,
         department: department,
         organisations: [organisation],

--- a/spec/jobs/send_invitation_reminders_job_spec.rb
+++ b/spec/jobs/send_invitation_reminders_job_spec.rb
@@ -89,7 +89,7 @@ describe SendInvitationRemindersJob do
         :invitation,
         user: user1, follow_up: follow_up7,
         created_at: 3.days.ago, valid_until: 4.days.from_now,
-        reminder: true
+        trigger: "reminder"
       )
     end
 

--- a/spec/jobs/send_periodic_invite_job_spec.rb
+++ b/spec/jobs/send_periodic_invite_job_spec.rb
@@ -37,7 +37,8 @@ describe SendPeriodicInviteJob do
           follow_up: invitation.follow_up,
           motif_category: invitation.motif_category,
           user: invitation.user,
-          format: "email"
+          format: "email",
+          trigger: "periodic"
         )
 
         expect(invitation.valid_until.end_of_day).to eq(

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -35,7 +35,7 @@ describe FollowUp do
       context "when the user has been last invited manually more than 3 days ago in this context" do
         let!(:invitation) { create(:invitation, follow_up: follow_up, created_at: 5.days.ago) }
         let!(:invitation2) { create(:invitation, follow_up: follow_up, created_at: 4.days.ago) }
-        let!(:invitation3) { create(:invitation, reminder: true, follow_up: follow_up, created_at: 1.day.ago) }
+        let!(:invitation3) { create(:invitation, trigger: "reminder", follow_up: follow_up, created_at: 1.day.ago) }
 
         it "retrieve the follow_up" do
           expect(subject).to include(follow_up)
@@ -287,7 +287,7 @@ describe FollowUp do
           end
 
           context "when there is a reminder" do
-            let!(:invitation3) { create(:invitation, follow_up: follow_up, reminder: true, created_at: 1.day.ago) }
+            let!(:invitation3) { create(:invitation, follow_up: follow_up, trigger: "reminder", created_at: 1.day.ago) }
 
             it "is not taken into account" do
               expect(follow_up.invited_before_time_window?(number_of_days_before_action_required)).to eq(true)

--- a/spec/services/invitations/save_and_send_spec.rb
+++ b/spec/services/invitations/save_and_send_spec.rb
@@ -38,6 +38,11 @@ describe Invitations::SaveAndSend, type: :service do
 
     it "saves an invitation" do
       expect { subject }.to change(Invitation, :count).by(1)
+      expect(Invitation.last).to have_attributes(
+        user: user,
+        format: "sms",
+        trigger: "manual"
+      )
     end
 
     it "sends the invitation" do

--- a/spec/services/invitations/send_email_spec.rb
+++ b/spec/services/invitations/send_email_spec.rb
@@ -43,7 +43,7 @@ describe Invitations::SendEmail, type: :service do
             format: "email",
             user: user,
             follow_up: build(:follow_up, motif_category: category_rsa_orientation),
-            reminder: true
+            trigger: "reminder"
           )
         end
 
@@ -113,7 +113,7 @@ describe Invitations::SendEmail, type: :service do
             :invitation,
             user: user, format: "email",
             follow_up: build(:follow_up, motif_category: category_psychologue),
-            reminder: true
+            trigger: "reminder"
           )
         end
 
@@ -153,7 +153,7 @@ describe Invitations::SendEmail, type: :service do
             :invitation,
             user: user, format: "email",
             follow_up: build(:follow_up, motif_category: category_atelier_enfants_ados),
-            reminder: true
+            trigger: "reminder"
           )
         end
 
@@ -212,7 +212,7 @@ describe Invitations::SendEmail, type: :service do
             :invitation,
             user: user, format: "email",
             follow_up: build(:follow_up, motif_category: category_rsa_orientation_on_phone_platform),
-            reminder: true
+            trigger: "reminder"
           )
         end
 

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -106,7 +106,7 @@ describe Invitations::SendSms, type: :service do
       end
 
       before do
-        invitation.update!(reminder: true, valid_until: 5.days.from_now)
+        invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
       end
 
       it "calls the send transactional service with the right content" do
@@ -188,7 +188,7 @@ describe Invitations::SendSms, type: :service do
           end
 
           before do
-            invitation.update!(reminder: true, valid_until: 5.days.from_now)
+            invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
           end
 
           it "calls the send transactional service with the right content" do
@@ -236,7 +236,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -288,7 +288,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -339,7 +339,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -390,7 +390,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -442,7 +442,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -492,7 +492,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -543,7 +543,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -593,7 +593,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -721,7 +721,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do
@@ -847,7 +847,7 @@ describe Invitations::SendSms, type: :service do
         end
 
         before do
-          invitation.update!(reminder: true, valid_until: 5.days.from_now)
+          invitation.update!(trigger: "reminder", valid_until: 5.days.from_now)
         end
 
         it "calls the send transactional service with the right content" do


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/1997

Pour le rattrapage du stock d'invitations périodiques (300 à la louche) déjà envoyées cela va être compliqué car on a que les user dans les logs mattermost.
On pourrait regarder pour chaque user les invitations envoyées vers 14h00 (heure du job d'envoi des invitations pérodiques).
Je ne sais pas ce que vous en pensez, si ca vaut le coup de s'y pencher ou pas.