### PR TITLE
ux(tags): rework of tag configuration ux and add a disclaimer

### DIFF
--- a/app/controllers/category_configurations_controller.rb
+++ b/app/controllers/category_configurations_controller.rb
@@ -18,6 +18,7 @@ class CategoryConfigurationsController < ApplicationController
 
   def index
     @available_tags = (@department || @organisation.department).tags.distinct
+    @user_count_by_tag_id = user_count_by_tag_id
   end
 
   def show; end
@@ -102,6 +103,16 @@ class CategoryConfigurationsController < ApplicationController
 
   def set_organisation
     @organisation = policy_scope(Organisation).find(params[:organisation_id])
+  end
+
+  def user_count_by_tag_id
+    User.joins(:tags,
+               :organisations)
+        .where(tags: { id: @available_tags.pluck(:id) })
+        .where(organisations: { id: @organisation.id })
+        .distinct
+        .group(:tag_id)
+        .count
   end
 
   def authorize_organisation_category_configuration

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -9,9 +9,7 @@ class TagsController < ApplicationController
 
     @organisation.tags << tag
 
-    @user_count_by_tag_id = user_count_by_tag_id
-
-    render turbo_stream: turbo_stream.append("tags", partial: "tags/tag", locals: { tag: tag })
+    redirect_to organisation_category_configurations_path(@organisation)
   end
 
   def destroy
@@ -27,16 +25,6 @@ class TagsController < ApplicationController
 
   def set_organisation
     @organisation = policy_scope(Organisation).find(params[:organisation_id])
-  end
-
-  def user_count_by_tag_id
-    User.joins(:tags,
-               :organisations)
-        .where(tags: { id: @organisation.department.tags.distinct.pluck(:id) })
-        .where(organisations: { id: @organisation.id })
-        .distinct
-        .group(:tag_id)
-        .count
   end
 
   def tag_params

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -9,6 +9,8 @@ class TagsController < ApplicationController
 
     @organisation.tags << tag
 
+    @user_count_by_tag_id = user_count_by_tag_id
+
     render turbo_stream: turbo_stream.append("tags", partial: "tags/tag", locals: { tag: tag })
   end
 
@@ -25,6 +27,16 @@ class TagsController < ApplicationController
 
   def set_organisation
     @organisation = policy_scope(Organisation).find(params[:organisation_id])
+  end
+
+  def user_count_by_tag_id
+    User.joins(:tags,
+               :organisations)
+        .where(tags: { id: @organisation.department.tags.distinct.pluck(:id) })
+        .where(organisations: { id: @organisation.id })
+        .distinct
+        .group(:tag_id)
+        .count
   end
 
   def tag_params

--- a/app/javascript/stylesheets/_text.scss
+++ b/app/javascript/stylesheets/_text.scss
@@ -9,3 +9,7 @@
 .text-underline {
   text-decoration: underline;
 }
+
+.text-large {
+  font-size: large;
+}

--- a/app/javascript/stylesheets/_variables.scss
+++ b/app/javascript/stylesheets/_variables.scss
@@ -4,7 +4,7 @@ $light-grey: #E3E4E6;
 $dark-grey: #B2ADAD;
 $dark-grey-alt: #507494;
 $alt-grey: #212529;
-$light-blue: #437FD8;
+$light-blue: #65809C;
 $orange: #EC4C4C;
 $orange-light: #ffb88e;
 $dark-blue: #083b66;

--- a/app/javascript/stylesheets/components/_card.scss
+++ b/app/javascript/stylesheets/components/_card.scss
@@ -29,10 +29,8 @@
 
 .card-organisation {
   min-height: 200px;
-  color: $light-blue;
   background-image: linear-gradient(rgba(255, 255,255, 0.4), rgba(255, 255, 255, 0.1));
   background-position: center;
-
 }
 
 .card-demo {

--- a/app/javascript/stylesheets/components/_color.scss
+++ b/app/javascript/stylesheets/components/_color.scss
@@ -22,6 +22,10 @@
   color: $purple;
 }
 
+.text-light-blue {
+  color: #65809C;
+}
+
 .link-blue-light {
   color: $light-blue-alt;
   &:hover {

--- a/app/javascript/stylesheets/components/_color.scss
+++ b/app/javascript/stylesheets/components/_color.scss
@@ -23,7 +23,7 @@
 }
 
 .text-light-blue {
-  color: #65809C;
+  color: $light-blue;
 }
 
 .link-blue-light {

--- a/app/views/category_configurations/index.html.erb
+++ b/app/views/category_configurations/index.html.erb
@@ -42,9 +42,7 @@
 
     <h6 class="px-0 mb-3">Créer un nouveau tag*</h6>
 
-    <%= turbo_frame_tag "new_tag", class: "px-0" do %>
       <%= render "tags/tag_form" %>
-    <% end %>
 
     <div class="text-light-blue px-0 mt-3 mb-2">
       <small>

--- a/app/views/category_configurations/index.html.erb
+++ b/app/views/category_configurations/index.html.erb
@@ -32,13 +32,21 @@
 
   <h4>Gestion des tags associés</h4>
   <div class="row card-white mb-4">
+    <h6 class="px-0 mb-3">Tags utilisés dans cette organisation</h6>
+
+    <div class="mb-3">
+      <%= turbo_frame_tag "tags", class: "d-flex flex-wrap px-0" do %>
+        <%= render @organisation.tags %>
+      <% end %>
+    </div>
+
     <h6 class="px-0 mb-3">Créer un nouveau tag*</h6>
 
     <%= turbo_frame_tag "new_tag", class: "px-0" do %>
       <%= render "tags/tag_form" %>
     <% end %>
 
-    <div class="text-light-blue px-0 mt-3 mb-4">
+    <div class="text-light-blue px-0 mt-3 mb-2">
       <small>
         *Ce champ est une zone de commentaires libres : veillez à utiliser des termes objectifs, pertinents, non excessifs et/ou insultants.
         <br>
@@ -49,12 +57,6 @@
         de suppression des informations qui seraient considérées comme sensibles.
       </small>
     </div>
-
-    <h6 class="px-0 mb-3">Tags utilisés dans cette organisation</h6>
-
-    <%= turbo_frame_tag "tags", class: "d-flex flex-wrap px-0" do %>
-      <%= render @organisation.tags %>
-    <% end %>
   </div>
 
   <h4>Configuration des messages</h4>

--- a/app/views/category_configurations/index.html.erb
+++ b/app/views/category_configurations/index.html.erb
@@ -32,11 +32,28 @@
 
   <h4>Gestion des tags associés</h4>
   <div class="row card-white mb-4">
-    <%= turbo_frame_tag "tags", class: "d-flex flex-wrap px-0" do %>
-      <%= render @organisation.tags %>
-    <% end %>
+    <h6 class="px-0 mb-3">Créer un nouveau tag*</h6>
+
     <%= turbo_frame_tag "new_tag", class: "px-0" do %>
       <%= render "tags/tag_form" %>
+    <% end %>
+
+    <div class="text-light-blue px-0 mt-3 mb-4">
+      <small>
+        *Ce champ est une zone de commentaires libres : veillez à utiliser des termes objectifs, pertinents, non excessifs et/ou insultants.
+        <br>
+        Conformément aux articles 9 et 10 du RGPD, les données sensibles telles que celles relatives à la santé, à la vie sexuelle des personnes,
+        <br>
+        à leur situation judiciaire (infractions, condamnations et mesures de sureté) sont proscrites. L’équipe de rdv-insertion se réserve un droit
+        <br>
+        de suppression des informations qui seraient considérées comme sensibles.
+      </small>
+    </div>
+
+    <h6 class="px-0 mb-3">Tags utilisés dans cette organisation</h6>
+
+    <%= turbo_frame_tag "tags", class: "d-flex flex-wrap px-0" do %>
+      <%= render @organisation.tags %>
     <% end %>
   </div>
 

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,17 +1,16 @@
-<%= turbo_frame_tag tag, class: "badge badge-tag w-auto d-flex justify-content-between bg-primary mb-2" do %>
+<%= turbo_frame_tag tag, class: "badge badge-tag justify-content-between background-blue-light text-dark-blue me-2 d-flex" do %>
     <%= tag.value %>
     <%=
       link_to(
         organisation_tag_path(organisation_id: @organisation.id, id: tag.id),
         data: {
+          turbo_confirm: true,
+          turbo_confirm_template: raw(render("tags/tag_remove_from_organisation_confirm", tag: tag, organisation: @organisation)),
           turbo_method: :delete,
-          turbo_confirm: "Supprimer ce tag ?",
-          turbo_confirm_text_content: "Supprimer ce tag le désaffectera également des usagers qui y sont associés, êtes-vous sur de vouloir le supprimer ?",
-          turbo_confirm_text_action: "Supprimer",
         },
-        class: 'text-white'
+        class: 'text-dark-grey-alt ms-2'
       ) do
     %>
-      <i class="fas fa-minus icon-sm"></i>
+      <i class="fas fa-times"></i>
     <% end%>
 <% end %>

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -8,7 +8,7 @@
         organisation_tag_path(organisation_id: @organisation.id, id: tag.id),
         data: {
           turbo_confirm: true,
-          turbo_confirm_template: raw(render("tags/tag_remove_from_organisation_confirm", tag: tag, organisation: @organisation)),
+          turbo_confirm_template: raw(render("tags/tag_remove_from_organisation_confirm", tag: tag, organisation: @organisation, user_count: @user_count_by_tag_id[tag.id] || 0)),
           turbo_method: :delete,
         },
         class: 'text-dark-grey-alt ms-2'

--- a/app/views/tags/_tag.html.erb
+++ b/app/views/tags/_tag.html.erb
@@ -1,5 +1,8 @@
-<%= turbo_frame_tag tag, class: "badge badge-tag justify-content-between background-blue-light text-dark-blue me-2 d-flex" do %>
+<%= turbo_frame_tag tag, class: "badge badge-tag text-truncate justify-content-between background-blue-light text-dark-blue me-2 d-flex" do %>
+  <div class="text-truncate">
     <%= tag.value %>
+  </div>
+  <div>
     <%=
       link_to(
         organisation_tag_path(organisation_id: @organisation.id, id: tag.id),
@@ -13,4 +16,5 @@
     %>
       <i class="fas fa-times"></i>
     <% end%>
+  </div>
 <% end %>

--- a/app/views/tags/_tag_form.html.erb
+++ b/app/views/tags/_tag_form.html.erb
@@ -8,6 +8,6 @@
     </div>
   </div>
   <%= button_tag type: 'submit', class: "btn btn-primary mx-2" do %>
-    Créer le tag
+    <i class="fas fa-plus"></i> Créer le tag
   <% end  %>
 <% end %>

--- a/app/views/tags/_tag_form.html.erb
+++ b/app/views/tags/_tag_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(:tag, url: organisation_tags_path, method: :post, class: "d-flex", data: { controller: :tags, action: "turbo:submit-end->tags#clear" }) do |f| %>
   <div class="autocomplete-container" data-controller="autocomplete">
     <%= f.text_field :value, class: "form-control", placeholder: "Nom du tag", autocomplete: "off" %>
-    <div class="autocomplete">
+    <div class="autocomplete d-none">
       <% @available_tags.each do |tag| %>
         <button type="button"><%= tag.value %></button>
       <% end %>

--- a/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
+++ b/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
@@ -7,7 +7,7 @@
       <%= image_tag "illustrations/error-warning-line.svg", alt: "Illustration d'un message d'avertissement", class: "mb-3" %>
       <h5 class="mt-2">Le tag sera définitivement supprimé</h5>
     </div>
-    <p>Si vous supprimez le tag <b><%= tag.value %></b> de l’organisation <b><%= organisation %></b>, celui-ci sera retiré de tous les usagers comportant ce tag dans cette organisation.</p>
+    <p>Si vous supprimez le tag <b class="text-large text-truncate d-block"><i><%= tag.value %></i></b> de l’organisation <b><%= organisation %></b>, celui-ci sera retiré de tous les usagers comportant ce tag dans cette organisation.</p>
     <ul class="mt-2">
         <% user_count = User.joins(:tags, :organisations)
                 .where(tags: { id: tag.id })
@@ -17,7 +17,7 @@
         %>
         <li><b>Nombre d'usager concernés :</b> <%= user_count %> </li>
     </ul>
-    <p>Êtes-vous sur  vouloir supprimer le tag <b><%= tag.value %></b> de l’organisation <b><%= organisation %></b> ?</p>
+    <p>Êtes-vous sur  vouloir supprimer le tag <b class="text-large text-truncate d-block"><i><%= tag.value %></i></b> de l’organisation <b><%= organisation %></b> ?</p>
   </div>
   <div class="d-flex justify-content-end align-items-center px-3">
     <button type="button" class="btn btn-blue-out border-0 me-2" data-bs-dismiss="modal">

--- a/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
+++ b/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
@@ -9,7 +9,7 @@
     </div>
     <p>Si vous supprimez le tag <b class="text-large text-truncate d-block"><i><%= tag.value %></i></b> de l’organisation <b><%= organisation %></b>, celui-ci sera retiré de tous les usagers comportant ce tag dans cette organisation.</p>
     <ul class="mt-2">
-      <li><b>Nombre d'usager concernés :</b> <%= @user_count_by_tag_id[tag.id] || 0 %></li>
+      <li><b>Nombre d'usager concernés :</b> <%= user_count %></li>
     </ul>
     <p>Êtes-vous sur  vouloir supprimer le tag <b class="text-large text-truncate d-block"><i><%= tag.value %></i></b> de l’organisation <b><%= organisation %></b> ?</p>
   </div>

--- a/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
+++ b/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
@@ -1,0 +1,31 @@
+<div class="modal-header border-0 pb-0">
+  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+</div>
+<div class="modal-body pt-0">
+  <div id="custom-body" class="w-100 mb-4">
+    <div class="w-100 text-center mb-3">
+      <%= image_tag "illustrations/error-warning-line.svg", alt: "Illustration d'un message d'avertissement", class: "mb-3" %>
+      <h5 class="mt-2">Le tag sera définitivement supprimé</h5>
+    </div>
+    <p>Si vous supprimez le tag <b><%= tag.value %></b> de l’organisation <b><%= organisation %></b>, celui-ci sera retiré de tous les usagers comportant ce tag dans cette organisation.</p>
+    <ul class="mt-2">
+        <% user_count = User.joins(:tags, :organisations)
+                .where(tags: { id: tag.id })
+                .where(organisations: { id: organisation.id })
+                .distinct
+                .count
+        %>
+        <li><b>Nombre d'usager concernés :</b> <%= user_count %> </li>
+    </ul>
+    <p>Êtes-vous sur  vouloir supprimer le tag <b><%= tag.value %></b> de l’organisation <b><%= organisation %></b> ?</p>
+  </div>
+  <div class="d-flex justify-content-end align-items-center px-3">
+    <button type="button" class="btn btn-blue-out border-0 me-2" data-bs-dismiss="modal">
+      Annuler
+    </button>
+    <button type="button" id="confirm-button" class="btn btn-danger me-2" data-bs-dismiss="modal">
+      <i class="fas fa-trash-alt me-2"></i>
+      Supprimer
+    </button>
+  </div>
+</div>

--- a/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
+++ b/app/views/tags/_tag_remove_from_organisation_confirm.html.erb
@@ -9,13 +9,7 @@
     </div>
     <p>Si vous supprimez le tag <b class="text-large text-truncate d-block"><i><%= tag.value %></i></b> de l’organisation <b><%= organisation %></b>, celui-ci sera retiré de tous les usagers comportant ce tag dans cette organisation.</p>
     <ul class="mt-2">
-        <% user_count = User.joins(:tags, :organisations)
-                .where(tags: { id: tag.id })
-                .where(organisations: { id: organisation.id })
-                .distinct
-                .count
-        %>
-        <li><b>Nombre d'usager concernés :</b> <%= user_count %> </li>
+      <li><b>Nombre d'usager concernés :</b> <%= @user_count_by_tag_id[tag.id] || 0 %></li>
     </ul>
     <p>Êtes-vous sur  vouloir supprimer le tag <b class="text-large text-truncate d-block"><i><%= tag.value %></i></b> de l’organisation <b><%= organisation %></b> ?</p>
   </div>

--- a/app/views/users/_user_tags.html.erb
+++ b/app/views/users/_user_tags.html.erb
@@ -7,17 +7,17 @@
       <% tags.each do |tag| %>
         <span class="badge badge-tag justify-content-between background-blue-light text-dark-blue me-2 d-flex">
           <%= tag.value %>
-          <%= 
+          <%=
             link_to(
               tag_assignations_path(user_id: user.id, tag_id: tag.id),
               data: {
                 turbo_confirm: "Retirer le tag de cet usager ?",
-                turbo_confirm_text_content: "Êtes-vous sûr de vouloir retirer le tag <b>#{tag.value}</b> de l'usager <b>#{user}</b> ?",
+                turbo_confirm_text_content: "Êtes-vous sûr de vouloir retirer le tag <b class='text-large text-truncate d-block'><i>#{tag.value}</i></b> de l'usager <b>#{user}</b> ?",
                 turbo_confirm_text_action: "- Retirer",
                 turbo_method: :delete,
               },
               class: 'text-dark-grey-alt ms-2'
-            ) do 
+            ) do
           %>
             <i class="fas fa-times"></i>
           <% end %>


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/2013 https://github.com/betagouv/rdv-insertion/issues/2014

Merci beaucoup à @Michaelvilleneuve pour l'ajout de la modale d'alerte qui a rendu cette PR beaucoup plus rapide à implémenter.

Voici le résultat, je me suis permis de préciser "dans cette organisation" dans le message : "celui-ci sera retiré de tous les usagers comportant ce tag dans cette organisation." car le tag peux persister dans d'autres organisations. C'est plus clair pour les admins sur de multiples organisations.

<img width="1614" alt="Capture d’écran 2024-05-24 à 16 15 29" src="https://github.com/betagouv/rdv-insertion/assets/28594222/05dc45c6-f3b2-4ec9-ac36-73f816bc7e6b">


<img width="1614" alt="Capture d’écran 2024-05-24 à 16 18 24" src="https://github.com/betagouv/rdv-insertion/assets/28594222/83f71e41-f6ed-4aa2-9e5c-90a735855ff2">
