### PR TITLE
fix(parcours): prevent showing parcours in some departments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,5 @@ MATTERMOST_MAIN_CHANNEL_URL=mattermost_main_channel_url
 # Carnet de bord
 CARNET_DE_BORD_URL=https://demo.carnetdebord.inclusion.beta.gouv.fr
 CARNET_DE_BORD_API_SECRET=secret_api_token
+
+DEPARTMENTS_WHERE_PARCOURS_DISABLED=44

--- a/app/policies/department_policy.rb
+++ b/app/policies/department_policy.rb
@@ -10,6 +10,8 @@ class DepartmentPolicy < ApplicationPolicy
   def batch_actions? = upload?
 
   def parcours?
+    return false if record.number.in?(ENV.fetch("DEPARTMENTS_WHERE_PARCOURS_DISABLED", "").split(","))
+
     pundit_user
       .organisations
       .pluck(:organisation_type)

--- a/app/policies/organisation_policy.rb
+++ b/app/policies/organisation_policy.rb
@@ -24,7 +24,8 @@ class OrganisationPolicy < ApplicationPolicy
   end
 
   def parcours?
-    upload? && record.organisation_type.in?(Organisation::ORGANISATION_TYPES_WITH_PARCOURS_ACCESS)
+    upload? && record.organisation_type.in?(Organisation::ORGANISATION_TYPES_WITH_PARCOURS_ACCESS) &&
+      !record.department.number.in?(ENV.fetch("DEPARTMENTS_WHERE_PARCOURS_DISABLED", "").split(","))
   end
 
   def configure?

--- a/spec/features/agent_can_upload_documents_for_users_spec.rb
+++ b/spec/features/agent_can_upload_documents_for_users_spec.rb
@@ -37,6 +37,19 @@ describe "Agents can upload documents for users", :js do
       end
     end
 
+    context "on a department that is not authorized to see the parcours" do
+      let!(:department) { create(:department, number: "75") }
+
+      before do
+        stub_const "ENV", ENV.to_h.merge("DEPARTMENTS_WHERE_PARCOURS_DISABLED" => "75")
+      end
+
+      it "redirects right away" do
+        visit department_user_parcours_path(user_id: user.id, department_id: department.id)
+        expect(page).to have_current_path(organisation_users_path(organisation))
+      end
+    end
+
     it "renders the page" do
       visit department_user_parcours_path(user_id: user.id, department_id: department.id)
       expect(page).to have_content("Aucun diagnostic renseigné.")
@@ -48,6 +61,19 @@ describe "Agents can upload documents for users", :js do
       let!(:organisation) do
         create(:organisation, organisation_type: "siae", name: "CD 26", agents: organisation_agents,
                               department: department)
+      end
+
+      it "cannot see the parcours tab" do
+        visit organisation_user_path(organisation_id: organisation.id, id: user.id)
+        expect(page).to have_no_content("Parcours")
+      end
+    end
+
+    context "on a department that is not authorized to see the parcours" do
+      let!(:department) { create(:department, number: "75") }
+
+      before do
+        stub_const "ENV", ENV.to_h.merge("DEPARTMENTS_WHERE_PARCOURS_DISABLED" => "75")
       end
 
       it "cannot see the parcours tab" do


### PR DESCRIPTION
Cette PR permet de ne pas afficher le parcours dans les départements qui ne le souhaitent pas.
En l'occurence pour le 44 (il restera à activer la variable d'env).

Fix https://github.com/betagouv/rdv-insertion/issues/2060