### PR TITLE
fix(super_admin): ensure template can be affected to motif_category

### DIFF
--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -21,7 +21,7 @@ class MotifCategory < ApplicationRecord
   }
 
   def selected_template_allows_mandatory_rdv_subscription
-    return unless template.model.include?("atelier") && !optional_rdv_subscription?
+    return unless template&.model&.include?("atelier") && !optional_rdv_subscription?
 
     errors.add(:base, "La participation doit être facultative pour un template de type atelier")
   end

--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -11,6 +11,7 @@ class MotifCategory < ApplicationRecord
   validates :short_name, presence: true, uniqueness: true
   validates :name, presence: true
   validates :rdv_solidarites_motif_category_id, uniqueness: true, allow_nil: true
+  validate :selected_template_allows_mandatory_rdv_subscription
 
   delegate :model, to: :template, prefix: true
   delegate :atelier?, to: :template
@@ -18,4 +19,10 @@ class MotifCategory < ApplicationRecord
   scope :optional_rdv_subscription, lambda { |optional_rdv_subscription = true|
     where(optional_rdv_subscription: optional_rdv_subscription)
   }
+
+  def selected_template_allows_mandatory_rdv_subscription
+    return unless template.model.include?("atelier") && !optional_rdv_subscription?
+
+    errors.add(:base, "La participation doit être facultative pour un template de type atelier")
+  end
 end

--- a/spec/factories/motif_category.rb
+++ b/spec/factories/motif_category.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     template
     sequence(:short_name) { |n| "rsa_orientation_#{n}" }
     name { "RSA orientation" }
+    optional_rdv_subscription { true }
   end
 end

--- a/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
+++ b/spec/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job_spec.rb
@@ -64,7 +64,7 @@ describe InboundWebhooks::RdvSolidarites::ProcessRdvJob do
 
   let!(:agent) { create(:agent) }
 
-  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation") }
+  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation", optional_rdv_subscription: false) }
   let!(:category_configuration) do
     create(:category_configuration, organisation: organisation, convene_user: false, motif_category: motif_category)
   end

--- a/spec/jobs/send_invitation_reminders_job_spec.rb
+++ b/spec/jobs/send_invitation_reminders_job_spec.rb
@@ -13,11 +13,23 @@ describe SendInvitationRemindersJob do
     end
     let!(:user6) { create(:user, email: "camille6@gouv.fr", phone_number: "0649031935") }
 
-    let!(:follow_up1) { create(:follow_up, status: "invitation_pending", user: user1) }
-    let!(:follow_up2) { create(:follow_up, status: "invitation_pending", user: user2) }
-    let!(:follow_up3) { create(:follow_up, status: "invitation_pending", user: user3) }
+    let!(:follow_up1) do
+      create(:follow_up, status: "invitation_pending", user: user1,
+                         motif_category: create(:motif_category, optional_rdv_subscription: false))
+    end
+    let!(:follow_up2) do
+      create(:follow_up, status: "invitation_pending", user: user2,
+                         motif_category: create(:motif_category, optional_rdv_subscription: false))
+    end
+    let!(:follow_up3) do
+      create(:follow_up, status: "invitation_pending", user: user3,
+                         motif_category: create(:motif_category, optional_rdv_subscription: false))
+    end
     let!(:follow_up4) { create(:follow_up, status: "rdv_pending", user: user4) }
-    let!(:follow_up5) { create(:follow_up, status: "invitation_pending", user: user5) }
+    let!(:follow_up5) do
+      create(:follow_up, status: "invitation_pending", user: user5,
+                         motif_category: create(:motif_category, optional_rdv_subscription: false))
+    end
     let!(:follow_up6) do
       create(
         :follow_up,
@@ -26,7 +38,10 @@ describe SendInvitationRemindersJob do
         user: user6
       )
     end
-    let!(:follow_up7) { create(:follow_up, status: "invitation_pending", user: user1) }
+    let!(:follow_up7) do
+      create(:follow_up, status: "invitation_pending", user: user1,
+                         motif_category: create(:motif_category, optional_rdv_subscription: false))
+    end
 
     # OK
     let!(:invitation1) do

--- a/spec/services/motif_categories/create_spec.rb
+++ b/spec/services/motif_categories/create_spec.rb
@@ -46,6 +46,23 @@ describe MotifCategories::Create do
       end
     end
 
+    context "when the motif category is for an atelier template and is not optional" do
+      let!(:template) { create(:template, model: "atelier") }
+
+      before do
+        motif_category.template = template
+        motif_category.optional_rdv_subscription = false
+      end
+
+      it "is a failure" do
+        is_a_failure
+      end
+
+      it "stores the error" do
+        expect(subject.errors[0]).to include("facultative")
+      end
+    end
+
     context "when the motif category creation fails" do
       before do
         allow(RdvSolidaritesApi::CreateMotifCategory).to receive(:call)


### PR DESCRIPTION
Cette PR permet d'éviter la création de motif category avec participation obligatoire pour des template de type atelier. 

Fix https://github.com/betagouv/rdv-insertion/issues/2006