### PR TITLE
fix(template): model validation flaws

### DIFF
--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -21,8 +21,13 @@ class MotifCategory < ApplicationRecord
   }
 
   def selected_template_allows_mandatory_rdv_subscription
-    return unless template&.model&.include?("atelier") && !optional_rdv_subscription?
+    return if
+      optional_rdv_subscription? ||
+      Rails
+      .root
+      .join("app", "views", "mailers", "invitation_mailer", "#{template.model}_invitation_reminder.html.erb")
+      .exist?
 
-    errors.add(:base, "La participation doit être facultative pour un template de type atelier")
+    errors.add(:base, "Ce modèle de RDV n'est pas compatible avec un suivi obligatoire (email de rappel non configuré)")
   end
 end

--- a/app/models/motif_category.rb
+++ b/app/models/motif_category.rb
@@ -25,7 +25,7 @@ class MotifCategory < ApplicationRecord
       optional_rdv_subscription? ||
       Rails
       .root
-      .join("app", "views", "mailers", "invitation_mailer", "#{template.model}_invitation_reminder.html.erb")
+      .join("app", "views", "mailers", "invitation_mailer", "#{template&.model}_invitation_reminder.html.erb")
       .exist?
 
     errors.add(:base, "Ce modèle de RDV n'est pas compatible avec un suivi obligatoire (email de rappel non configuré)")

--- a/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
@@ -129,7 +129,6 @@ describe "Super admin can manage motif categories" do
         click_button("Enregistrer")
 
         expect(stub_create_motif_category).not_to have_been_requested
-        expect(page).to have_content("1 erreur ont empêché Catégorie de motifs d'être sauvegardé(e)")
         expect(page).to have_content("Template doit exister")
       end
     end

--- a/spec/services/motif_categories/create_spec.rb
+++ b/spec/services/motif_categories/create_spec.rb
@@ -46,7 +46,7 @@ describe MotifCategories::Create do
       end
     end
 
-    context "when the motif category is for an atelier template and is not optional" do
+    context "when the template model does not support reminders and subscription is mandatory" do
       let!(:template) { create(:template, model: "atelier") }
 
       before do
@@ -59,7 +59,20 @@ describe MotifCategories::Create do
       end
 
       it "stores the error" do
-        expect(subject.errors[0]).to include("facultative")
+        expect(subject.errors[0]).to include("compatible")
+      end
+    end
+
+    context "when the template model supports reminders and subscription is mandatory" do
+      let!(:template) { create(:template, model: "atelier_enfants_ados") }
+
+      before do
+        motif_category.template = template
+        motif_category.optional_rdv_subscription = false
+      end
+
+      it "is a success" do
+        is_a_success
       end
     end
 


### PR DESCRIPTION
Cette PR permet de vérifier la présence du template de reminder plutôt qu'une validation sur le type de model. 