### PR TITLE
fix(model): nullify agent orientations

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -7,7 +7,7 @@ class Agent < ApplicationRecord
   has_many :agent_roles, dependent: :destroy
   has_many :referent_assignations, dependent: :destroy
   has_many :agents_rdvs, dependent: :destroy
-  has_many :orientations, dependent: :restrict_with_error
+  has_many :orientations, dependent: :nullify
   has_many :csv_exports, dependent: :destroy
 
   has_many :organisations, through: :agent_roles


### PR DESCRIPTION
closes #2087 

Les agents ne pouvaient pas être supprimés s'ils avaient une orientation. A la place, on nullifie la relation pour permettre le destroy.