### PR TITLE
fix(:stats): fix stats when not logged in

### DIFF
--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -39,7 +39,9 @@ module CurrentStructure
     @current_structure ||=
       department_level? ? Department.find(current_department_id) : Organisation.find(current_organisation_id)
 
-    authorize @current_structure, :access? if current_agent
+    return @current_structure unless current_agent
+
+    authorize @current_structure, :access?
   end
 
   def current_department


### PR DESCRIPTION
Après les changements récents, il y avait un souci sur l'écriture du conditionnel de l'auhtorization sur `current_structure` qui empêchait l'affichage des pages stats par orga ou département quand le visiteur n'était pas loggé. Cette PR résout ce problème.