### PR TITLE
feat(user): selecting org based on address

### DIFF
--- a/app/javascript/controllers/new_user_form_controller.js
+++ b/app/javascript/controllers/new_user_form_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus";
+import retrieveRelevantOrganisation from "../lib/retrieveRelevantOrganisation";
+
+export default class extends Controller {
+  async submit(event) {
+    event.preventDefault();
+    const organisation = await retrieveRelevantOrganisation(
+      this.element.dataset.departmentNumber,
+      null,
+      this.element.querySelector("#user_address").value,
+    )
+    
+    if (organisation?.id) {
+      this.element.querySelector("#user_organisation_ids").value = organisation.id;
+      this.element.submit();
+    }
+  }
+}

--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -11,6 +11,7 @@
   </div>
   <div class="mb-4">
     <div class="row d-flex justify-content-start flex-wrap">
+      <%= f.hidden_field :organisation_ids if !@user.persisted? && department_level? %>
       <%= render "common/attribute_input", f:f, attribute: :first_name, mandatory: true %>
       <%= render "common/attribute_input", f:f, attribute: :last_name, mandatory: true %>
       <%= render "common/attribute_input", f:f, attribute: :title, mandatory: true, as: :select, collection: ["monsieur", "madame"] %>
@@ -24,9 +25,6 @@
       <%= render "common/attribute_input", f:f, attribute: :address %>
       <%= render "common/attribute_input", f:f, attribute: :phone_number %>
       <%= render "common/attribute_input", f:f, attribute: :rights_opening_date, as: :date, start_year: Date.today.year - 10 %>
-      <% if department_level? && !@user.persisted? %>
-        <%= render "common/attribute_input", f:f, attribute: :organisation_ids, as: :select, collection: current_agent_department_organisations.map { |o| [o.name, o.id] }, mandatory: true %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,16 @@
 <% content_for :title, "Créer un usager - #{current_structure.name} - rdv-insertion" %>
 
-<%= form_for(@user, url: structure_users_path, method: :post) do |f| %>
+<%= 
+  form_for(
+    @user, 
+    url: structure_users_path, 
+    method: :post, 
+    data: department_level? ? { 
+      controller: "new-user-form", 
+      action: "submit->new-user-form#submit",
+      department_number: current_department.number
+    } : {}
+  ) do |f| %>
   <%= render "user_form", f: f, return_path: structure_users_path %>
 <% end %>
 

--- a/spec/features/agent_can_create_user_through_form_spec.rb
+++ b/spec/features/agent_can_create_user_through_form_spec.rb
@@ -1,5 +1,5 @@
 describe "Agents can create user through form", :js do
-  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:agent) { create(:agent, organisations: [organisation, organisation2]) }
   let!(:department) { create(:department) }
   let!(:organisation) do
     create(
@@ -10,10 +10,20 @@ describe "Agents can create user through form", :js do
     )
   end
 
+  let!(:organisation2) do
+    create(
+      :organisation,
+      department: department,
+      rdv_solidarites_organisation_id: rdv_solidarites_organisation_id2,
+      category_configurations: [category_configuration]
+    )
+  end
+
   let!(:category_configuration) { create(:category_configuration) }
 
   let!(:rdv_solidarites_user_id) { 2323 }
   let!(:rdv_solidarites_organisation_id) { 3234 }
+  let!(:rdv_solidarites_organisation_id2) { 3233 }
 
   describe "#create" do
     before do
@@ -56,11 +66,12 @@ describe "Agents can create user through form", :js do
           click_button("Enregistrer")
 
           expect(page).to have_content("Veuillez choisir une organisation")
+          find("select.swal2-select").select(organisation2.name)
           click_button("Sélectionner")
 
           expect(page).to have_content("Informations")
           expect(page).to have_content("Bob")
-          expect(page).to have_content(organisation.name)
+          expect(page).to have_content(organisation2.name)
         end
       end
 

--- a/spec/features/agent_can_create_user_through_form_spec.rb
+++ b/spec/features/agent_can_create_user_through_form_spec.rb
@@ -69,7 +69,9 @@ describe "Agents can create user through form", :js do
         let!(:city_code) { "26323" }
         let!(:street_ban_id) { "26444" }
         let!(:rdv_solidarites_id) { 999 }
-        let!(:rdv_solidarites_organisation) { RdvSolidarites::Organisation.new(id: organisation.rdv_solidarites_organisation_id) }
+        let!(:rdv_solidarites_organisation) do
+          RdvSolidarites::Organisation.new(id: organisation.rdv_solidarites_organisation_id)
+        end
 
         it "creates user directly" do
           expect(RetrieveGeolocalisation).to receive(:call)

--- a/spec/features/agent_can_create_user_through_form_spec.rb
+++ b/spec/features/agent_can_create_user_through_form_spec.rb
@@ -44,6 +44,58 @@ describe "Agents can create user through form", :js do
       expect(page).to have_content("bob@kelso.com")
     end
 
+    context "from department page" do
+      context "no organisation found for this address" do
+        it "asks to choose organisation" do
+          visit new_department_user_path(organisation.department.id)
+
+          page.fill_in "user_first_name", with: "Bob"
+          page.fill_in "user_last_name", with: "Kelso"
+          page.fill_in "user_email", with: "bob@kelso.com"
+
+          click_button("Enregistrer")
+
+          expect(page).to have_content("Veuillez choisir une organisation")
+          click_button("Sélectionner")
+
+          expect(page).to have_content("Informations")
+          expect(page).to have_content("Bob")
+          expect(page).to have_content(organisation.name)
+        end
+      end
+
+      context "an organisation has been found for this address" do
+        let!(:address) { "20 avenue de la résistance 26150 Die" }
+        let!(:city_code) { "26323" }
+        let!(:street_ban_id) { "26444" }
+        let!(:rdv_solidarites_id) { 999 }
+        let!(:rdv_solidarites_organisation) { RdvSolidarites::Organisation.new(id: organisation.rdv_solidarites_organisation_id) }
+
+        it "creates user directly" do
+          expect(RetrieveGeolocalisation).to receive(:call)
+            .with(address:, department_number: organisation.department.number)
+            .once
+            .and_return(OpenStruct.new(success?: true, city_code:, street_ban_id:))
+
+          expect(RdvSolidaritesApi::RetrieveOrganisations).to receive(:call)
+            .once
+            .and_return(OpenStruct.new(success?: true, organisations: [rdv_solidarites_organisation]))
+
+          visit new_department_user_path(organisation.department.id)
+
+          page.fill_in "user_first_name", with: "Bob"
+          page.fill_in "user_last_name", with: "Kelso"
+          page.fill_in "user_email", with: "bob@kelso.com"
+          page.fill_in "user_address", with: address
+
+          click_button("Enregistrer")
+          expect(page).to have_content("Informations")
+          expect(page).to have_content("Bob")
+          expect(page).to have_content(organisation.name)
+        end
+      end
+    end
+
     context "when data is missing" do
       context "when a required attribute is missing" do
         it "returns an error" do


### PR DESCRIPTION
Lors de la création d'un usager au niveau du département, nous sélectionnons désormais l'organisation en fonction de l'adresse entrée par l'usager. 
Si aucune organisation n'est trouvée, on lève une modale pour choisir l'organisation. 

La majorité de ce workflow est récupérée de la page upload où nous avons déjà un comportement similaire. 

<img width="1395" alt="image" src="https://github.com/betagouv/rdv-insertion/assets/4990201/694361c2-f325-478f-87f1-529602c6e8f8">



Fix https://github.com/betagouv/rdv-insertion/issues/2067