### PR TITLE
fix(index): fix display current rdv date

### DIFF
--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -70,6 +70,7 @@ class FollowUp < ApplicationRecord
   end
 
   def current_pending_rdv
-    participations.select(&:pending?).min_by(&:starts_at)
+    # if rdv is the same day, it is not in the future therefore not considered "pending", but the follow-up is still
+    participations.select(&:pending?).min_by(&:starts_at) || participations.select(&:unknown?).min_by(&:starts_at)
   end
 end

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -71,6 +71,6 @@ class FollowUp < ApplicationRecord
 
   def current_pending_rdv
     # if rdv is the same day, it is not in the future therefore not considered "pending", but the follow-up is still
-    participations.select(&:pending?).min_by(&:starts_at) || participations.select(&:unknown?).min_by(&:starts_at)
+    participations.select(&:pending?).min_by(&:starts_at) || participations.select(&:unknown?).max_by(&:starts_at)
   end
 end

--- a/app/views/follow_ups/_follow_up_status_cell.html.erb
+++ b/app/views/follow_ups/_follow_up_status_cell.html.erb
@@ -1,7 +1,10 @@
 <td
   id="follow-up-status-<%= follow_up.id %>"
-  class="<%= background_class_for_follow_up_status(follow_up, category_configuration&.number_of_days_before_action_required) %>"
+  class="<%= background_class_for_follow_up_status(follow_up, number_of_days_before_action_required) %>"
   data-link-path="<%= structure_user_follow_ups_path(follow_up.user_id) %>"
 >
-  <%= display_follow_up_status(follow_up, category_configuration&.number_of_days_before_action_required) %>
+  <%= display_follow_up_status(follow_up, number_of_days_before_action_required) %>
+  <% if follow_up.rdv_pending? && follow_up.current_pending_rdv.present? %>
+    <span class="text-darker-grey"><em><%= " (le #{format_date(follow_up.current_pending_rdv.starts_at)})" %></em></span>
+  <% end %>
 </td>

--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -32,7 +32,7 @@
         <% else %>
           <% @all_configurations.each do |category_configuration| %>
             <% if follow_up = user.follow_up_for(category_configuration.motif_category) %>
-              <%= render "follow_ups/follow_up_status_cell", follow_up: follow_up, category_configuration: %>
+              <%= render "follow_ups/follow_up_status_cell", follow_up:, number_of_days_before_action_required: category_configuration&.number_of_days_before_action_required %>
             <% else %>
               <td id=<%= dom_id(category_configuration.motif_category, "user_#{user.id}") %>>
                 <%= render "follow_ups/new_button", user:, category_configuration:, organisation: @organisation, department: @department, button_text: "Ajouter" %>

--- a/app/views/users/_users_table_for_motif_category.html.erb
+++ b/app/views/users/_users_table_for_motif_category.html.erb
@@ -62,12 +62,7 @@
             <td><%= display_attribute format_date(follow_up.last_convocation_created_at) %></td>
           <% end %>
         <% end %>
-        <td data-link-path="<%= structure_user_follow_ups_path(follow_up.user_id) %>" id="follow-up-status-<%= follow_up.id %>" class="<%= background_class_for_follow_up_status(follow_up, @current_category_configuration.number_of_days_before_action_required) %>">
-          <%= display_follow_up_status(follow_up, @current_category_configuration.number_of_days_before_action_required) %>
-          <% if follow_up.rdv_pending? && follow_up.current_pending_rdv.present? %>
-            <span class="text-darker-grey"><em><%= " (le #{format_date(follow_up.current_pending_rdv.starts_at)})" %></em></span>
-          <% end %>
-        </td>
+        <%= render "follow_ups/follow_up_status_cell", follow_up:, number_of_days_before_action_required: @current_category_configuration.number_of_days_before_action_required %>
         <td class="padding-left-15">
           <%= link_to structure_user_path(user.id) do %>
             <button class="btn btn-blue">Gérer</button>

--- a/spec/features/agent_can_see_curent_pending_rdv_date_on_users_index_spec.rb
+++ b/spec/features/agent_can_see_curent_pending_rdv_date_on_users_index_spec.rb
@@ -1,0 +1,63 @@
+describe "Agent can see current pending rdv date on users index", :js do
+  let!(:department) { create(:department) }
+  let!(:organisation) { create(:organisation, department:) }
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:user) { create(:user, organisations: [organisation]) }
+  let!(:motif_category) { create(:motif_category) }
+  let!(:category_configuration) do
+    create(:category_configuration, organisation: organisation, motif_category: motif_category)
+  end
+  let!(:motif) { create(:motif, organisation:, motif_category:) }
+  let!(:follow_up) { create(:follow_up, user:, motif_category:, status: "rdv_pending") }
+  let!(:rdv) { create(:rdv, organisation: organisation, motif: motif, starts_at: 2.days.from_now) }
+  let!(:participation) { create(:participation, follow_up:, user:, rdv:, status: "unknown") }
+
+  before do
+    setup_agent_session(agent)
+    visit organisation_users_path(organisation)
+  end
+
+  context "when the user has a pending rdv" do
+    context "on the all users tab" do
+      it "displays the current pending rdv date" do
+        expect(page).to have_current_path(organisation_users_path(organisation))
+
+        within("td#follow-up-status-#{follow_up.id}") do
+          expect(page).to have_content(rdv.starts_at.strftime("RDV à venir (le %d/%m/%Y)"))
+        end
+      end
+    end
+
+    context "on the motif category tab" do
+      before do
+        visit organisation_users_path(organisation, motif_category_id: motif_category.id)
+      end
+
+      it "displays the current pending rdv date" do
+        expect(page).to have_current_path(organisation_users_path(organisation, motif_category_id: motif_category.id))
+
+        within("td#follow-up-status-#{follow_up.id}") do
+          expect(page).to have_content(rdv.starts_at.strftime("RDV à venir (le %d/%m/%Y)"))
+        end
+      end
+    end
+  end
+
+  context "when the rdv is today but in the past" do
+    let!(:rdv) do
+      create(:rdv, organisation: organisation, motif: motif, starts_at: Time.zone.parse("2024-06-01 10:30"))
+    end
+
+    before do
+      travel_to(Time.zone.parse("2024-06-01 12:30"))
+    end
+
+    it "displays the current pending rdv date" do
+      expect(page).to have_current_path(organisation_users_path(organisation))
+
+      within("td#follow-up-status-#{follow_up.id}") do
+        expect(page).to have_content(rdv.starts_at.strftime("RDV à venir (le %d/%m/%Y)"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #2074 

Dans notre app, il peut exister un décalage entre le statut d'un `follow_up` et l'état d'un `rdv` : le jour de la tenue du `rdv`, le `follow_up` gardera la statut `rdv_pending` jusqu'à ce que [ce CRON](https://github.com/betagouv/rdv-insertion/blob/staging/app/jobs/refresh_out_of_date_follow_up_statuses_job.rb) tourne - il tourne tous les soirs à 21. Je fais en sorte que la date de ce `RDV à venir` continue à s'afficher à côté du statut sur les listes de l'index dans ce cas là.

N.B. : 
- sur la page upload le problème ne se posait pas car la comparaison du rdv dans le futur se fait sur la date générée par `todaysDateString`, qui correspond au début de la journée. Tous les rdvs du jour même sont donc bien considérés comme étant dans le futur - pas besoin de fix
- Le display de la date du `RDV à venir` n'était pas effectif sur la page `Tous les contacts`. J'ai fait une petite refacto pour que ce soit le cas.