### PR TITLE
fix(invitations): Reset loading button in show page

### DIFF
--- a/app/controllers/concerns/turbo_stream_concern.rb
+++ b/app/controllers/concerns/turbo_stream_concern.rb
@@ -28,7 +28,8 @@ module TurboStreamConcern
 
   def turbo_stream_display_error_modal(errors)
     render(
-      turbo_stream: turbo_stream.replace("remote_modal", partial: "common/error_modal", locals: { errors: })
+      turbo_stream: turbo_stream.replace("remote_modal", partial: "common/error_modal", locals: { errors: }),
+      status: :unprocessable_entity
     )
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -62,8 +62,9 @@ class InvitationsController < ApplicationController
   def set_organisations
     @organisations =
       policy_scope(Organisation)
-      .includes(:motif_categories, :department, :messages_configuration)
+      .preload(:motif_categories, :department, :messages_configuration)
       .where(department_level? ? { department_id: params[:department_id] } : { id: params[:organisation_id] })
+      .joins(:motif_categories).where(motif_categories: { id: invitation_params.dig(:motif_category, :id) })
   end
 
   def set_user

--- a/app/javascript/controllers/invitation_button_controller.js
+++ b/app/javascript/controllers/invitation_button_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
   }
 
   disconnect() {
-    this.element.removeEventListener("turbo:submit-end", this.handleSubmitEnd.bind(this))
+    this.element.removeEventListener("turbo:submit-end", this.handleSubmitEnd.bind(this));
   }
 
   displayButtonAsLoading() {

--- a/app/javascript/controllers/remote_modal_controller.js
+++ b/app/javascript/controllers/remote_modal_controller.js
@@ -20,8 +20,12 @@ export default class extends Controller {
   }
 
   submitEnd(e) {
-    if (e.detail.success) {
-      this.modal.hide();
-    }
+    if (!e.detail.success && this.displayErrorsInsideModal()) return;
+
+    this.modal.hide();
+  }
+
+  displayErrorsInsideModal() {
+    return !!this.element.querySelector("#error_list");
   }
 }

--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -15,7 +15,6 @@ class InviteUser < BaseService
     set_invitation_organisations
     set_invitation
     result.invitation = @invitation
-    check_if_invitation_should_be_sent!
     save_and_send_invitation!
   end
 
@@ -47,16 +46,6 @@ class InviteUser < BaseService
       else
         @organisations
       end
-  end
-
-  def check_if_invitation_should_be_sent!
-    return unless invitation_already_sent_today? && !@invitation.format_postal?
-
-    fail!("Une invitation #{@invitation.format} a déjà été envoyée aujourd'hui à cet usager")
-  end
-
-  def invitation_already_sent_today?
-    @follow_up.invitations.where(format: @invitation.format).where("created_at > ?", 24.hours.ago).present?
   end
 
   def find_or_create_follow_up

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -4,7 +4,9 @@ describe InvitationsController do
     let!(:organisation_id) { "22232" }
     let!(:department) { create(:department) }
     let!(:organisation) { create(:organisation, id: organisation_id, department: department) }
+    let!(:category_configuration) { create(:category_configuration, organisation:, motif_category:) }
     let!(:other_org) { create(:organisation, department: department) }
+    let!(:other_category_configuration) { create(:category_configuration, organisation: other_org, motif_category:) }
 
     let!(:organisations) { Organisation.where(id: organisation.id) }
     let!(:agent) { create(:agent, organisations: organisations) }
@@ -74,6 +76,19 @@ describe InvitationsController do
         expect(InviteUser).to receive(:call)
           .with(user:, organisations:, invitation_attributes:, motif_category_attributes:)
         post :create, params: create_params
+      end
+
+      context "when an org does not have a configuration for this category" do
+        let!(:other_category_configuration) do
+          create(:category_configuration, organisation: other_org, motif_category: create(:motif_category))
+        end
+        let!(:organisations) { Organisation.where(id: [organisation.id]) }
+
+        it "calls the service with only the orgs handling the category" do
+          expect(InviteUser).to receive(:call)
+            .with(user:, organisations:, invitation_attributes:, motif_category_attributes:)
+          post :create, params: create_params
+        end
       end
     end
 

--- a/spec/services/invite_user_spec.rb
+++ b/spec/services/invite_user_spec.rb
@@ -165,36 +165,6 @@ describe InviteUser, type: :service do
           end
         end
       end
-
-      context "when there is already a sent invitation today" do
-        let!(:existing_invitation) { create(:invitation, format: "sms", created_at: 4.hours.ago, follow_up:) }
-
-        it "is a failure" do
-          is_a_failure
-        end
-
-        it "does not call the save and send service" do
-          expect(Invitations::SaveAndSend).not_to receive(:call)
-          subject
-        end
-
-        it "stores the error" do
-          expect(subject.errors).to eq(["Une invitation sms a déjà été envoyée aujourd'hui à cet usager"])
-        end
-
-        context "when the format is postal" do
-          let!(:existing_invitation) { create(:invitation, format: "postal", created_at: 4.hours.ago, follow_up:) }
-
-          it "is a success" do
-            is_a_success
-          end
-
-          it "still sends the invitation" do
-            expect(Invitations::SaveAndSend).to receive(:call)
-            subject
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Ici je fixe un changement introduit dans #2039 qui faisait que sur la page show, lorsque l'invitation d'un usager échouait, le bouton restait dans son loading state.

J'en profite pour: 

* Lier les invitations au niveau du département aux seules organisations qui gèrent la catégorie dans laquelle on invite (ce n'était pas le cas)
* déplacer la validation des invitations envoyées il y a - de 24h dans le service `Invitations::Validate` 