### PR TITLE
fix(stats): fix stats display

### DIFF
--- a/app/controllers/concerns/current_structure.rb
+++ b/app/controllers/concerns/current_structure.rb
@@ -39,8 +39,6 @@ module CurrentStructure
     @current_structure ||=
       department_level? ? Department.find(current_department_id) : Organisation.find(current_organisation_id)
 
-    return @current_structure unless current_agent
-
     authorize @current_structure, :access?
   end
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,9 +1,10 @@
 class StatsController < ApplicationController
   skip_before_action :authenticate_agent!, only: [:index, :show, :deployment_map]
   before_action :set_organisation, :set_department, :set_stat, only: [:show]
+  before_action :set_departments, only: [:index, :show]
 
   def index
-    @department_count = Department.displayed_in_stats.count
+    @department_count = @departments.count
     @stat = Stat.find_by(statable_type: "Department", statable_id: nil)
   end
 
@@ -13,6 +14,10 @@ class StatsController < ApplicationController
 
   private
 
+  def set_departments
+    @departments = Department.displayed_in_stats.order(:number)
+  end
+
   def set_organisation
     @organisation = Organisation.find(params[:organisation_id]) if params[:organisation_id]
   end
@@ -21,7 +26,9 @@ class StatsController < ApplicationController
     @department = @organisation&.department || Department.find(params[:department_id])
   end
 
+  def structure = @organisation || @department
+
   def set_stat
-    @stat = Stat.find_by(statable: current_structure)
+    @stat = structure.stat
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -1,9 +1,7 @@
 module StatsHelper
-  def options_for_department_select
-    Department.displayed_in_stats
-              .order(:number)
-              .map { |d| ["#{d.number} - #{d.name}", d.id] }
-              .unshift(["Tous les départements", "0"])
+  def options_for_department_select(departments)
+    departments.map { |d| ["#{d.number} - #{d.name}", d.id] }
+               .unshift(["Tous les départements", "0"])
   end
 
   def options_for_organisation_select(department)
@@ -14,5 +12,9 @@ module StatsHelper
 
   def exclude_current_month(stat)
     stat&.delete_if { |key, _value| key == Time.zone.now.strftime("%m/%Y") }
+  end
+
+  def structure_name_and_department_number(organisation, departement)
+    "#{(organisation || department).name} (#{departement.number})"
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -13,8 +13,4 @@ module StatsHelper
   def exclude_current_month(stat)
     stat&.delete_if { |key, _value| key == Time.zone.now.strftime("%m/%Y") }
   end
-
-  def structure_name_and_department_number(organisation, departement)
-    "#{(organisation || department).name} (#{departement.number})"
-  end
 end

--- a/app/views/stats/_header.html.erb
+++ b/app/views/stats/_header.html.erb
@@ -16,7 +16,7 @@
     <div>
       <%=
         select(
-          "department", "id", options_for_department_select,
+          "department", "id", options_for_department_select(@departments),
           { },
           class: "text-center form-select js-department-selector"
         )

--- a/app/views/stats/show.html.erb
+++ b/app/views/stats/show.html.erb
@@ -1,3 +1,3 @@
-<% content_for :title, "Statistiques - #{current_structure.name} (#{current_structure.try(:number) || current_structure.department_number}) - rdv-insertion" %>
+<% content_for :title, "Statistiques - #{@stat.statable.name} (#{@department.number}) - rdv-insertion" %>
 
 <%= render "stats" %>


### PR DESCRIPTION
Lorsque l'on est connecté on ne peut pas afficher les stats d'un département auquel on appartient pas ce qui n'est pas logique, j'essaie de réparer ça ici en enlevant la logique de `current_structure` de la page stat où on en a pas forcément besoin. Ça permet de ne pas avoir ce genre d'incohérence en gardant toujours la logique d'autorisations dans notre concern et donc de l'utiliser que pour un usager connecté. 

On a également [des erreurs 500](https://sentry.incubateur.net/organizations/betagouv/issues/104334/) signalées sur sentry à l'affichage des stats, je n'ai pas réussi à identifier le problème mais cette PR devrait le régler cependant.

**Annexe**: j'en profite pour déplacer une requête qui se trouver dans le helper dans le controller.

