### PR TITLE
fix(users): fix action required filter

### DIFF
--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -34,7 +34,7 @@ class FollowUp < ApplicationRecord
   scope :invited_before_time_window, lambda { |number_of_days_before_action_required|
     where.not(
       id: joins(:invitations).where("invitations.created_at > ?", number_of_days_before_action_required.days.ago)
-                             .where.not(invitations: Invitation.reminder)
+                             .where(invitations: { trigger: "manual" })
                              .pluck(:follow_up_id)
     )
   }

--- a/db/migrate/20240611225639_add_index_to_triggers.rb
+++ b/db/migrate/20240611225639_add_index_to_triggers.rb
@@ -1,0 +1,5 @@
+class AddIndexToTriggers < ActiveRecord::Migration[7.1]
+  def change
+    add_index :invitations, :trigger
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_23_142208) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_11_225639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -200,6 +200,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_23_142208) do
     t.string "trigger", default: "manual", null: false
     t.index ["department_id"], name: "index_invitations_on_department_id"
     t.index ["follow_up_id"], name: "index_invitations_on_follow_up_id"
+    t.index ["trigger"], name: "index_invitations_on_trigger"
     t.index ["user_id"], name: "index_invitations_on_user_id"
     t.index ["uuid"], name: "index_invitations_on_uuid", unique: true
   end


### PR DESCRIPTION
Le filtre "intervention nécessaire" ne fonctionnait plus correctement et renvoyait des usagers avec invitations dont le délai n'était pas dépassé, probablement suite à la migration de #2056 .
Je tente ici de le réparer, et j'en profite pour mettre un index sur les `trigger` de la table invitation.