### PR TITLE
fix(stats): Increase stat job retries

### DIFF
--- a/app/jobs/stats/global_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/global_stats/upsert_stat_job.rb
@@ -1,7 +1,7 @@
 module Stats
   module GlobalStats
     class UpsertStatJob < ApplicationJob
-      sidekiq_options retry: 1
+      sidekiq_options retry: 3
 
       def perform(structure_type, structure_id)
         # to do : add timeout as a global concern for all jobs and remove it here

--- a/app/jobs/stats/monthly_stats/upsert_stat_job.rb
+++ b/app/jobs/stats/monthly_stats/upsert_stat_job.rb
@@ -1,7 +1,7 @@
 module Stats
   module MonthlyStats
     class UpsertStatJob < ApplicationJob
-      sidekiq_options retry: 1
+      sidekiq_options retry: 3
 
       def perform(structure_type, structure_id, until_date_string)
         # to do : add timeout as a global concern for all jobs and remove it here


### PR DESCRIPTION
On a des erreurs régulières de timeout sur les jobs de stat (voir [ici](https://sentry.incubateur.net/organizations/betagouv/issues/?project=16&query=is%3Aunresolved+upsert&referrer=issue-list&statsPeriod=14d) sur sentry). J'ai l'impression cependant qu'au retry le job s'exécute correctement (parce que moins de jobs et moins de load sur la db en parallèle probablement).
Pour en être certain, je passe les jobs de 1 à 3 retries ici juste  pour rendre + visible si ce n'est pas le cas. Vu les horaires où le CRON se lance ça ne devrait pas avoir d'impact sur les performances de l'appli.