### PR TITLE
fix(flaky): upload page flaky

### DIFF
--- a/app/javascript/react/components/user/EditableTags.jsx
+++ b/app/javascript/react/components/user/EditableTags.jsx
@@ -9,8 +9,8 @@ export default observer(({ user, cell, values, setIsEditingTags }) => {
     else setTemporarySelection([...temporarySelection, tag]);
   }
 
-  const saveTemporarySelection = () => {
-    user.updateAttribute(cell, temporarySelection);
+  const saveTemporarySelection = async () => {
+    await user.updateAttribute(cell, temporarySelection);
     setIsEditingTags(false);
   };
 

--- a/spec/features/agent_can_edit_uploaded_user_list_spec.rb
+++ b/spec/features/agent_can_edit_uploaded_user_list_spec.rb
@@ -67,6 +67,7 @@ describe "Agents can upload user list", :js do
 
           modal.find("input[value='Gentils']").check
           modal.click_button("Enregistrer")
+          expect(page).to have_no_content("Modifier les tags")
 
           expect(column).to have_content("Gentils, cool")
         else


### PR DESCRIPTION
Je fix ce flaky en mettant le "hide" de la modal derrière un await de la requête, ce qui permet d'élargir le délai entre le moment où on clique sur enregistrer et le moment où on check la colonne.

Testé en local de la façon suivante : 
```
bundle exec rspec spec/features/agent_can_edit_u***
```

Cette façon de lancer le test permettait de reproduire le flaky (2 fois sur 3 au moins) et passe désormais