### PR TITLE
fix(orientation): add new user org to rdvsp as well

### DIFF
--- a/app/services/orientations/save.rb
+++ b/app/services/orientations/save.rb
@@ -20,7 +20,11 @@ module Orientations
     def add_user_to_organisation
       fail!("Une organisation doit être renseignée") if @orientation.organisation.nil?
 
-      @orientation.user.organisations << @orientation.organisation
+      call_service!(
+        Users::AddToOrganisations,
+        user: @orientation.user,
+        organisations: [@orientation.organisation]
+      )
     end
 
     def other_user_orientations

--- a/app/services/users/add_to_organisations.rb
+++ b/app/services/users/add_to_organisations.rb
@@ -1,0 +1,20 @@
+module Users
+  class AddToOrganisations < BaseService
+    def initialize(user:, organisations:)
+      @user = user
+      @organisations = organisations
+    end
+
+    def call
+      UsersOrganisation.transaction do
+        @user.organisations << @organisations
+
+        call_service!(
+          RdvSolidaritesApi::CreateUserProfiles,
+          rdv_solidarites_user_id: @user.rdv_solidarites_user_id,
+          rdv_solidarites_organisation_ids: @organisations.map(&:rdv_solidarites_organisation_id)
+        )
+      end
+    end
+  end
+end

--- a/spec/services/orientations/save_spec.rb
+++ b/spec/services/orientations/save_spec.rb
@@ -11,6 +11,12 @@ describe Orientations::Save, type: :service do
   let!(:starts_at) { Date.parse("12/12/2022") }
   let!(:ends_at) { Date.parse("22/12/2022") }
 
+  before do
+    allow(Users::AddToOrganisations).to receive(:call)
+      .with(user: user, organisations: [organisation])
+      .and_return(OpenStruct.new(success?: true))
+  end
+
   describe "#call" do
     it "is a success" do
       is_a_success
@@ -158,9 +164,12 @@ describe Orientations::Save, type: :service do
 
       context "when user is not part of the organisation" do
         it "adds the user to the organisation" do
-          expect(user.organisations).not_to include(organisation)
+          expect(Users::AddToOrganisations).to receive(:call)
+            .with(user: user, organisations: [organisation])
+            .once
+            .and_return(OpenStruct.new(success?: true))
+
           subject
-          expect(user.organisations.reload).to include(orientation.organisation)
         end
       end
 

--- a/spec/services/users/add_to_organisations_spec.rb
+++ b/spec/services/users/add_to_organisations_spec.rb
@@ -1,0 +1,50 @@
+describe Users::AddToOrganisations, type: :service do
+  subject do
+    described_class.call(organisations: [organisation], user:)
+  end
+
+  let!(:organisation) { create(:organisation) }
+  let!(:user) { create(:user) }
+
+  describe "#call" do
+    before do
+      allow(RdvSolidaritesApi::CreateUserProfiles).to receive(:call)
+        .with(
+          rdv_solidarites_user_id: user.rdv_solidarites_user_id,
+          rdv_solidarites_organisation_ids: [organisation.rdv_solidarites_organisation_id]
+        ).and_return(OpenStruct.new(success?: true))
+    end
+
+    it "is a success" do
+      is_a_success
+    end
+
+    it "adds the user to the organisation" do
+      subject
+      expect(user.reload.organisations).to include(organisation)
+    end
+
+    context "when it fails it remove the added org" do
+      before do
+        allow(RdvSolidaritesApi::CreateUserProfiles).to receive(:call)
+          .with(
+            rdv_solidarites_user_id: user.rdv_solidarites_user_id,
+            rdv_solidarites_organisation_ids: [organisation.rdv_solidarites_organisation_id]
+          ).and_return(OpenStruct.new(success?: false, errors: ["impossible to create"]))
+      end
+
+      it "is a failure" do
+        is_a_failure
+      end
+
+      it "does not add the user to the organisation" do
+        subject
+        expect(user.reload.organisations).not_to include(organisation)
+      end
+
+      it "outputs an error" do
+        expect(subject.errors).to eq(["impossible to create"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette PR corrige un bug de désynchronisation, lors de la création d'une orientation, on ne créait pas l'orga sur rdvsp

fix https://github.com/betagouv/rdv-insertion/issues/2140