### PR TITLE
fix(validation): email regex

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,8 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :tag_users
 
   validates :last_name, :first_name, presence: true
-  validates :email, allow_blank: true, format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]+\z/ }
+  validates :email, allow_blank: true,
+                    format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/ }
   validate :birth_date_validity
   validates :rdv_solidarites_user_id, :nir, :france_travail_id,
             uniqueness: true, allow_nil: true, unless: :skip_uniqueness_validations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,8 +51,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :tag_users
 
   validates :last_name, :first_name, presence: true
-  validates :email, allow_blank: true,
-                    format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/ }
+  validates :email, allow_blank: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validate :birth_date_validity
   validates :rdv_solidarites_user_id, :nir, :france_travail_id,
             uniqueness: true, allow_nil: true, unless: :skip_uniqueness_validations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,8 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :tag_users
 
   validates :last_name, :first_name, presence: true
-  validates :email, allow_blank: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, allow_blank: true,
+                    format: { with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/ }
   validate :birth_date_validity
   validates :rdv_solidarites_user_id, :nir, :france_travail_id,
             uniqueness: true, allow_nil: true, unless: :skip_uniqueness_validations

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -117,6 +117,17 @@ describe User do
           .to include("Email n'est pas valide")
       end
     end
+
+    context "almost perfect but incorrect email format" do
+      let(:user) { build(:user, email: "abc@abc..fr") }
+
+      it "add errors" do
+        expect(user).not_to be_valid
+        expect(user.errors.details).to eq({ email: [{ error: :invalid, value: "abc@abc..fr" }] })
+        expect(user.errors.full_messages.to_sentence)
+          .to include("Email n'est pas valide")
+      end
+    end
   end
 
   describe "phone format validation" do


### PR DESCRIPTION
Juste un fix sur la regex de validation de l'email que je rend un peu plus stricte pour ne pas permettre l'enchainement de 2 points dans le domaine pour éviter des erreurs comme celle là https://www.rdv-insertion.fr/sidekiq/retries/1718823809.0168757-a0391319d2c58c38ca6e6d3c

