### PR TITLE
fix(upload): spinner when sending invite with one already sent

### DIFF
--- a/app/javascript/react/components/user/InvitationCell.jsx
+++ b/app/javascript/react/components/user/InvitationCell.jsx
@@ -17,6 +17,19 @@ export default observer(({ user, format }) => {
 
   const actionType = `${format}Invitation`;
 
+  const inviteButtonContent = () => {
+    if (user.triggers[actionType]) {
+      if (user.lastInvitationDate(format)) return <i className="fas fa-spinner fa-spin" />;
+      return "Invitation...";
+    }
+
+    if (user.lastInvitationDate(format)) return (
+      <i className="fas fa-redo-alt small-wheel d-block p-1" />
+    )
+
+    return CTA_BY_FORMAT[format];
+  };
+
   return (
     user.list.canBeInvitedBy(format) && (
       <>
@@ -57,17 +70,11 @@ export default observer(({ user, format }) => {
                     !user.belongsToCurrentOrg()
                   }
                     className={
-                      user.lastInvitationDate(format) === undefined || user.triggers[actionType] ? `btn btn-primary btn-blue invitation-${format}` : `reinvitation-${format}`
+                      user.lastInvitationDate(format) === undefined ? `btn btn-primary btn-blue invitation-${format}` : `reinvitation-${format}`
                     }
                   onClick={() => handleInvitationClick()}
                 >
-                    {user.triggers[actionType] ? "Invitation..."
-                      : user.lastInvitationDate(format) === undefined ? (
-                        CTA_BY_FORMAT[format]
-                      ) : (
-                        < i className="fas fa-redo-alt small-wheel d-block p-1" />
-                      )
-                    }
+                    {inviteButtonContent()}
                 </button>
               </div>
             </Tippy>


### PR DESCRIPTION
Dans cette PR je mets un spinner cohérent avec le bouton initial pour le cas où l'on réinvite un usager. J'ai aussi extract dans une méthode pour éviter la ternaire illisible

<img width="233" alt="Screenshot 2024-06-19 at 17 01 09" src="https://github.com/betagouv/rdv-insertion/assets/4990201/053f565e-3069-4f81-89b4-51141c4db177">

Fix https://github.com/betagouv/rdv-insertion/issues/2101