### PR TITLE
feat(invitations): don't display delay when optional rdv subscription

### DIFF
--- a/app/controllers/previews/invitations_controller.rb
+++ b/app/controllers/previews/invitations_controller.rb
@@ -109,7 +109,8 @@ module Previews
         rdv_subject: @invitation.rdv_subject,
         custom_sentence: @invitation.custom_sentence,
         invitation_url: @invitation.rdv_solidarites_public_url(with_protocol: false),
-        qr_code: @invitation.qr_code
+        qr_code: @invitation.qr_code,
+        optional_rdv_subscription: @invitation.motif_category.optional_rdv_subscription?
       }
     end
 

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -2,9 +2,8 @@ class InvitationMailer < ApplicationMailer
   include ActsAsRdvSolidaritesConcern
 
   before_action :set_invitation, :set_user, :set_department, :set_signature_lines,
-                :set_organisation_logo_path, :set_department_logo_path
-
-  before_action :set_rdv_title, :set_user_designation, :set_mandatory_warning, :set_punishable_warning,
+                :set_organisation_logo_path, :set_department_logo_path, :set_optional_rdv_subscription,
+                :set_rdv_title, :set_user_designation, :set_mandatory_warning, :set_punishable_warning,
                 :set_rdv_purpose, :set_rdv_subject, :set_custom_sentence
 
   default to: -> { @user.email }, reply_to: -> { "invitation+#{@invitation.uuid}@reply.rdv-insertion.fr" }
@@ -105,6 +104,10 @@ class InvitationMailer < ApplicationMailer
 
   def set_user_designation
     @user_designation = @invitation.user_designation
+  end
+
+  def set_optional_rdv_subscription
+    @optional_rdv_subscription = @invitation.motif_category.optional_rdv_subscription?
   end
 
   def set_mandatory_warning

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -81,7 +81,7 @@ class Invitation < ApplicationRecord
   def rdv_solidarites_public_url(with_protocol: true)
     url = "#{ENV['RDV_SOLIDARITES_URL']}/i/r/#{uuid}"
 
-    with_protocol ? url : url.gsub("https://", "").gsub("www.", "")
+    with_protocol ? url : url.gsub("https://", "").gsub("http://", "").gsub("www.", "")
   end
 
   def qr_code

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -21,7 +21,7 @@ module Invitations
     def standard_content
       "#{user.full_name},\nVous êtes #{user_designation} et êtes #{user.conjugate('invité')} à" \
         " participer à un #{rdv_title}. Pour choisir la date du RDV, " \
-        "cliquez sur ce lien#{display_delay_if_reminder}: " \
+        "cliquez sur ce lien#{display_time_to_accept_invitation}: " \
         "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
@@ -31,7 +31,7 @@ module Invitations
     def phone_platform_content
       "#{user.full_name},\nVous êtes #{user_designation} et devez contacter la plateforme " \
         "départementale afin de #{rdv_purpose}. Pour cela, merci d'appeler le " \
-        "#{formatted_phone_number}#{display_delay_if_reminder}. " \
+        "#{formatted_phone_number}#{display_time_to_accept_invitation}. " \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}"
     end
@@ -99,7 +99,7 @@ module Invitations
 
     ###
 
-    def display_delay_if_reminder
+    def display_time_to_accept_invitation
       " dans les #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours" unless motif_category.optional_rdv_subscription?
     end
 

--- a/app/services/concerns/invitations/sms_content.rb
+++ b/app/services/concerns/invitations/sms_content.rb
@@ -2,7 +2,7 @@ module Invitations
   module SmsContent
     extend ActiveSupport::Concern
 
-    delegate :user, :help_phone_number, :number_of_days_before_expiration,
+    delegate :user, :help_phone_number, :number_of_days_before_expiration, :motif_category,
              :rdv_purpose, :rdv_title, :user_designation, :mandatory_warning, :punishable_warning,
              to: :invitation
 
@@ -21,7 +21,7 @@ module Invitations
     def standard_content
       "#{user.full_name},\nVous êtes #{user_designation} et êtes #{user.conjugate('invité')} à" \
         " participer à un #{rdv_title}. Pour choisir la date du RDV, " \
-        "cliquez sur ce lien dans les #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours: " \
+        "cliquez sur ce lien#{display_delay_if_reminder}: " \
         "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
@@ -31,7 +31,7 @@ module Invitations
     def phone_platform_content
       "#{user.full_name},\nVous êtes #{user_designation} et devez contacter la plateforme " \
         "départementale afin de #{rdv_purpose}. Pour cela, merci d'appeler le " \
-        "#{formatted_phone_number} dans un délai de #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours. " \
+        "#{formatted_phone_number}#{display_delay_if_reminder}. " \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}"
     end
@@ -57,7 +57,7 @@ module Invitations
     ### Reminders
 
     def short_reminder_content
-      "#{user.full_name},\nVous avez reçu un message il y a 3 jours " \
+      "#{user.full_name},\nVous avez reçu un message il y a #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours " \
         "vous invitant à prendre un #{rdv_title}." \
         " Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
         "jours: " \
@@ -68,9 +68,9 @@ module Invitations
     end
 
     def standard_reminder_content
-      "#{user.full_name},\nEn tant que #{user_designation}, vous avez reçu un message il y a 3 jours " \
-        "vous invitant à prendre RDV au créneau de votre choix afin de #{rdv_purpose}." \
-        " Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
+      "#{user.full_name},\nEn tant que #{user_designation}, vous avez reçu un message il y a " \
+        "#{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours vous invitant à prendre RDV au créneau de votre choix " \
+        "afin de #{rdv_purpose}. Ce lien de prise de RDV expire dans #{number_of_days_before_expiration} " \
         "jours: " \
         "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
@@ -79,19 +79,18 @@ module Invitations
     end
 
     def phone_platform_reminder_content
-      "#{user.full_name},\nEn tant que #{user_designation}, vous avez reçu un message il y a 3 jours vous " \
-        "invitant à contacter la plateforme départementale afin de #{rdv_purpose}. " \
-        "Il vous reste #{number_of_days_before_expiration} jours pour appeler le " \
+      "#{user.full_name},\nEn tant que #{user_designation}, vous avez reçu un message il y a " \
+        "#{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours vous invitant à contacter la plateforme départementale " \
+        "afin de #{rdv_purpose}. Il vous reste #{number_of_days_before_expiration} jours pour appeler le " \
         "#{formatted_phone_number}. " \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}"
     end
 
     def atelier_enfants_ados_reminder_content
-      "#{user.full_name},\nTu as reçu un message il y a 3 jours " \
+      "#{user.full_name},\nTu as reçu un message il y a #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours " \
         "t'invitant à participer à un #{rdv_title}." \
-        " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} " \
-        "jours: " \
+        " Le lien de prise de RDV suivant expire dans #{number_of_days_before_expiration} jours: " \
         "#{@invitation.rdv_solidarites_public_url(with_protocol: false)}\n" \
         "#{mandatory_warning_message}" \
         "#{punishable_warning_message}" \
@@ -99,6 +98,10 @@ module Invitations
     end
 
     ###
+
+    def display_delay_if_reminder
+      " dans les #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours" unless motif_category.optional_rdv_subscription?
+    end
 
     def mandatory_warning_message
       mandatory_warning ? "#{mandatory_warning} " : ""

--- a/app/services/invitations/generate_letter.rb
+++ b/app/services/invitations/generate_letter.rb
@@ -24,7 +24,7 @@ module Invitations
       )
     end
 
-    def locals
+    def locals # rubocop:disable Metrics/AbcSize
       {
         invitation: @invitation,
         department: @invitation.department,
@@ -46,7 +46,8 @@ module Invitations
         rdv_subject: @invitation.rdv_subject,
         custom_sentence: @invitation.custom_sentence,
         invitation_url: @invitation.rdv_solidarites_public_url(with_protocol: false),
-        qr_code: @invitation.qr_code
+        qr_code: @invitation.qr_code,
+        optional_rdv_subscription: @invitation.motif_category.optional_rdv_subscription?
       }
     end
 

--- a/app/views/letters/invitations/phone_platform.html.erb
+++ b/app/views/letters/invitations/phone_platform.html.erb
@@ -12,7 +12,7 @@
   <p><%= user.title.capitalize %>,</p>
   <p>Vous êtes <%= user_designation %> et devez bénéficier d’un accompagnement obligatoire dans le cadre de vos démarches d’insertion.</p>
   <p>La première étape est <span class="bold-blue">un appel téléphonique avec un professionnel de l’insertion</span> afin de définir, selon votre situation et vos besoins, quelle sera la structure la mieux adaptée pour vous accompagner.</p>
-  <p>Pour cela, <span class="bold-blue">merci d’appeler le <%= invitation.help_phone_number %> dans un délai de <%= Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER %> jours à réception de ce courrier.</span></p>
+  <p>Pour cela, <span class="bold-blue">merci d’appeler le <%= invitation.help_phone_number %><%= " dans un délai de #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours à réception de ce courrier" unless optional_rdv_subscription %>.</span></p>
   <%= tag.p tag.span(mandatory_warning, class: "bold-blue") if mandatory_warning %>
   <%= tag.p tag.span("En l'absence d'action de votre part, #{punishable_warning}.", class: "bold-blue") if punishable_warning.present? %>
   <%= render "letters/invitations/help_message", invitation: invitation, help_address: help_address %>

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -13,7 +13,7 @@
   <p>Vous êtes <%= user_designation %> et à ce titre vous êtes <%= user.conjugate('invité') %> à participer à un <%= rdv_title %> afin de <%= rdv_purpose %>.</p>
   <%= tag.p(custom_sentence) if custom_sentence %>
   <p>Pour faciliter votre prise de rendez-vous, <%= sender_name %> a mis en place <span class="bold-blue">une plateforme vous permettant de prendre rendez-vous vous-même.</span></p>
-  <p>Choisissez un créneau à votre convenance dans un délai de <%= Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER %> jours à réception de ce courrier&nbsp;:</p>
+  <p>Choisissez un créneau à votre convenance<%= " dans un délai de #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours à réception de ce courrier" unless optional_rdv_subscription %>&nbsp;:</p>
   <div>
     <div class="invitation-left-col pdf-align-center">
       <div>soit en scannant ce QR code</div>

--- a/app/views/mailers/invitation_mailer/phone_platform_invitation.erb
+++ b/app/views/mailers/invitation_mailer/phone_platform_invitation.erb
@@ -1,6 +1,6 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
 <p>En tant que <%= @user_designation %> vous devez contacter la plateforme départementale afin de <%= @rdv_purpose %>.</p>
-<p><span class="font-weight-bold">Pour cela, merci d’appeler le <%= @invitation.help_phone_number_formatted %> dans un délai de <%= Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER %> jours.</span></p>
+<p><span class="font-weight-bold">Pour cela, merci d’appeler le <%= @invitation.help_phone_number_formatted %><%= tag.span(" dans un délai de #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours", class: ["font-weight-bold"]) unless @optional_rdv_subscription %>.</span></p>
 <%= tag.p tag.strong(@mandatory_warning) if @mandatory_warning %>
 <%= tag.p tag.strong("En l'absence d'action de votre part, #{@punishable_warning}.") if @punishable_warning.present? %>
 <%= render 'common/organisation_signature', signature_lines: @signature_lines, department: @department %>

--- a/app/views/mailers/invitation_mailer/standard_invitation.html.erb
+++ b/app/views/mailers/invitation_mailer/standard_invitation.html.erb
@@ -1,7 +1,7 @@
 <h1>Bonjour <%= "#{@user.first_name} #{@user.last_name.upcase}" %>,</h1>
 <p>Vous êtes <%= @user_designation %> et à ce titre vous êtes <%= @user.conjugate('invité') %> à participer à un <%= @rdv_title %> afin de <%= @rdv_purpose %>.</p>
 <%= tag.p(@custom_sentence) if @custom_sentence %>
-<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant <span class="font-weight-bold">dans un délai de <%= Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER %> jours</span>:</p>
+<p><span class="font-weight-bold">Pour pouvoir choisir la date et l'horaire de votre rendez-vous</span>, vous pouvez accéder au service RDV-Solidarités en cliquant sur le bouton suivant<%= tag.span(" dans un délai de #{Invitation::NUMBER_OF_DAYS_BEFORE_REMINDER} jours", class: ["font-weight-bold"]) unless @optional_rdv_subscription %>:</p>
 <p class="btn-wrapper">
   <%= link_to @invitation.rdv_solidarites_public_url, class: "btn btn-primary" do %>
     Choisir un créneau

--- a/spec/factories/motif_category.rb
+++ b/spec/factories/motif_category.rb
@@ -3,6 +3,6 @@ FactoryBot.define do
     template
     sequence(:short_name) { |n| "rsa_orientation_#{n}" }
     name { "RSA orientation" }
-    optional_rdv_subscription { true }
+    optional_rdv_subscription { false }
   end
 end

--- a/spec/services/invitations/generate_letter_spec.rb
+++ b/spec/services/invitations/generate_letter_spec.rb
@@ -364,6 +364,7 @@ describe Invitations::GenerateLetter, type: :service do
           "Pour en profiter au mieux, nous vous invitons à vous inscrire directement" \
           " et librement aux ateliers et formations de votre choix"
         )
+        expect(content).not_to include("dans un délai de 3 jours")
         expect(content).not_to include("Vous devez obligatoirement prendre ce rendez-vous")
         expect(content).not_to include(
           "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
@@ -384,6 +385,8 @@ describe Invitations::GenerateLetter, type: :service do
           "Pour en profiter au mieux, nous vous invitons à vous inscrire directement" \
           " et librement aux ateliers et formations de votre choix"
         )
+        expect(content).to include("Choisissez un créneau à votre convenance")
+        expect(content).not_to include("dans un délai de 3 jours")
         expect(content).not_to include("Vous devez obligatoirement prendre ce rendez-vous")
         expect(content).not_to include(
           "En l'absence d'action de votre part, vous risquez une suspension ou réduction du versement de votre RSA."
@@ -404,7 +407,8 @@ describe Invitations::GenerateLetter, type: :service do
           "Pour en profiter au mieux, nous vous invitons à vous inscrire directement" \
           " et librement aux ateliers et formations de votre choix"
         )
-        expect(content).not_to include("Choisissez un créneau à votre convenance dans un délai de 3 jours à réception")
+        expect(content).to include("Choisissez un créneau à votre convenance")
+        expect(content).not_to include("dans un délai de 3 jours")
         expect(content).not_to include(
           "En l'absence d'action de votre part, votre RSA pourra être suspendu ou réduit."
         )

--- a/spec/services/invitations/send_sms_spec.rb
+++ b/spec/services/invitations/send_sms_spec.rb
@@ -52,7 +52,7 @@ describe Invitations::SendSms, type: :service do
     before do
       allow(SendTransactionalSms).to receive(:call).and_return(OpenStruct.new(success?: true))
       allow(invitation).to receive(:sms_sender_name).and_return(sms_sender_name)
-      ENV["HOST"] = "www.rdv-insertion.fr"
+      ENV["RDV_SOLIDARITES_URL"] = "www.rdv-solidarites.fr"
     end
 
     it("is a success") { is_a_success }
@@ -212,7 +212,7 @@ describe Invitations::SendSms, type: :service do
       let!(:content) do
         "M. John DOE,\nVous êtes bénéficiaire du RSA et devez contacter la plateforme départementale " \
           "afin de démarrer un parcours d'accompagnement. Pour cela, merci d'appeler le " \
-          "0147200001 dans un délai de 3 jours. " \
+          "0147200001 dans les 3 jours. " \
           "Cet appel est obligatoire pour le traitement de votre dossier. "
       end
 

--- a/spec/support/motif_categories_helper.rb
+++ b/spec/support/motif_categories_helper.rb
@@ -6,6 +6,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA orientation", short_name: "rsa_orientation",
         leads_to_orientation: true,
+        optional_rdv_subscription: false,
         template: create(
           :template,
           model: "standard",
@@ -57,6 +58,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA accompagnement",
         short_name: "rsa_accompagnement",
+        optional_rdv_subscription: false,
         template: create(
           :template,
           model: "standard",
@@ -111,6 +113,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA signature CER",
         short_name: "rsa_cer_signature",
+        optional_rdv_subscription: false,
         template: create(
           :template,
           model: "standard",
@@ -128,6 +131,7 @@ module MotifCategoriesHelper
         :motif_category,
         name: "RSA suivi",
         short_name: "rsa_follow_up",
+        optional_rdv_subscription: false,
         template: create(
           :template,
           model: "standard",


### PR DESCRIPTION
closes #2126 

Dans cette PR, je fais en sorte de ne pas afficher le délai de prise de rdv quand il n'y a pas de reminder envoyé.

Question subsidiaire :  il n'y a pas de lien entre `display_mandatory_warning` (template) et `optional_rdv_subscription` (motif_category), est-ce que c'est logique ?