### PR TITLE
feat(follow_ups): delete multiple rdvs canceled status

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -40,7 +40,6 @@ module UsersHelper
       ["rdv_needs_status_update", statuses_count["rdv_needs_status_update"]],
       ["rdv_excused", statuses_count["rdv_excused"]],
       ["rdv_revoked", statuses_count["rdv_revoked"]],
-      ["multiple_rdvs_cancelled", statuses_count["multiple_rdvs_cancelled"]],
       ["rdv_noshow", statuses_count["rdv_noshow"]],
       ["rdv_seen", statuses_count["rdv_seen"]],
       ["closed", statuses_count["closed"]]

--- a/app/models/concerns/follow_up_status.rb
+++ b/app/models/concerns/follow_up_status.rb
@@ -11,7 +11,6 @@ module FollowUpStatus
       rdv_revoked: "rdv_revoked",
       rdv_excused: "rdv_excused",
       rdv_seen: "rdv_seen",
-      multiple_rdvs_cancelled: "multiple_rdvs_cancelled",
       closed: "closed"
     }
     before_save :set_status
@@ -49,10 +48,6 @@ module FollowUpStatus
     last_invitation_created_at > participation_date_to_compare
   end
 
-  def multiple_cancelled_participations?
-    participations.select(&:cancelled_by_user?).length > 1
-  end
-
   def seen_rdv_after_last_created_participation?
     seen_participations.present? &&
       seen_participations.max_by(&:starts_at).starts_at > last_created_participation.created_at
@@ -63,8 +58,6 @@ module FollowUpStatus
       :rdv_pending
     elsif last_created_participation.seen? || seen_rdv_after_last_created_participation?
       :rdv_seen
-    elsif multiple_cancelled_participations?
-      :multiple_rdvs_cancelled
     elsif last_created_participation.cancelled?
       :"rdv_#{last_created_participation.status}"
     else

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -20,10 +20,10 @@ class FollowUp < ApplicationRecord
   delegate :name, :short_name, to: :motif_category, prefix: true
 
   STATUSES_WITH_ACTION_REQUIRED = %w[
-    rdv_needs_status_update rdv_noshow rdv_revoked rdv_excused multiple_rdvs_cancelled
+    rdv_needs_status_update rdv_noshow rdv_revoked rdv_excused
   ].freeze
   CONVOCABLE_STATUSES = %w[
-    rdv_noshow rdv_excused multiple_rdvs_cancelled
+    rdv_noshow rdv_excused
   ].freeze
 
   scope :status, ->(status) { where(status: status) }

--- a/config/locales/models/follow_up.fr.yml
+++ b/config/locales/models/follow_up.fr.yml
@@ -14,5 +14,4 @@ fr:
           rdv_revoked: RDV annulé à l'initative du Service
           rdv_excused: RDV annulé à l'initiative de l'usager
           rdv_seen: RDV honoré
-          multiple_rdvs_cancelled: Plusieurs RDV reportés par l'usager
           closed: Dossier traité

--- a/spec/features/agent_can_convene_user_spec.rb
+++ b/spec/features/agent_can_convene_user_spec.rb
@@ -227,17 +227,6 @@ describe "Agents can convene user to rdv", :js do
         end
       end
 
-      context "when multiple rdvs were canceled" do
-        let!(:follow_up) do
-          create(:follow_up, status: "multiple_rdvs_cancelled", user: user, motif_category: motif_category)
-        end
-
-        it "shows a link to convene the user" do
-          visit organisation_users_path(organisation, motif_category_id: motif_category.id)
-          expect(page).to have_link("📅 Convoquer")
-        end
-      end
-
       context "when the category_configuration is not set to convene users" do
         before { category_configuration.update! convene_user: false }
 

--- a/spec/models/follow_up_spec.rb
+++ b/spec/models/follow_up_spec.rb
@@ -231,20 +231,6 @@ describe FollowUp do
             end
           end
 
-          context "when the last rdv is cancelled and one other has been cancelled" do
-            let!(:rdv3) { create(:rdv) }
-            let!(:participation) do
-              create(
-                :participation,
-                created_at: 1.day.ago, rdv: rdv3, user: user, follow_up: follow_up, status: "excused"
-              )
-            end
-
-            it "is mutliple rdvs cancelled" do
-              expect(subject).to eq(:multiple_rdvs_cancelled)
-            end
-          end
-
           context "when the last rdv already took place but the status is not updated" do
             let!(:rdv3) do
               create(:rdv, starts_at: 2.days.ago)


### PR DESCRIPTION
closes #2144 

🚮
Je n'ai pas inclus de script parce qu'il suffira de faire `FollowUp.where(status: "multiple_rdvs_cancelled").each(&:save)` en console pour forcer la mise à jour des follow_ups concernés.