### PR TITLE
feat(show): add creation date to user_tag

### DIFF
--- a/app/controllers/concerns/users/taggable.rb
+++ b/app/controllers/concerns/users/taggable.rb
@@ -4,6 +4,7 @@ module Users::Taggable
   def set_user_tags
     @user_tags = policy_scope(@user.tags)
                  .joins(:organisations)
+                 .preload(:tag_users)
                  .where(current_organisations_filter)
                  .order(Arel.sql("LOWER(tags.value)"))
                  .group("tags.id")

--- a/app/controllers/concerns/users/taggable.rb
+++ b/app/controllers/concerns/users/taggable.rb
@@ -4,7 +4,6 @@ module Users::Taggable
   def set_user_tags
     @user_tags = policy_scope(@user.tags)
                  .joins(:organisations)
-                 .preload(:tag_users)
                  .where(current_organisations_filter)
                  .order(Arel.sql("LOWER(tags.value)"))
                  .group("tags.id")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -161,6 +161,7 @@ class UsersController < ApplicationController
   def set_user
     @user =
       policy_scope(User)
+      .preload(:tag_users)
       .where(current_organisations_filter)
       .find(params[:id])
   end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,6 +1,6 @@
 module TagsHelper
   def user_tag_creation_date(tag, user)
-    tag.tag_users.find { |tag_user| tag_user.user_id == user.id }
-       .created_at.strftime("%d/%m/%Y")
+    user.tag_users.find { |tag_user| tag_user.tag_id == tag.id }
+        .created_at.strftime("%d/%m/%Y")
   end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,6 @@
+module TagsHelper
+  def user_tag_creation_date(tag, user)
+    tag.tag_users.find { |tag_user| tag_user.user_id == user.id }
+       .created_at.strftime("%d/%m/%Y")
+  end
+end

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -17,6 +17,16 @@ export default class extends Controller {
     });
   }
 
+  tagCreationDate() {
+    tippy(this.element, {
+      content(reference) {
+        const { tagCreationDate } = reference.dataset;
+        return (`Tag ajouté le ${tagCreationDate}`);
+      },
+      allowHTML: true,
+    });
+  }
+
   csvExportUsers() {
     tippy(this.element, {
       content: "Les usagers correspondant aux filtres actuels seront exportés",

--- a/app/views/users/_user_page_header.html.erb
+++ b/app/views/users/_user_page_header.html.erb
@@ -17,12 +17,10 @@
       <%= render "users/user_icon", user: @user %> <%= "#{@user.first_name} #{@user.last_name.upcase}" %>
     </h4>
     <% if @user_tags.any? %>
-      <div class="mb-3 mt-3 flex-wrap d-flex justify-content-center" id="header_tags_list">
+      <div class="mb-3 mt-3 flex-wrap d-flex justify-content-center w-100" id="header_tags_list">
         <% @user_tags.each do |tag| %>
           <%= link_to(structure_user_path(@user.id, anchor: "tags_list"), class: "d-flex text-truncate", target: "_top") do %>
-            <span class="badge badge-tag background-blue-light text-dark-blue me-2 text-truncate">
-              <%= tag.value %>
-            </span>
+            <%= render "users_tags/user_tag_badge", user: @user, tag:, with_delete: false %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/users/_user_tags.html.erb
+++ b/app/views/users/_user_tags.html.erb
@@ -5,25 +5,7 @@
       -
     <% else %>
       <% tags.each do |tag| %>
-        <span class="badge badge-tag justify-content-between background-blue-light text-dark-blue me-2 d-flex text-truncate">
-          <span class="text-truncate">
-            <%= tag.value %>
-          </span>
-          <%=
-            link_to(
-              structure_tag_assignations_path(user.id, tag_id: tag.id),
-              data: {
-                turbo_confirm: "Retirer le tag de cet usager ?",
-                turbo_confirm_text_content: "Êtes-vous sûr de vouloir retirer le tag <b class='text-large text-truncate d-block'><i>#{tag.value}</i></b> de l'usager <b>#{user}</b> ?",
-                turbo_confirm_text_action: "- Retirer",
-                turbo_method: :delete,
-              },
-              class: 'text-dark-grey-alt ms-2'
-            ) do
-          %>
-            <i class="fas fa-times"></i>
-          <% end %>
-        </span>
+        <%= render "users_tags/user_tag_badge", user: @user, tag:, with_delete: true %>
       <% end %>
     <% end %>
   </p>

--- a/app/views/users_tags/_user_tag_badge.html.erb
+++ b/app/views/users_tags/_user_tag_badge.html.erb
@@ -1,0 +1,26 @@
+<span
+  class="badge badge-tag justify-content-between background-blue-light text-dark-blue me-2 d-flex text-truncate"
+  data-controller="tooltip"
+  data-action="mouseover->tooltip#tagCreationDate"
+  data-tag-creation-date="<%= user_tag_creation_date(tag, user) %>"
+>
+  <span class="text-truncate">
+    <%= tag.value %>
+  </span>
+  <% if with_delete %>
+    <%=
+      link_to(
+        structure_tag_assignations_path(user.id, tag_id: tag.id),
+        data: {
+          turbo_confirm: "Retirer le tag de cet usager ?",
+          turbo_confirm_text_content: "Êtes-vous sûr de vouloir retirer le tag <b class='text-large text-truncate d-block'><i>#{tag.value}</i></b> de l'usager <b>#{user}</b> ?",
+          turbo_confirm_text_action: "- Retirer",
+          turbo_method: :delete,
+        },
+        class: 'text-dark-grey-alt ms-2'
+      ) do
+    %>
+      <i class="fas fa-times"></i>
+    <% end %>
+  <% end %>
+</span>


### PR DESCRIPTION
closes #2128 

Dans cette PR, je fais en sorte d'afficher la date de rattachement du tag à un usager lorsque l'on survole ce tag à la souris. J'en profite pour faire une petite refacto du composant.