### PR TITLE
ux(message): inform agent when organisation has no email when add a user on it

### DIFF
--- a/app/views/organisations/user_added_notifications/_no_email.html.erb
+++ b/app/views/organisations/user_added_notifications/_no_email.html.erb
@@ -1,0 +1,25 @@
+<%= render "common/remote_modal", title: "Informer l’organisation par email" do %>
+  <div>
+    <div class="text-center mb-3">
+      <%= image_tag "illustrations/error-warning-line.svg", alt: "Illustration d'un message d'avertissement", class: "mb-3" %>
+    </div>
+    <p>
+      L'organisation <b class="text-large"><i><%= organisation.name %></i></b> n'a pas d'adresse email renseignée. Vous ne pouvez donc pas informer l'organisation depuis rdv-insertion.
+    </p>
+    <p>
+      A défaut, nous vous invitions à les notifier depuis votre boîte mail ou par téléphone.
+    </p>
+    <p>
+      Si vous avez les droits d'admin, nous vous invitons à ajouter une adresse email de contact depuis la page
+      <%= link_to organisation_category_configurations_path(organisation), data: { turbo: "false" }  do %>
+        <span class="text-underline">"configurer l'organisation"</span>
+      <% end %>
+      de <b class="text-large"><i><%= organisation.name %></i></b>.
+    </p>
+  </div>
+  <div class="d-flex justify-content-end px-3">
+    <button type="button" id="confirm-button" class="btn btn-blue me-2" data-bs-dismiss="modal">
+      J'ai compris
+    </button>
+  </div>
+<% end %>

--- a/app/views/users_organisations/create.turbo_stream.erb
+++ b/app/views/users_organisations/create.turbo_stream.erb
@@ -8,4 +8,8 @@
   <%= turbo_stream.replace "remote_modal" do %>
     <%= render partial: "organisations/user_added_notifications/form", locals: { emails: [@organisation_to_add.email], user: @user, organisation: @organisation_to_add } %>
   <% end %>
+<% else %>
+  <%= turbo_stream.replace "remote_modal" do %>
+    <%= render partial: "organisations/user_added_notifications/no_email", locals: { organisation: @organisation_to_add } %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
close https://github.com/betagouv/rdv-insertion/issues/2129

Voici le message qu'on affiche désormais quand une organisation n'a pas de mail et qu'un agent y ajoute des usagers. 
Nous n'avions aucun message avant et cela portait à confusion.

<img width="643" alt="Capture d’écran 2024-06-21 à 11 58 38" src="https://github.com/betagouv/rdv-insertion/assets/28594222/9d4de465-e24c-4740-8a18-0f23396c950d">
