### PR TITLE
fix users oriented stat

### DIFF
--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -11,6 +11,14 @@ module StatsHelper
   end
 
   def exclude_current_month(stat)
-    stat&.delete_if { |key, _value| key == Time.zone.now.strftime("%m/%Y") }
+    exclude_months(stat, [Time.zone.now.strftime("%m/%Y")])
+  end
+
+  def exclude_current_and_previous_month(stat)
+    exclude_months(stat, [1.month.ago.strftime("%m/%Y"), Time.zone.now.strftime("%m/%Y")])
+  end
+
+  def exclude_months(stat, months)
+    stat&.delete_if { |key, _value| months.include?(key) }
   end
 end

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -69,23 +69,21 @@ module Stats
 
       def rate_of_users_oriented_in_less_than_30_days_for_focused_month
         ComputeRateOfRdvSeenInLessThanNDays.call(
-          # we take the records of the previous month because we want at least 30 days old users
-          follow_ups: @stat.users_first_orientation_follow_up.where(created_at: (@date - 1.month).all_month),
+          follow_ups: created_during_focused_mont(@stat.users_first_orientation_follow_up),
           number_of_days: 30
         ).value.round
       end
 
       def rate_of_users_oriented_in_less_than_15_days_for_focused_month
         ComputeRateOfRdvSeenInLessThanNDays.call(
-          # we take the records of the previous month to be sure to have at least a 15 days window
-          follow_ups: @stat.users_first_orientation_follow_up.where(created_at: (@date - 1.month).all_month),
+          follow_ups: created_during_focused_mont(@stat.users_first_orientation_follow_up),
           number_of_days: 15
         ).value.round
       end
 
       def rate_of_users_oriented_for_focused_month
         ComputeRateOfUsersWithRdvSeen.call(
-          follow_ups: created_during_focused_month(@stat.orientation_follow_ups_with_invitations)
+          follow_ups: created_during_focused_mont(@stat.orientation_follow_ups_with_invitations)
         ).value.round
       end
 

--- a/app/services/stats/monthly_stats/compute_for_focused_month.rb
+++ b/app/services/stats/monthly_stats/compute_for_focused_month.rb
@@ -69,21 +69,21 @@ module Stats
 
       def rate_of_users_oriented_in_less_than_30_days_for_focused_month
         ComputeRateOfRdvSeenInLessThanNDays.call(
-          follow_ups: created_during_focused_mont(@stat.users_first_orientation_follow_up),
+          follow_ups: created_during_focused_month(@stat.users_first_orientation_follow_up),
           number_of_days: 30
         ).value.round
       end
 
       def rate_of_users_oriented_in_less_than_15_days_for_focused_month
         ComputeRateOfRdvSeenInLessThanNDays.call(
-          follow_ups: created_during_focused_mont(@stat.users_first_orientation_follow_up),
+          follow_ups: created_during_focused_month(@stat.users_first_orientation_follow_up),
           number_of_days: 15
         ).value.round
       end
 
       def rate_of_users_oriented_for_focused_month
         ComputeRateOfUsersWithRdvSeen.call(
-          follow_ups: created_during_focused_mont(@stat.orientation_follow_ups_with_invitations)
+          follow_ups: created_during_focused_month(@stat.orientation_follow_ups_with_invitations)
         ).value.round
       end
 

--- a/app/services/stats/monthly_stats/upsert_stat.rb
+++ b/app/services/stats/monthly_stats/upsert_stat.rb
@@ -39,7 +39,7 @@ module Stats
           # We don't want to start the hash until we have a value
           next if stat_attribute == {} && stat_value.zero?
 
-          if stat_name.to_s.include?("rate_of_users_oriented_in_less_than")
+          if stat_name.to_s.include?("rate_of_users_oriented")
             # these stats are computed with 1 month lag
             stat_attribute.merge!({ (@date - 1.month).strftime("%m/%Y") => stat_value })
           else

--- a/app/services/stats/monthly_stats/upsert_stat.rb
+++ b/app/services/stats/monthly_stats/upsert_stat.rb
@@ -39,12 +39,7 @@ module Stats
           # We don't want to start the hash until we have a value
           next if stat_attribute == {} && stat_value.zero?
 
-          if stat_name.to_s.include?("rate_of_users_oriented")
-            # these stats are computed with 1 month lag
-            stat_attribute.merge!({ (@date - 1.month).strftime("%m/%Y") => stat_value })
-          else
-            stat_attribute.merge!({ @date.strftime("%m/%Y") => stat_value })
-          end
+          stat_attribute.merge!({ @date.strftime("%m/%Y") => stat_value })
         end
       end
 

--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -57,7 +57,7 @@
     <div class="col-12 col-md-6 px-5 pb-5">
       <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented&.round %> %</p>
       <p class="highlight-stat margin-left">d'usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
-      <%= line_chart exclude_current_month(@stat.rate_of_users_oriented_grouped_by_month), title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
+      <%= line_chart @stat.rate_of_users_oriented_grouped_by_month, title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
     </div>
   </div>
   <div class="row d-flex justify-content-center flex-wrap-reverse">

--- a/app/views/stats/_stats.html.erb
+++ b/app/views/stats/_stats.html.erb
@@ -40,12 +40,12 @@
     <div class="col-12 col-md-6 px-5 pb-5">
       <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented_in_less_than_30_days&.round %> %</p>
       <p class="highlight-stat margin-left">d'usagers <strong>ayant honoré un 1er rendez-vous RSA en - de 30 jours</strong></p>
-      <%= line_chart @stat.rate_of_users_oriented_in_less_than_30_days_by_month, title: "Taux rdv en - de 30 jours par mois", suffix: "%", colors: ["#083b66"] %>
+      <%= line_chart exclude_current_month(@stat.rate_of_users_oriented_in_less_than_30_days_by_month), title: "Taux rdv en - de 30 jours par mois", suffix: "%", colors: ["#083b66"] %>
     </div>
     <div class="col-12 col-md-6 px-5 pb-5">
       <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented_in_less_than_15_days&.round %> %</p>
       <p class="highlight-stat margin-left">d'usagers <strong>ayant honoré un 1er rendez-vous RSA en - de 15 jours</strong></p>
-      <%= line_chart @stat.rate_of_users_oriented_in_less_than_15_days_by_month, title: "Taux rdv en - de 15 jours par mois", suffix: "%", colors: ["#083b66"] %>
+      <%= line_chart exclude_current_month(@stat.rate_of_users_oriented_in_less_than_15_days_by_month), title: "Taux rdv en - de 15 jours par mois", suffix: "%", colors: ["#083b66"] %>
     </div>
   </div>
   <div class="row d-flex justify-content-center flex-wrap-reverse">
@@ -57,7 +57,7 @@
     <div class="col-12 col-md-6 px-5 pb-5">
       <p class="highlight-stat big margin-left"><%= @stat.rate_of_users_oriented&.round %> %</p>
       <p class="highlight-stat margin-left">d'usagers ajoutés dans l'outil pour un RDV d'orientation <strong>ont eu leur orientation réalisée via rdv-insertion</strong></p>
-      <%= line_chart @stat.rate_of_users_oriented_grouped_by_month, title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
+      <%= line_chart exclude_current_and_previous_month(@stat.rate_of_users_oriented_grouped_by_month), title: "Taux d'usagers orientés via l'outil par mois", suffix: "%", colors: ["#083b66"] %>
     </div>
   </div>
   <div class="row d-flex justify-content-center flex-wrap-reverse">

--- a/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
+++ b/spec/services/stats/monthly_stats/compute_for_focused_month_spec.rb
@@ -4,7 +4,7 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
   let!(:stat) { create(:stat, statable_type: "Department", statable_id: department.id) }
 
   let(:date) { Time.zone.parse("17/03/2022 12:00") }
-  let(:date_from_previous_month) { Time.zone.parse("17/02/2022 12:00") }
+  let(:date_from_previous_month) { Time.zone.parse("15/02/2022 12:00") }
 
   let!(:department) { create(:department) }
   let!(:organisation) { create(:organisation, department: department) }
@@ -15,8 +15,8 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
   let!(:participation1) { create(:participation, created_at: date, rdv: rdv1) }
   let!(:participation2) { create(:participation, created_at: date_from_previous_month, rdv: rdv2) }
   let!(:notification) { create(:notification, participation: participation2) }
-  let!(:follow_up1) { create(:follow_up, created_at: date, user: user1) }
   let!(:follow_up2) { create(:follow_up, created_at: date_from_previous_month, user: user2) }
+  let!(:follow_up1) { create(:follow_up, created_at: date, user: user1) }
   let!(:invitation1) do
     create(:invitation, created_at: date, department: department)
   end
@@ -43,11 +43,9 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
       allow(Stats::ComputeAverageTimeBetweenInvitationAndRdvInDays).to receive(:call)
         .and_return(OpenStruct.new(success?: true, value: 4.0))
       allow(Stats::ComputeRateOfRdvSeenInLessThanNDays).to receive(:call)
-        .with(follow_ups: [follow_up2], number_of_days: 30)
-        .and_return(OpenStruct.new(success?: true, value: 50.0))
+        .and_return(OpenStruct.new(success?: true, value: 0))
       allow(Stats::ComputeRateOfRdvSeenInLessThanNDays).to receive(:call)
-        .with(follow_ups: [follow_up2], number_of_days: 15)
-        .and_return(OpenStruct.new(success?: true, value: 25.0))
+        .and_return(OpenStruct.new(success?: true, value: 0))
       allow(Stats::ComputeRateOfUsersWithRdvSeen).to receive(:call)
         .and_return(OpenStruct.new(success?: true, value: 50.0))
       allow(Stats::ComputeRateOfAutonomousUsers).to receive(:call)
@@ -132,15 +130,15 @@ describe Stats::MonthlyStats::ComputeForFocusedMonth, type: :service do
     it "computes the percentage of users with rdv seen in less than 30 days" do
       expect(stat).to receive(:users_first_orientation_follow_up)
       expect(Stats::ComputeRateOfRdvSeenInLessThanNDays).to receive(:call)
-        .with(follow_ups: [follow_up2], number_of_days: 30)
-      expect(subject.stats_values[:rate_of_users_oriented_in_less_than_30_days_by_month]).to eq(50.0)
+        .with(follow_ups: [], number_of_days: 30)
+      expect(subject.stats_values[:rate_of_users_oriented_in_less_than_30_days_by_month]).to eq(0)
     end
 
     it "computes the percentage of users with rdv seen in less than 15 days" do
       expect(stat).to receive(:users_first_orientation_follow_up)
       expect(Stats::ComputeRateOfRdvSeenInLessThanNDays).to receive(:call)
-        .with(follow_ups: [follow_up2], number_of_days: 15)
-      expect(subject.stats_values[:rate_of_users_oriented_in_less_than_15_days_by_month]).to eq(25.0)
+        .with(follow_ups: [], number_of_days: 15)
+      expect(subject.stats_values[:rate_of_users_oriented_in_less_than_15_days_by_month]).to eq(0)
     end
 
     it "computes the percentage of users with rdv seen posterior to an invitation" do

--- a/spec/services/stats/monthly_stats/upsert_stat_spec.rb
+++ b/spec/services/stats/monthly_stats/upsert_stat_spec.rb
@@ -82,7 +82,7 @@ describe Stats::MonthlyStats::UpsertStat, type: :service do
         { "01/2022" => 5, "02/2022" => 5, "03/2022" => 5, "04/2022" => 5 }
       )
       expect(stat.reload[:rate_of_users_oriented_in_less_than_30_days_by_month]).to eq(
-        { "12/2021" => 7, "01/2022" => 7, "02/2022" => 7, "03/2022" => 7 }
+        { "01/2022" => 7, "02/2022" => 7, "03/2022" => 7, "04/2022" => 7 }
       )
       expect(stat.reload[:rate_of_autonomous_users_grouped_by_month]).to eq(
         { "01/2022" => 8, "02/2022" => 8, "03/2022" => 8, "04/2022" => 8 }


### PR DESCRIPTION
closes #2119 

Pour éviter qu'il y ait un décrochage systématique sur le dernier mois affiché pour la stat du "Taux d'usagers orientés via l'outil par mois", on décale le calcul de la stat d'un mois pour pouvoir observer des cohortes + cohérentes, qui ont eu le temps nécessaire pour avoir leur rdv (ce qui peut parfois prendre + d'un mois)