### PR TITLE
fix(config): change inclusion connect base url in env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ SHARED_SECRET_FOR_AGENTS_AUTH=S3cr3T
 AGENT_SIGNATURE_KEY="2cdf69c5-6405-41d3-aebd-b2a4e9de4457"
 
 # Inclusion Connect (local development values)
-INCLUSION_CONNECT_BASE_URL=http://0.0.0.0:8080/realms/local/protocol/openid-connect
+INCLUSION_CONNECT_BASE_URL=http://inclusion-connect-test.localhost
 INCLUSION_CONNECT_CLIENT_ID=local_inclusion_connect
 INCLUSION_CONNECT_CLIENT_SECRET=password
 


### PR DESCRIPTION
après les changements apportés par @Holist dans #2000 au fichier `config/initializers/content_security_policy.rb`, je modifie la valeur d'exemple de `INCLUSION_CONNECT_BASE_URL` pour qu'elle corresponde à la valeur de `env.test`