### PR TITLE
fix(configuration): Fix delete category configuration button

### DIFF
--- a/app/views/category_configurations/_category_configurations_list.html.erb
+++ b/app/views/category_configurations/_category_configurations_list.html.erb
@@ -13,7 +13,15 @@
         <%= link_to edit_organisation_category_configuration_path(organisation, category_configuration), data: { turbo: :false } do %>
           <button class="btn btn-blue mx-2">Modifier</button>
         <% end %>
-        <%= button_to organisation_category_configuration_path(organisation, category_configuration), method: :delete, form: { data: { turbo_confirm: "Attention", turbo_confirm_text_content: "Cette action va supprimer la category_configuration #{category_configuration.motif_category_name} pour votre organisation, êtes-vous sûr de vouloir continuer ?", turbo_confirm_text_action: "Supprimer" } } do %>
+        <%= link_to(
+              organisation_category_configuration_path(organisation, category_configuration),
+              data: {
+                turbo_confirm: "Attention",
+                turbo_confirm_text_content: "Cette action va supprimer la configuration pour la catégorie #{category_configuration.motif_category_name} pour votre organisation, êtes-vous sûr de vouloir continuer ?",
+                turbo_confirm_text_action: "Supprimer",
+                turbo_method: :delete
+              }
+            ) do %>
           <button class="btn btn-danger">Supprimer</button>
         <% end %>
       </div>


### PR DESCRIPTION
closes #2109 

Le lien de suppression d'une category configuration ne marchait parce que l'élément était un `button_to` et pas un `link_to` et donc le code js modale de confirmation n'arrivait pas à récupérer le lien de l'élément. 
Les data attributes étaient également pas déclarés correctement.

## Preview 📷 
![image](https://github.com/betagouv/rdv-insertion/assets/7602809/264c8a7a-ce16-4cfa-afe5-a9d8dac86929)
