### PR TITLE
feat(super_admin): Add warning message when adding ancient org

### DIFF
--- a/app/views/super_admins/organisations/new.html.erb
+++ b/app/views/super_admins/organisations/new.html.erb
@@ -38,7 +38,7 @@ to do the heavy lifting.
   <%= render "form", page: page %>
   <br/>
   <p>
-    ☢️ ATTENTION ☢️ !! Si l'organisation RDV SP à relier est ancienne, il faut contacter un développeur de l'équipe pour relier l'organisation à rdv-insertion
-    </p>
+    ☢️ ATTENTION ☢️ !! Si l'organisation RDV-SP est déjà utilisée avant de la lier à rdv-insertion, il faut contacter un développeur de l'équipe pour la créer sur rdv-insertion !
+  </p>
 </section>
 

--- a/app/views/super_admins/organisations/new.html.erb
+++ b/app/views/super_admins/organisations/new.html.erb
@@ -1,0 +1,44 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+# original file : https://github.com/thoughtbot/administrate/blob/main/app/views/administrate/application/new.html.erb
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) do %>
+  <%= t(
+    "administrate.actions.new_resource",
+    name: display_resource_name(page.resource_name).titleize
+  ) %>
+<% end %>
+
+<header class="main-content__header">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to t("administrate.actions.back"), :back, class: "button" %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "form", page: page %>
+  <br/>
+  <p>
+    ☢️ ATTENTION ☢️ !! Si l'organisation RDV SP à relier est ancienne, il faut contacter un développeur de l'équipe pour relier l'organisation à rdv-insertion
+    </p>
+</section>
+


### PR DESCRIPTION
Closes #1462 

J'ajoute un warning au moment de lier l'organisation à celle rdvsp pour faire attention aux cas où l'organisation rdvsp est ancienne:

![image](https://github.com/betagouv/rdv-insertion/assets/7602809/1c741ff0-0916-45e4-b44e-474290baaee2)
