### PR TITLE
feat(archive): Expire invitation if user archived in invitation orgs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -219,6 +219,10 @@ class User < ApplicationRecord
     archives.find { |a| a.organisation_id == organisation.id }
   end
 
+  def archived_in_organisation?(organisation)
+    !archive_in_organisation(organisation).nil?
+  end
+
   def tag_users_attributes=(attributes)
     attributes.map!(&:with_indifferent_access)
     attributes.uniq! { |attr| attr["tag_id"] }


### PR DESCRIPTION
closes #2569 

Dans #2184 il a été fait en sorte qu'après la création d'un archivage, on parcourait les invitations liant l'organisation et l'usager de cette archivage et on les invalidait si l'usager était **archivé dans toutes les organisations de l'invitation**.

Or il se peut que l'usager n'appartienne pas à une des orgas de l'invitation, et donc forcément il n'est pas archivé dans cette orga et donc l'invitation n'est pas invalidé. 
Ça crée notamment des problèmes au moment de la relance puisque l'usager [n'est pas actif dans une des orgas de l'invitation](https://github.com/gip-inclusion/rdv-insertion/blob/2ebdca2c272644e54e0773af2992d6dc5d386900/app/services/invitations/validate.rb#L69).

Pour résoudre ce problème, je change la condition pour invalider l'invitation si l'usager est **archivé dans les organisations qu'il partage avec l'invitation**.