### PR TITLE
matching(user): role and affiliation number set to lowest priority when matching user

### DIFF
--- a/app/services/users/find.rb
+++ b/app/services/users/find.rb
@@ -14,9 +14,9 @@ module Users
     def find_matching_user
       find_user_by_nir ||
         find_user_by_department_internal_id ||
-        find_user_by_role_and_affiliation_number ||
         find_user_by_email ||
-        find_user_by_phone_number
+        find_user_by_phone_number ||
+        find_user_by_role_and_affiliation_number
     end
 
     def find_user_by_nir


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/2813
J'ajoute également un test pour vérifier l'ordre de matching.