### PR TITLE
refactor(invitation): Change and refactor periodic invitations logic

### DIFF
--- a/app/jobs/send_periodic_invite_job.rb
+++ b/app/jobs/send_periodic_invite_job.rb
@@ -1,32 +1,41 @@
 class SendPeriodicInviteJob < ApplicationJob
-  def perform(invitation_id, category_configuration_id, format)
-    @invitation = Invitation.find(invitation_id)
-    @category_configuration = CategoryConfiguration.find(category_configuration_id)
+  def perform(previous_invitation_id, format)
+    @previous_invitation = Invitation.find(previous_invitation_id)
     @format = format
 
-    return if invitation_already_sent_today?
-    return unless creneaux_available_for_invitation?
+    return alert_non_eligible_periodic_invite unless @previous_invitation.should_be_sent_again_as_periodic_invite?
 
-    send_invitation
+    save_and_send_invitation if creneaux_available_for_invitation?
   end
 
   private
 
-  def send_invitation
-    new_invitation = @invitation.dup
-
-    new_invitation.format = @format
-    new_invitation.trigger = "periodic"
-    new_invitation.expires_at = @category_configuration.new_invitation_will_expire_at
-    new_invitation.organisations = @invitation.organisations
-    new_invitation.uuid = nil
-    new_invitation.save!
-
-    Invitations::SaveAndSend.call(invitation: new_invitation, check_creneaux_availability: false)
+  def save_and_send_invitation
+    call_service!(Invitations::SaveAndSend, invitation: new_invitation, check_creneaux_availability: false)
   end
 
+  def new_invitation
+    @new_invitation ||= Invitation.new(
+      trigger: "periodic",
+      user: @previous_invitation.user,
+      department: @previous_invitation.department,
+      organisations: @previous_invitation.organisations,
+      follow_up: @previous_invitation.follow_up,
+      format: @format,
+      help_phone_number: @previous_invitation.help_phone_number,
+      rdv_solidarites_lieu_id: @previous_invitation.rdv_solidarites_lieu_id,
+      link: @previous_invitation.link,
+      rdv_solidarites_token: @previous_invitation.rdv_solidarites_token,
+      expires_at: nil,
+      rdv_with_referents: @previous_invitation.rdv_with_referents
+    )
+  end
+
+  # Creneaux availability check is done here and not in the service Invitations::SaveAndSend because:
+  # - we don't want the service to fail if the creneaux are not available
+  # - we want to cache the result for similar invitations params to avoid calling the API too often
   def creneaux_available_for_invitation?
-    params = @invitation.link_params.symbolize_keys.slice(
+    params = @previous_invitation.link_params.symbolize_keys.slice(
       :motif_category_short_name,
       :departement,
       :organisation_ids,
@@ -34,16 +43,16 @@ class SendPeriodicInviteJob < ApplicationJob
     )
 
     Rails.cache.fetch("RetrieveCreneauAvailability/#{params.sort.to_h.to_query}", expires_in: 12.hours) do
-      @category_configuration.organisation.agents.first.with_rdv_solidarites_session do
+      @previous_invitation.organisations.active.first.agents.first.with_rdv_solidarites_session do
         RdvSolidaritesApi::RetrieveCreneauAvailability.call(link_params: params).creneau_availability
       end
     end
   end
 
-  def invitation_already_sent_today?
-    @invitation.follow_up.invitations
-               .where(format: @format)
-               .where("created_at > ?", 24.hours.ago)
-               .any?
+  def alert_non_eligible_periodic_invite
+    Sentry.capture_message(
+      "Invitation périodique non envoyée pour l'utilisateur #{@previous_invitation.user.id} en rapport à " \
+      "l'invitation #{@previous_invitation.id} car non éligible"
+    )
   end
 end

--- a/app/jobs/send_periodic_invites_job.rb
+++ b/app/jobs/send_periodic_invites_job.rb
@@ -5,7 +5,7 @@ class SendPeriodicInvitesJob < ApplicationJob
     FollowUp
       .joins(:invitations)
       .preload(invitations: [{ organisations: :category_configurations }, :user])
-      .where(invitations: Invitation.valid)
+      .where(invitations: Invitation.candidates_for_periodic_invite)
       .distinct
       .find_each do |follow_up|
       send_invite(follow_up)
@@ -14,32 +14,19 @@ class SendPeriodicInvitesJob < ApplicationJob
     notify_on_mattermost
   end
 
+  private
+
   def send_invite(follow_up)
     last_invitation = follow_up.last_invitation
-    category_configuration = last_invitation&.current_category_configuration
 
-    return if category_configuration.blank?
-    return unless should_send_periodic_invite?(last_invitation, category_configuration)
+    return unless last_invitation.should_be_sent_again_as_periodic_invite?
 
     @sent_invites_user_ids << last_invitation.user.id
 
     %w[email sms].each do |format|
       next unless last_invitation.user.can_be_invited_through?(format)
 
-      SendPeriodicInviteJob.perform_later(last_invitation.id, category_configuration.id, format)
-    end
-  end
-
-  def should_send_periodic_invite?(last_invitation, category_configuration)
-    if category_configuration.day_of_the_month_periodic_invites.present?
-      Time.zone.today.day == category_configuration.day_of_the_month_periodic_invites &&
-        # We don't send an invite the first month if the invitation was sent less than 10 days ago
-        last_invitation.sent_before?(10.days.ago)
-    elsif category_configuration.number_of_days_between_periodic_invites.present?
-      (Time.zone.today - last_invitation.created_at.to_date).to_i ==
-        category_configuration.number_of_days_between_periodic_invites
-    else
-      false
+      SendPeriodicInviteJob.perform_later(last_invitation.id, format)
     end
   end
 

--- a/app/models/category_configuration.rb
+++ b/app/models/category_configuration.rb
@@ -1,4 +1,6 @@
 class CategoryConfiguration < ApplicationRecord
+  include CategoryConfiguration::PeriodicInvites
+
   has_paper_trail
 
   belongs_to :motif_category
@@ -11,16 +13,13 @@ class CategoryConfiguration < ApplicationRecord
   validates :organisation, uniqueness: { scope: :motif_category,
                                          message: "a déjà une category_configuration pour cette catégorie de motif" }
   validate :minimum_invitation_duration,
-           :invitation_formats_validity,
-           :periodic_invites_can_be_activated
+           :invitation_formats_validity
 
   validates :email_to_notify_no_available_slots, :email_to_notify_rdv_changes,
             format: {
               with: /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}\z/,
               allow_blank: true
             }
-  validates :number_of_days_between_periodic_invites, numericality: { only_integer: true, greater_than: 13 },
-                                                      allow_nil: true
 
   validates :phone_number, phone_number: { allow_4_digits_numbers: true }
 
@@ -33,10 +32,6 @@ class CategoryConfiguration < ApplicationRecord
     attribute_names.select do |attribute_name|
       attribute_name.start_with?("template") && attribute_name.end_with?("override")
     end
-  end
-
-  def periodic_invites_activated?
-    day_of_the_month_periodic_invites.present? || number_of_days_between_periodic_invites.present?
   end
 
   def phone_number
@@ -53,17 +48,6 @@ class CategoryConfiguration < ApplicationRecord
     return if invitations_never_expire?
 
     number_of_days_before_invitations_expire.days.from_now
-  end
-
-  private
-
-  def periodic_invites_can_be_activated
-    return unless periodic_invites_activated? && invitations_expire?
-
-    errors.add(:base, "Les invitations périodiques ne peuvent pas être activées si " \
-                      "les liens des invitations ont une durée de validitée définie. " \
-                      "Veuillez retirer la limite de durée de validité des liens d'invitation, " \
-                      "ou désactiver les invitations périodiques.")
   end
 
   def minimum_invitation_duration

--- a/app/models/concerns/category_configuration/periodic_invites.rb
+++ b/app/models/concerns/category_configuration/periodic_invites.rb
@@ -1,0 +1,49 @@
+module CategoryConfiguration::PeriodicInvites
+  extend ActiveSupport::Concern
+
+  MINIMUM_DAYS_BETWEEN_PERIODIC_INVITES = 13
+  MAXIMUM_DAYS_BETWEEN_PERIODIC_INVITES = 45
+
+  included do
+    validate :periodic_invites_can_be_activated
+    validates :number_of_days_between_periodic_invites,
+              numericality: { only_integer: true, greater_than: MINIMUM_DAYS_BETWEEN_PERIODIC_INVITES,
+                              less_than: MAXIMUM_DAYS_BETWEEN_PERIODIC_INVITES },
+              allow_nil: true
+  end
+
+  class_methods do
+    def time_range_for_candidates_for_periodic_invite
+      MAXIMUM_DAYS_BETWEEN_PERIODIC_INVITES.days.ago...MINIMUM_DAYS_BETWEEN_PERIODIC_INVITES.days.ago
+    end
+  end
+
+  def periodic_invites_activated?
+    day_of_the_month_periodic_invites.present? || number_of_days_between_periodic_invites.present?
+  end
+
+  def periodic_invite_should_be_sent?(last_invitation_sent_at)
+    day_of_the_month_periodic_invites_is_today? ||
+      number_of_days_between_periodic_invites_reached_today?(last_invitation_sent_at)
+  end
+
+  private
+
+  def day_of_the_month_periodic_invites_is_today?
+    day_of_the_month_periodic_invites.present? && Time.zone.today.day == day_of_the_month_periodic_invites
+  end
+
+  def number_of_days_between_periodic_invites_reached_today?(last_invitation_sent_at)
+    number_of_days_between_periodic_invites.present? &&
+      (Time.zone.today - last_invitation_sent_at.to_date).to_i == number_of_days_between_periodic_invites
+  end
+
+  def periodic_invites_can_be_activated
+    return unless periodic_invites_activated? && invitations_expire?
+
+    errors.add(:base, "Les invitations périodiques ne peuvent pas être activées si " \
+                      "les liens des invitations ont une durée de validitée définie. " \
+                      "Veuillez retirer la limite de durée de validité des liens d'invitation, " \
+                      "ou désactiver les invitations périodiques.")
+  end
+end

--- a/spec/jobs/send_periodic_invites_job_spec.rb
+++ b/spec/jobs/send_periodic_invites_job_spec.rb
@@ -29,10 +29,8 @@ describe SendPeriodicInvitesJob do
       context "number_of_days_between_periodic_invites is set" do
         context "when renewing is due" do
           it "sends periodic invites" do
-            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                          "email")
-            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                          "sms")
+            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, "email")
+            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, "sms")
             subject
           end
         end
@@ -49,10 +47,8 @@ describe SendPeriodicInvitesJob do
           end
 
           it "does not send periodic invites" do
-            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                              "email")
-            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                              "sms")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "email")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "sms")
             subject
           end
         end
@@ -69,10 +65,8 @@ describe SendPeriodicInvitesJob do
 
         context "when renewing is due" do
           it "sends periodic invites" do
-            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                          "email")
-            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                          "sms")
+            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, "email")
+            expect(SendPeriodicInviteJob).to receive(:perform_later).with(invitation.id, "sms")
             subject
           end
         end
@@ -87,10 +81,8 @@ describe SendPeriodicInvitesJob do
           end
 
           it "sends periodic invites" do
-            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                              "email")
-            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                              "sms")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "email")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "sms")
             subject
           end
         end
@@ -105,10 +97,8 @@ describe SendPeriodicInvitesJob do
           end
 
           it "does not send periodic invites" do
-            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                              "email")
-            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                              "sms")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "email")
+            expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "sms")
             subject
           end
         end
@@ -126,10 +116,8 @@ describe SendPeriodicInvitesJob do
         end
 
         it "does not send periodic invites" do
-          expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                            "email")
-          expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                            "sms")
+          expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "email")
+          expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "sms")
           subject
         end
       end
@@ -145,10 +133,8 @@ describe SendPeriodicInvitesJob do
       end
 
       it "does not send periodic invites" do
-        expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                          "email")
-        expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, category_configuration.id,
-                                                                          "sms")
+        expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "email")
+        expect(SendPeriodicInviteJob).not_to receive(:perform_later).with(invitation.id, "sms")
         subject
       end
     end

--- a/spec/models/category_configuration_spec.rb
+++ b/spec/models/category_configuration_spec.rb
@@ -96,4 +96,38 @@ describe CategoryConfiguration do
       end
     end
   end
+
+  describe "#periodic_invite_should_be_sent?" do
+    context "day_of_the_month_periodic_invites is set" do
+      let(:category_configuration) do
+        build(:category_configuration, organisation: create(:organisation), day_of_the_month_periodic_invites: 15)
+      end
+
+      context "today is the 15th of the month" do
+        before { travel_to(Time.zone.local(2025, 6, 15, 12, 0, 0)) }
+
+        it { expect(category_configuration.periodic_invite_should_be_sent?(20.days.ago)).to eq(true) }
+      end
+
+      context "today is not the 15th of the month" do
+        before { travel_to(Time.zone.local(2025, 6, 16, 12, 0, 0)) }
+
+        it { expect(category_configuration.periodic_invite_should_be_sent?(20.days.ago)).to eq(false) }
+      end
+    end
+
+    context "number_of_days_between_periodic_invites is set" do
+      let(:category_configuration) do
+        build(:category_configuration, organisation: create(:organisation), number_of_days_between_periodic_invites: 15)
+      end
+
+      it "returns false if the invitation was sent the number of days between periodic invites" do
+        expect(category_configuration.periodic_invite_should_be_sent?(10.days.ago)).to eq(false)
+      end
+
+      it "returns true if the invitation was sent the number of days between periodic invites" do
+        expect(category_configuration.periodic_invite_should_be_sent?(15.days.ago)).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
En travaillant sur #2871 , je me suis rendu compte de plusieurs soucis sur la manière dont on traite les invitations périodiques que j'essaie de régler ici. 

## Duplication des invitations 

Comme expliqué sur le ticket, je n'appelle plus la méthode `#dup` sur les invitations et j'instancie directement l'invitation à envoyer. Cela permet de ne pas dupliquer par erreur des attributs que l'on ne voudrait pas dupliquer comme c'est le cas pour les attributs liés à la délivrance.

## Persistence des invitations

Je me suis rendu compte que l'invitation est persistée ici avant d'appeler le service `Invitations::SaveAndSend` qui est en charge de s'assurer que l'invitation n'est persistée que si elle a été envoyée. 
Cela veut dire que les invitations périodiques qui sont sauvegardée en base de donnée n'ont pas forcément été envoyées. Cette problématique est discutée [ici](https://mattermost.incubateur.net/betagouv/pl/36bxjaweq3rbdezbw3yzxopp7o).

## Itérer sur les invitations valide

Pour envoyer les invitations périodiques, nous itérions sur les invitations valide (dans le `SendPeriodicInvitesJob`) pour voir quelles invitations sont à renvoyer. Le problème c'est qu'une invitation est invalidée lorsqu'un rdv est pris. 
Cela veut dire qu'une "chaîne" d'invitations périodiques est brisée lorsqu'un rdv est pris, ce qui va à l'encontre de ce qui avait été pensé initialement pour cette feature. 
Je fais donc en sorte de ne plus itérer sur ces invitations valides seulement mais sur toutes les invitations qui ont été envoyées dans le time range qui fait qu'elles peuvent possiblement être renvoyées en tant qu'invitations périodiques.

## Refactor

J'en profite pour changer plusieurs choses dans la manière dont cette logique est mise en place: 

* Je délègue le fait de savoir si une invitation peut être envoyée en tant qu'invitation périodique au modèle `invitation` lui-même via une méthode d'instance `should_be_sent_again_as_periodic_invite?`, qui fait appel à une méthode `periodic_invite_should_be_sent?` de la `category_configuration` correspondante
* J'introduis un concern `CategoryConfiguration::PeriodicInvites` pour isoler le code liées aux invitations périodiques. Cela permettra de le supprimer plus facilement si on le voulait (voir partie suivante)
* Je fais en sorte de revérifier que l'invitation est éligible à être envoyée en tant qu'invitation périodique avant de l'envoyer

## La suite

Au vu des nombreux problèmes qu'a suscité cette feature (qui était mal définie dès le départ), du fait qu'on ait eu peu de remontées de tous ces bugs, et de sa faible utilisation (voir [ici](https://mattermost.incubateur.net/betagouv/pl/7hm6k5z3zb86pm8bafjz87esta)), il est très possible qu'on décide d'arrêter cette feature à l'avenir.