### PR TITLE
fix(anonymizer): deanonymize event field from table notifications

### DIFF
--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -256,9 +256,9 @@ tables:
       - motif_category_id
 
   - table_name: notifications
-    anonymized_column_names:
-      - event
+    anonymized_column_names: []
     non_anonymized_column_names:
+      - event
       - sent_at
       - created_at
       - delivery_status


### PR DESCRIPTION
Cette PR enlève le champ event des colonnes anonymizée dans metabase 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2944