### PR TITLE
fix(user): move save CTA

### DIFF
--- a/app/views/users/_user_form.html.erb
+++ b/app/views/users/_user_form.html.erb
@@ -5,9 +5,6 @@
         <button class="btn btn-blue-out" type="button">Annuler</button>
       <% end %>
     </div>
-    <div>
-      <button type="submit" class="btn btn-blue">Enregistrer</button>
-    </div>
   </div>
   <div class="mb-4">
     <div class="row d-flex justify-content-start flex-wrap">
@@ -30,6 +27,9 @@
       <%= render "common/attribute_input", f:f, attribute: :address %>
       <%= render "common/attribute_input", f:f, attribute: :phone_number %>
       <%= render "common/attribute_input", f:f, attribute: :rights_opening_date, as: :date, start_year: Date.today.year - 10 %>
+    </div>
+    <div class="row d-flex justify-content-end">
+      <button type="submit" class="btn btn-blue w-auto">Enregistrer</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Cette PR déplace le bouton enregistrer en bas à droite du formulaire pour être cohérent avec les autres formulaires. 

<img width="1647" height="905" alt="image" src="https://github.com/user-attachments/assets/1ae15bd5-b71b-45b2-bcba-d4407128fa5d" />

Fix https://github.com/gip-inclusion/rdv-insertion/issues/2967