### PR TITLE
fix(creneaux): make sure pending invitations are uniquely counted per follow_up_id

### DIFF
--- a/app/services/creneaux/store_number_of_creneaux_available.rb
+++ b/app/services/creneaux/store_number_of_creneaux_available.rb
@@ -39,7 +39,7 @@ module Creneaux
                 .where(follow_ups: { motif_category_id: category_configuration.motif_category_id })
                 .where(organisations: { id: category_configuration.organisation_id })
                 .valid
-                .count
+                .count("DISTINCT follow_up_id")
     end
   end
 end

--- a/spec/services/creneaux/store_number_of_creneaux_available_spec.rb
+++ b/spec/services/creneaux/store_number_of_creneaux_available_spec.rb
@@ -28,5 +28,16 @@ describe Creneaux::StoreNumberOfCreneauxAvailable, type: :service do
       subject
       expect(CreneauAvailability.last.number_of_pending_invitations).to eq(1)
     end
+
+    context "with multiple invitations of the same follow_up" do
+      let!(:invitation2) do
+        create(:invitation, user: user, follow_up: follow_up, organisations: [category_configuration.organisation])
+      end
+
+      it "stores the number of pending invitations" do
+        subject
+        expect(CreneauAvailability.last.number_of_pending_invitations).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Cette PR garanti l'unicité du comptage des invitations en attente destinées au centre de notifications. 
Le distinct(:follow_up_id) n'était pas suffisant car il n'était plus pris en compte à cause du JOIN, le fait de l'écrire directement dans le count permet de garantir sa prise en charge. 

Fix https://github.com/gip-inclusion/rdv-insertion/issues/3037