### PR TITLE
fix(mailer): `follow_up_statuses_filter` is missing in export mail

### DIFF
--- a/app/mailers/csv_export_mailer.rb
+++ b/app/mailers/csv_export_mailer.rb
@@ -10,7 +10,7 @@ class CsvExportMailer < ApplicationMailer
   private
 
   def set_request_filters
-    set_status_filter
+    set_follow_up_statuses_filter
     set_referent_filter
     set_creation_dates_filter
     set_invitation_dates_filter
@@ -29,8 +29,8 @@ class CsvExportMailer < ApplicationMailer
       end
   end
 
-  def set_status_filter
-    @status_filter = @request_params[:status]
+  def set_follow_up_statuses_filter
+    @follow_up_statuses_filter = @request_params[:follow_up_statuses]
   end
 
   def set_referent_filter

--- a/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
+++ b/app/views/mailers/csv_export_mailer/notify_csv_export.html.erb
@@ -10,8 +10,10 @@
   <% if @motif_category_filter %>
     <li><strong>Catégorie</strong>&nbsp;: <%= @motif_category_filter.name %></li>
   <% end %>
-  <% if @status_filter %>
-    <li><strong>Statut</strong>&nbsp;: <%= I18n.t("activerecord.attributes.follow_up.statuses.#{@status_filter}") %></li>
+  <% if @follow_up_statuses_filter %>
+    <li><strong><%= @follow_up_statuses_filter.size > 1 ? "Statuts" : "Statut" %></strong>&nbsp;:
+      <%= @follow_up_statuses_filter.map { |status| I18n.t("activerecord.attributes.follow_up.statuses.#{status}") }.join(", ") %>
+    </li>
   <% end %>
   <% if @referent_filter %>
     <li><strong>Référent</strong>&nbsp;: <%= @referent_filter.to_s %></li>

--- a/spec/mailers/csv_export_mailer_spec.rb
+++ b/spec/mailers/csv_export_mailer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe CsvExportMailer do
           action_required: "true", first_invitation_date_before: "15-04-2024",
           last_invitation_date_after: "01-01-2024", last_invitation_date_before: "02-04-2024",
           motif_category_id: motif_category.id.to_s,
-          referent_id: agent.id.to_s, search_query: "Bacri", status: "invitation_pending",
+          referent_id: agent.id.to_s, search_query: "Bacri", follow_up_statuses: ["invitation_pending"],
           tag_ids: [tag.id.to_s], organisation_id: organisation1.id.to_s
         }
       end


### PR DESCRIPTION
close https://github.com/gip-inclusion/rdv-insertion/issues/3060

Ce bug a été ajouté dans cette PR https://github.com/gip-inclusion/rdv-insertion/pull/2861/files
Le nom du paramètre a changé mais le changement n'avait pas été appliqué dans le mailer d'export.

Les autres filtres sont bien mentionnés dans le mail d'export et fonctionnent correctement.
