### PR TITLE
fix(app): Do not prefetch batch actions invite

### DIFF
--- a/app/views/users/_users_list_tabs.html.erb
+++ b/app/views/users/_users_list_tabs.html.erb
@@ -34,7 +34,7 @@
         <%= render "csv_export_button" %>
       <% end %>
       <% if @current_category_configuration.present? %>
-        <%= link_to(new_structure_batch_action_path(motif_category_id: @current_category_configuration.motif_category_id), class: "btn btn-blue-out", id: "rdvi_index-nav_send-invitations-uninvited") do %>
+        <%= link_to(new_structure_batch_action_path(motif_category_id: @current_category_configuration.motif_category_id), class: "btn btn-blue-out", id: "rdvi_index-nav_send-invitations-uninvited", data: { turbo_prefetch: "false" }) do %>
           <i class="ri-send-plane-fill"></i>
           Inviter les non-invités
         <% end %>


### PR DESCRIPTION
Le bouton "Inviter les non invités" est facilement accessible sur la page index, ce qui fait que le prefetch automatique effectué par rails au survol du lien peut être activé facilement. Comme l'action est coûteuse en terme de performance, je désactive le prefetch pour ne pas calculer le rendu pour rien lorsque le bouton n'est finalement pas cliqué.