### PR TITLE
feat(app): Partition users by department

### DIFF
--- a/app/jobs/users/partition_all_users_job.rb
+++ b/app/jobs/users/partition_all_users_job.rb
@@ -1,0 +1,15 @@
+module Users
+  class PartitionAllUsersJob < ApplicationJob
+    def perform
+      SlackClient.send_to_private_channel(
+        "🚀 Démarrage de la partition des usagers par département (#{User.active.count} usagers)"
+      )
+
+      User.active.find_each do |user|
+        Users::PartitionSingleUserJob.perform_later(user.id)
+      end
+
+      SlackClient.send_to_private_channel("✅ #{User.count} jobs de partition enqueués")
+    end
+  end
+end

--- a/app/jobs/users/partition_single_user_job.rb
+++ b/app/jobs/users/partition_single_user_job.rb
@@ -1,0 +1,100 @@
+module Users
+  class PartitionSingleUserJob < ApplicationJob
+    LOG_PREFIX = "[PartitionSingleUserJob]".freeze
+
+    def perform(user_id)
+      @user = User.find(user_id)
+
+      return handle_no_department if @user.departments.none?
+      return handle_single_department if @user.departments.one?
+
+      handle_multiple_departments
+    end
+
+    private
+
+    def handle_no_department
+      skip_with_warning("#{LOG_PREFIX} usager #{@user.id} ignoré : aucun département associé")
+    end
+
+    def handle_single_department
+      @user.update_column(:department_id, @user.departments.first.id)
+      Rails.logger.info("#{LOG_PREFIX} ✅ usager #{@user.id} assigné au département #{@user.departments.first.number}")
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def handle_multiple_departments
+      Rails.logger.info(
+        "#{LOG_PREFIX} 🔍 usager #{@user.id} dans les départements " \
+        "#{@user.departments.map(&:number).join(', ')}, principal : #{primary_department.number}"
+      )
+
+      if upcoming_rdv_in_secondary_orgs?
+        skip_with_warning(
+          "#{LOG_PREFIX} usager #{@user.id} ignoré : rdv à venir dans les orgas secondaires " \
+          "#{secondary_organisations.map(&:id)} (depts #{secondary_organisations.map do |o|
+            o.department.number
+          end.uniq.join(', ')})"
+        )
+        return
+      end
+
+      PaperTrail.request(whodunnit: self.class.name) { remove_from_secondary_organisations }
+      @user.update_column(:department_id, primary_department.id)
+      notify(
+        "✅ #{LOG_PREFIX} usager #{@user.id} partitionné vers le département #{primary_department.number}, " \
+        "retiré des orgas #{secondary_organisations.map(&:id)}"
+      )
+    end
+    # rubocop:enable Metrics/AbcSize
+
+    def primary_department
+      @primary_department ||= department_from_activity(most_recent_activity)
+    end
+
+    def secondary_organisations
+      @secondary_organisations ||= @user.organisations.reject { |o| o.department_id == primary_department.id }
+    end
+
+    def most_recent_activity
+      [
+        UsersOrganisation.where(user: @user).order(created_at: :desc).first,
+        Participation.where(user: @user).order(created_at: :desc).first,
+        Invitation.where(user: @user).order(created_at: :desc).first
+      ].compact.max_by(&:created_at)
+    end
+
+    def department_from_activity(activity)
+      case activity
+      when UsersOrganisation then activity.organisation.department
+      when Participation then activity.rdv.organisation.department
+      when Invitation then Department.find(activity.department_id)
+      end
+    end
+
+    def upcoming_rdv_in_secondary_orgs?
+      Rdv.not_cancelled
+         .future
+         .joins(:participations, :organisation)
+         .exists?(participations: { user: @user }, organisations: { id: secondary_organisations })
+    end
+
+    def remove_from_secondary_organisations
+      secondary_organisations.each do |org|
+        Rails.logger.info("#{LOG_PREFIX} 🗑️  usager #{@user.id} retiré de l'orga #{org.id} (#{org.name})")
+        call_service!(Users::RemoveFromOrganisation, user: @user, organisation: org)
+      end
+    end
+
+    def skip_with_warning(message)
+      Rails.logger.warn(message)
+      SlackClient.send_to_private_channel("⚠️ #{message}")
+      Sentry.capture_message(message, level: :warning, extra: { user_id: @user.id })
+    end
+
+    def notify(message)
+      Rails.logger.info(message)
+      SlackClient.send_to_private_channel(message)
+    end
+  end
+end

--- a/app/models/users_organisation.rb
+++ b/app/models/users_organisation.rb
@@ -1,4 +1,6 @@
 class UsersOrganisation < ApplicationRecord
+  has_paper_trail
+
   belongs_to :user
   belongs_to :organisation
 

--- a/db/migrate/20260309120000_re_add_department_id_to_users.rb
+++ b/db/migrate/20260309120000_re_add_department_id_to_users.rb
@@ -1,0 +1,5 @@
+class ReAddDepartmentIdToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :users, :department, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_11_105902) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_09_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -656,6 +656,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_105902) do
     t.string "created_from_structure_type"
     t.string "created_through"
     t.datetime "deleted_at"
+    t.bigint "department_id"
     t.string "department_internal_id"
     t.string "email"
     t.string "first_name"
@@ -673,6 +674,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_105902) do
     t.datetime "updated_at", null: false
     t.index ["created_from_structure_type", "created_from_structure_id"], name: "index_users_on_created_from_structure"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
+    t.index ["department_id"], name: "index_users_on_department_id"
     t.index ["department_internal_id"], name: "index_users_on_department_internal_id"
     t.index ["email"], name: "index_users_on_email"
     t.index ["nir"], name: "index_users_on_nir"
@@ -780,5 +782,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_11_105902) do
   add_foreign_key "user_list_upload_user_save_attempts", "users"
   add_foreign_key "user_list_uploads", "agents"
   add_foreign_key "user_list_uploads", "category_configurations"
+  add_foreign_key "users", "departments"
   add_foreign_key "webhook_receipts", "webhook_endpoints"
 end

--- a/lib/tasks/users/partition_users_by_department.rake
+++ b/lib/tasks/users/partition_users_by_department.rake
@@ -1,0 +1,6 @@
+namespace :users do
+  desc "Partition tous les usagers par département en leur assignant un department_id"
+  task partition_by_department: :environment do
+    Users::PartitionAllUsersJob.perform_later
+  end
+end

--- a/spec/jobs/users/partition_single_user_job_spec.rb
+++ b/spec/jobs/users/partition_single_user_job_spec.rb
@@ -1,0 +1,146 @@
+describe Users::PartitionSingleUserJob do
+  subject { described_class.new.perform(user.id) }
+
+  let!(:department1) { create(:department) }
+  let!(:department2) { create(:department) }
+  let!(:org1) { create(:organisation, department: department1) }
+  let!(:org2) { create(:organisation, department: department2) }
+
+  before do
+    allow(SlackClient).to receive(:send_to_private_channel)
+    allow(Users::RemoveFromOrganisation).to receive(:call)
+      .and_return(OpenStruct.new(success?: true))
+  end
+
+  context "when the user has no department" do
+    let!(:user) { create(:user, organisations: []) }
+
+    it "does not assign a department_id" do
+      expect { subject }.not_to(change { user.reload.department_id })
+    end
+
+    it "sends a slack warning mentioning the user id" do
+      expect(SlackClient).to receive(:send_to_private_channel).with(include(user.id.to_s))
+      subject
+    end
+  end
+
+  context "when the user belongs to a single department" do
+    let!(:user) do
+      create(:user, organisations: [org1]).tap { |u| u.update_column(:department_id, nil) }
+    end
+
+    it "assigns the department_id" do
+      expect { subject }.to change { user.reload.department_id }.to(department1.id)
+    end
+
+    it "does not call RemoveFromOrganisation" do
+      expect(Users::RemoveFromOrganisation).not_to receive(:call)
+      subject
+    end
+  end
+
+  context "when the user belongs to multiple departments" do
+    let!(:user) do
+      create(:user, organisations: [org1]).tap { |u| u.update_column(:department_id, nil) }
+    end
+
+    before do
+      # Bypass cross-department validation to simulate legacy data
+      UsersOrganisation.new(user:, organisation: org2).tap { |uo| uo.save!(validate: false) }
+      UsersOrganisation.where(user:, organisation: org2).update_all(created_at: 1.month.ago)
+    end
+
+    context "when there is no upcoming rdv in secondary orgs" do
+      context "when the most recent activity is a users_organisation in department1" do
+        before { UsersOrganisation.where(user:, organisation: org1).update_all(created_at: 2.days.ago) }
+
+        it "assigns department1 as the department" do
+          expect { subject }.to change { user.reload.department_id }.to(department1.id)
+        end
+
+        it "removes the user from the secondary organisation" do
+          expect(Users::RemoveFromOrganisation).to receive(:call).with(user:, organisation: org2)
+          subject
+        end
+
+        it "sends a slack notification mentioning the user id, department number and removed org id" do
+          expect(SlackClient).to receive(:send_to_private_channel)
+            .with(include(user.id.to_s, department1.number, org2.id.to_s))
+          subject
+        end
+      end
+
+      context "when the most recent activity is a participation in department2" do
+        before do
+          UsersOrganisation.where(user:).update_all(created_at: 1.month.ago)
+          rdv = create(:rdv, organisation: org2)
+          create(:participation, user:, rdv:, created_at: 1.day.ago)
+        end
+
+        it "assigns department2 as the department" do
+          expect { subject }.to change { user.reload.department_id }.to(department2.id)
+        end
+
+        it "removes the user from the secondary organisation" do
+          expect(Users::RemoveFromOrganisation).to receive(:call).with(user:, organisation: org1)
+          subject
+        end
+      end
+
+      context "when the most recent activity is an invitation in department1" do
+        before do
+          UsersOrganisation.where(user:).update_all(created_at: 1.month.ago)
+          create(:invitation, user:, department: department1, created_at: 1.day.ago)
+        end
+
+        it "assigns department1 as the department" do
+          expect { subject }.to change { user.reload.department_id }.to(department1.id)
+        end
+      end
+
+      context "when RemoveFromOrganisation fails" do
+        before do
+          UsersOrganisation.where(user:, organisation: org1).update_all(created_at: 2.days.ago)
+          allow(Users::RemoveFromOrganisation).to receive(:call)
+            .and_return(OpenStruct.new(success?: false, errors: ["some error"]))
+        end
+
+        it "raises an error" do
+          expect { subject }.to raise_error(ApplicationJob::FailedServiceError)
+        end
+
+        it "does not assign a department_id" do
+          expect do
+            subject
+          rescue StandardError
+            nil
+          end.not_to(change { user.reload.department_id })
+        end
+      end
+    end
+
+    context "when there is an upcoming rdv in a secondary org" do
+      before do
+        UsersOrganisation.where(user:, organisation: org1).update_all(created_at: 2.days.ago)
+        rdv = create(:rdv, organisation: org2, starts_at: 1.week.from_now)
+        create(:participation, user:, rdv:, created_at: 3.days.ago)
+      end
+
+      it "does not assign a department_id" do
+        expect { subject }.not_to(change { user.reload.department_id })
+      end
+
+      it "does not call RemoveFromOrganisation" do
+        expect(Users::RemoveFromOrganisation).not_to receive(:call)
+        subject
+      end
+
+      it "sends a slack warning mentioning the user id and secondary org id" do
+        expect(SlackClient).to receive(:send_to_private_channel)
+          .with(include(user.id.to_s, org2.id.to_s))
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/R-entrant-D-m-nagement-2-2-Rattacher-chaque-usager-un-d-partement-3105f321b6048018b262fb2cef30771f?source=copy_link

Je reprends les travaux entamés dans #2848 et j'adapte un peu la logique. 
Cette PR contient:
* L'ajout de la fk `department_id` à la table users
* Un script qui parcours tous les usagers et leur assigne un département:
  * Quand il y a qu'un seul département on met la référence au département en question
  * Quand il y en a plusieurs, on set comme département celui où il a eu la dernière activité (invitation, rdv ou ajout dans l'orga) et on l'enlève des anciennes orgas. Cela devrait concerner moins de 1% de nos usagers. S'il a un rdv à venir dans deux départements différents on met une alerte et on ne fait rien (ça concerne un seul usager aujourd'hui)
  * Quand il n'a pas d'organisations on ne fait rien non plus et on alerte. Je pense qu'il faudra au préalable supprimer les usagers qui n'ont pas d'organisations assignés (concerne principalement les soft deletés) qui n'ont pas d'utilité à être gardés, pour que tous les usagers aient un département assigné.
 * Des tests sur ce script

Si cette PR est déployé, il faudra qu'elle le soit dans une heure creuse pour que le scripte puisse être lancé avant de merger la PR suivante.
