### PR TITLE
fix(model): Change identifier validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,7 @@ class User < ApplicationRecord
             uniqueness: true, allow_nil: true, unless: :skip_uniqueness_validations
 
   validates :phone_number, phone_number: true
-  validate :identifier_must_be_present, unless: :imported_from_rdv_solidarites?
+  validate :identifier_must_be_present, on: :create, unless: :imported_from_rdv_solidarites?
 
   delegate :name, :number, to: :department, prefix: true
 

--- a/app/services/users/save.rb
+++ b/app/services/users/save.rb
@@ -16,7 +16,7 @@ module Users
       User.with_advisory_lock "saving_user_#{lock_key}" do
         User.transaction do
           assign_organisation if @organisation.present?
-          validate_user_department_uniqueness!
+          validate_user!
           save_record!(@user)
           push_user_to_rdv_solidarites
         end
@@ -31,8 +31,8 @@ module Users
       @user.organisations = (@user.organisations.to_a + [@organisation]).uniq
     end
 
-    def validate_user_department_uniqueness!
-      call_service!(Users::ValidateDepartmentUniqueness, user: @user, organisation: @organisation)
+    def validate_user!
+      call_service!(Users::Validate, user: @user, organisation: @organisation)
     end
 
     def push_user_to_rdv_solidarites

--- a/app/services/users/validate.rb
+++ b/app/services/users/validate.rb
@@ -1,5 +1,5 @@
 module Users
-  class ValidateDepartmentUniqueness < BaseService
+  class Validate < BaseService
     def initialize(user:, organisation: nil)
       @user = user
       @organisation = organisation
@@ -8,6 +8,7 @@ module Users
     def call
       validate_department_uniqueness_of(:nir, @user.nir)
       validate_department_uniqueness_of(:france_travail_id, @user.france_travail_id)
+      validate_identifier_not_removed if @user.persisted?
     end
 
     private
@@ -37,6 +38,29 @@ module Users
         ids << @organisation.department_id if @organisation
         ids.uniq
       end
+    end
+
+    def validate_identifier_not_removed
+      return unless removing_all_identifiers?
+
+      fail!(
+        "Impossible de retirer tous les identifiants (NIR, email, numéro de tel, ID interne, numéro CAF/rôle) " \
+        "d'un usager"
+      )
+    end
+
+    def removing_all_identifiers?
+      !identifiable? && previously_identifiable?
+    end
+
+    def previously_identifiable?
+      %i[nir department_internal_id email phone_number].any? { |attr| @user.attribute_in_database(attr).present? } ||
+        (@user.attribute_in_database(:affiliation_number).present? && @user.attribute_in_database(:role).present?)
+    end
+
+    def identifiable?
+      @user.nir? || @user.department_internal_id? || @user.email? || @user.phone_number? ||
+        (@user.affiliation_number? && @user.role?)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -90,6 +90,18 @@ describe User do
 
       it { expect(user).to be_valid }
     end
+
+    context "when the user is persisted and has no identifier" do
+      let(:user) do
+        create(:user, :skip_validate, nir: nil, department_internal_id: nil, email: nil, phone_number: nil,
+                                      affiliation_number: nil, role: nil)
+      end
+
+      it "is valid on update" do
+        user.first_name = "Updated"
+        expect(user).to be_valid
+      end
+    end
   end
 
   describe "#search_by_text" do

--- a/spec/services/users/save_spec.rb
+++ b/spec/services/users/save_spec.rb
@@ -16,7 +16,7 @@ describe Users::Save, type: :service do
   describe "#call" do
     before do
       allow(user).to receive(:save).and_return(true)
-      allow(Users::ValidateDepartmentUniqueness).to receive(:call)
+      allow(Users::Validate).to receive(:call)
         .and_return(OpenStruct.new(success?: true))
       allow(Users::PushToRdvSolidarites).to receive(:call)
         .and_return(OpenStruct.new(success?: true))
@@ -40,8 +40,8 @@ describe Users::Save, type: :service do
       subject
     end
 
-    it "validates the user's uniqueness in the department" do
-      expect(Users::ValidateDepartmentUniqueness).to receive(:call)
+    it "validates the user" do
+      expect(Users::Validate).to receive(:call)
         .with(user: user, organisation: organisation)
       subject
     end
@@ -108,7 +108,7 @@ describe Users::Save, type: :service do
 
     context "when the validation service fails" do
       before do
-        allow(Users::ValidateDepartmentUniqueness).to receive(:call)
+        allow(Users::Validate).to receive(:call)
           .with(user: user, organisation: organisation)
           .and_return(OpenStruct.new(success?: false, errors: ["invalid user"]))
       end

--- a/spec/services/users/validate_spec.rb
+++ b/spec/services/users/validate_spec.rb
@@ -1,4 +1,4 @@
-describe Users::ValidateDepartmentUniqueness, type: :service do
+describe Users::Validate, type: :service do
   subject { described_class.call(user: user, organisation: organisation) }
 
   let!(:department) { create(:department) }
@@ -67,6 +67,64 @@ describe Users::ValidateDepartmentUniqueness, type: :service do
             "Un usager avec le même Numéro de sécurité sociale se trouve au sein du département: [1395]"
           )
         end
+      end
+    end
+
+    context "when updating a persisted user" do
+      context "when the user previously had an email and it gets removed" do
+        let!(:user) do
+          create(:user, email: "test@example.com", nir: nil, department_internal_id: nil,
+                        phone_number: nil, affiliation_number: nil, organisations: [organisation])
+        end
+
+        before { user.email = nil }
+
+        it("is a failure") { is_a_failure }
+
+        it "returns an error" do
+          expect(subject.errors).to include("Impossible de retirer tous les identifiants d'un usager")
+        end
+      end
+
+      context "when the user previously had affiliation_number + role and role gets removed" do
+        let!(:user) do
+          create(:user, affiliation_number: "1234", role: "demandeur", nir: nil, department_internal_id: nil,
+                        email: nil, phone_number: nil, organisations: [organisation])
+        end
+
+        before { user.role = nil }
+
+        it("is a failure") { is_a_failure }
+
+        it "returns an error" do
+          expect(subject.errors).to include("Impossible de retirer tous les identifiants d'un usager")
+        end
+      end
+
+      context "when the user replaces one identifier with another" do
+        let!(:user) do
+          create(:user, email: "test@example.com", nir: nil, department_internal_id: nil,
+                        phone_number: nil, affiliation_number: nil, organisations: [organisation])
+        end
+
+        before do
+          user.email = nil
+          user.phone_number = "+33612345678"
+        end
+
+        it("is a success") { is_a_success }
+      end
+
+      context "when the user never had any identifier" do
+        let!(:user) do
+          create(
+            :user, :skip_validate,
+            nir: nil, department_internal_id: nil, email: nil, phone_number: nil, affiliation_number: nil,
+            role: nil, organisations: [organisation]
+          )
+        end
+
+        it("is a success") { is_a_success }
       end
     end
   end

--- a/spec/services/users/validate_spec.rb
+++ b/spec/services/users/validate_spec.rb
@@ -82,7 +82,10 @@ describe Users::Validate, type: :service do
         it("is a failure") { is_a_failure }
 
         it "returns an error" do
-          expect(subject.errors).to include("Impossible de retirer tous les identifiants d'un usager")
+          expect(subject.errors).to include(
+            "Impossible de retirer tous les identifiants (NIR, email, numéro de tel, ID interne, numéro CAF/rôle) " \
+            "d'un usager"
+          )
         end
       end
 
@@ -97,7 +100,10 @@ describe Users::Validate, type: :service do
         it("is a failure") { is_a_failure }
 
         it "returns an error" do
-          expect(subject.errors).to include("Impossible de retirer tous les identifiants d'un usager")
+          expect(subject.errors).to include(
+            "Impossible de retirer tous les identifiants (NIR, email, numéro de tel, ID interne, numéro CAF/rôle) " \
+            "d'un usager"
+          )
         end
       end
 


### PR DESCRIPTION
## Contexte

Suite au déplacement de la validation de la présence d'un identifiant à l'intérieur du model `User` dans #3242, on a plusieurs problèmes:
* Des usagers provenant de RDV-S ne pouvaient pas être créés, ce qu'on a corrigé dans #3252 
* On a une base d'usagers existant qui ne répondent pas à ces critères, ce qui fait qu'ils sont considérés comme invalides. Cela empêche certaines actions d'aboutir comme https://www.rdv-insertion.fr/sidekiq/retries/1774306249.7862487-706bea814c37a135d579f948. Cela peut s'expliquer par le fait que ces validations n'ont pas toujours existé et que de toutes façons les identifiants peuvent être nulifiés depuis RDV-SP

## Solution

Pour répondre à ces problèmes et ne pas dégrader l'UX en bloquant toute action sur des usagers existants n'ayant pas d'identifiants, j'ai décidé de: 
* Appliquer la validation au niveau du model qu'à la création d'usager. Ainsi on s'assure que les nouveaux usagers ont bien un identifiant (à part ceux importés depuis rdv-s)
* Appliquer une validation au niveau du service `Users::Validate` (je renomme le service `Users::ValidateDepartmentUniqueness` existant) pour s'assurer qu'on ne puisse pas enlever tous les identifiants d'un usager existant qui en possède déjà

Ainsi on s'assure au maximum la présence d'identifiants sur les usagers sans trop dégrader l'UX pour les utilisateurs.

