### PR TITLE
Scalingo(cron): add auto restarter cron everyday at 4am

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "command": "0 4 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
+    }
+  ]
+}

--- a/cron.json
+++ b/cron.json
@@ -1,7 +1,8 @@
 {
   "jobs": [
     {
-      "command": "0 4 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart"
+      "command": "0 4 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart",
+      "description": "Restart the app once a day at 4am to prevent memory leaks"
     }
   ]
 }


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Tech-Investiguer-les-fuites-de-m-moire-en-prod-3045f321b60480038269dfcee328dad9

Je me base sur ce qu'à fait rdvsp dans cette PR : 
https://github.com/betagouv/rdv-service-public/pull/5972

J'ai ajouté un collaborateur limité dans scalingo : rdv-insertion.cron@inclusion.gouv.fr
Il s'agit d'un groupe google avec redirection vers le mail de @aminedhobb et moi même.
J'utilise sa clé d'api stockée dans la variable d'env `RESTARTER_BOT_API_TOKEN`
Si la variable existe le cron redémarre tous les process de l'app à 4h.