### PR TITLE
api(ft): resend ft webhooks when user became retrievable in FT after an update

### DIFF
--- a/app/jobs/outgoing_webhooks/france_travail/send_pending_participations_job.rb
+++ b/app/jobs/outgoing_webhooks/france_travail/send_pending_participations_job.rb
@@ -1,0 +1,15 @@
+module OutgoingWebhooks
+  module FranceTravail
+    class SendPendingParticipationsJob < ApplicationJob
+      def perform(user_id:)
+        user = User.find(user_id)
+
+        user.participations.where(france_travail_id: nil).find_each do |participation|
+          next unless participation.eligible_for_france_travail_webhook?
+
+          participation.send_update_to_france_travail_if_eligible
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/participation/france_travail_webhooks.rb
+++ b/app/models/concerns/participation/france_travail_webhooks.rb
@@ -8,7 +8,7 @@ module Participation::FranceTravailWebhooks
     before_destroy :send_france_travail_delete_webhook, if: :france_travail_webhook_updatable?
   end
 
-  def send_update_to_france_travail_if_eligible(timestamp)
+  def send_update_to_france_travail_if_eligible(timestamp = updated_at)
     send_france_travail_upsert_webhook(timestamp) if eligible_for_france_travail_webhook?
   end
 

--- a/app/models/concerns/user/france_travail_webhooks.rb
+++ b/app/models/concerns/user/france_travail_webhooks.rb
@@ -3,7 +3,7 @@ module User::FranceTravailWebhooks
 
   included do
     after_commit :send_pending_participations_to_france_travail, on: :update,
-                                                                 if: :became_retrievable_in_france_travail?
+                                                                 if: :retrievable_in_france_travail_and_attributes_changed?
   end
 
   def retrievable_in_france_travail?
@@ -20,16 +20,12 @@ module User::FranceTravailWebhooks
 
   private
 
-  def became_retrievable_in_france_travail?
+  def retrievable_in_france_travail_and_attributes_changed?
     retrievable_in_france_travail? &&
       (saved_change_to_nir? || saved_change_to_france_travail_id? || saved_change_to_birth_date?)
   end
 
   def send_pending_participations_to_france_travail
-    participations.where(france_travail_id: nil).find_each do |participation|
-      next unless participation.eligible_for_france_travail_webhook?
-
-      participation.send_update_to_france_travail_if_eligible(Time.current)
-    end
+    OutgoingWebhooks::FranceTravail::SendPendingParticipationsJob.perform_later(user_id: id)
   end
 end

--- a/app/models/concerns/user/france_travail_webhooks.rb
+++ b/app/models/concerns/user/france_travail_webhooks.rb
@@ -2,8 +2,9 @@ module User::FranceTravailWebhooks
   extend ActiveSupport::Concern
 
   included do
-    after_commit :send_pending_participations_to_france_travail, on: :update,
-                                                                 if: :retrievable_in_france_travail_and_attributes_changed?
+    after_commit :send_pending_participations_to_france_travail,
+                 on: :update,
+                 if: :retrievable_in_france_travail_and_attributes_changed?
   end
 
   def retrievable_in_france_travail?

--- a/app/models/concerns/user/france_travail_webhooks.rb
+++ b/app/models/concerns/user/france_travail_webhooks.rb
@@ -1,0 +1,35 @@
+module User::FranceTravailWebhooks
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :send_pending_participations_to_france_travail, on: :update,
+                                                                 if: :became_retrievable_in_france_travail?
+  end
+
+  def retrievable_in_france_travail?
+    nir_and_birth_date? || valid_france_travail_id?
+  end
+
+  def valid_france_travail_id?
+    france_travail_id? && france_travail_id.match?(/\A\d{11}\z/)
+  end
+
+  def nir_and_birth_date?
+    birth_date? && nir?
+  end
+
+  private
+
+  def became_retrievable_in_france_travail?
+    retrievable_in_france_travail? &&
+      (saved_change_to_nir? || saved_change_to_france_travail_id? || saved_change_to_birth_date?)
+  end
+
+  def send_pending_participations_to_france_travail
+    participations.where(france_travail_id: nil).find_each do |participation|
+      next unless participation.eligible_for_france_travail_webhook?
+
+      participation.send_update_to_france_travail_if_eligible(Time.current)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
   include User::Referents
   include User::CreationOrigin
   include User::Geocodable
+  include User::FranceTravailWebhooks
 
   attr_accessor :skip_uniqueness_validations
 
@@ -230,19 +231,6 @@ class User < ApplicationRecord
     attributes.reject! { |attr| tag_users.any? { |tu| tu.tag_id == attr["tag_id"] } }
 
     super
-  end
-
-  def retrievable_in_france_travail?
-    nir_and_birth_date? || valid_france_travail_id?
-  end
-
-  def valid_france_travail_id?
-    # Valid France Travail ID is exactly 11 digits
-    france_travail_id? && france_travail_id.match?(/\A\d{11}\z/)
-  end
-
-  def nir_and_birth_date?
-    birth_date? && nir?
   end
 
   private

--- a/spec/jobs/outgoing_webhooks/france_travail/send_pending_participations_job_spec.rb
+++ b/spec/jobs/outgoing_webhooks/france_travail/send_pending_participations_job_spec.rb
@@ -1,0 +1,53 @@
+describe OutgoingWebhooks::FranceTravail::SendPendingParticipationsJob do
+  subject { described_class.new.perform(user_id: user.id) }
+
+  let!(:department) { create(:department) }
+  let!(:organisation) { create(:organisation, department: department) }
+  let!(:user) { create(:user, :with_valid_nir, organisations: [organisation]) }
+  let!(:follow_up) { create(:follow_up, user: user) }
+  let!(:rdv) { create(:rdv, organisation: organisation) }
+  let!(:participation) { create(:participation, user: user, rdv: rdv, follow_up: follow_up) }
+
+  before do
+    allow(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
+  end
+
+  context "when participation has no france_travail_id and is eligible" do
+    it "enqueues UpsertParticipationJob" do
+      expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
+        .with(hash_including(participation_id: participation.id))
+
+      subject
+    end
+  end
+
+  context "when participation already has a france_travail_id" do
+    before { participation.update_column(:france_travail_id, "ft-123") }
+
+    it "does not enqueue UpsertParticipationJob" do
+      expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+      subject
+    end
+  end
+
+  context "when organisation is not eligible" do
+    before { organisation.update_column(:organisation_type, "france_travail") }
+
+    it "does not enqueue UpsertParticipationJob" do
+      expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+      subject
+    end
+  end
+
+  context "when department has disable_ft_webhooks" do
+    before { department.update_column(:disable_ft_webhooks, true) }
+
+    it "does not enqueue UpsertParticipationJob" do
+      expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+      subject
+    end
+  end
+end

--- a/spec/models/concerns/user/france_travail_webhooks_spec.rb
+++ b/spec/models/concerns/user/france_travail_webhooks_spec.rb
@@ -1,0 +1,91 @@
+describe User::FranceTravailWebhooks, type: :concern do
+  describe "#send_pending_participations_to_france_travail" do
+    let!(:department) { create(:department) }
+    let!(:organisation) { create(:organisation, department: department) }
+    let!(:user) { create(:user, organisations: [organisation]) }
+    let!(:follow_up) { create(:follow_up, user: user) }
+    let!(:rdv) { create(:rdv, organisation: organisation) }
+    let!(:participation) { create(:participation, user: user, rdv: rdv, follow_up: follow_up) }
+
+    context "when nir is added to a user with birth_date" do
+      before { user.update!(birth_date: "1985-01-01") }
+
+      it "enqueues upsert job for participations without france_travail_id" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
+          .with(hash_including(participation_id: participation.id))
+
+        user.update!(nir: "185027800608443")
+      end
+    end
+
+    context "when birth_date is added to a user with nir" do
+      before { user.update!(nir: "185027800608443") }
+
+      it "enqueues upsert job for participations without france_travail_id" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
+          .with(hash_including(participation_id: participation.id))
+
+        user.update!(birth_date: "1985-01-01")
+      end
+    end
+
+    context "when france_travail_id is added" do
+      it "enqueues upsert job for participations without france_travail_id" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
+          .with(hash_including(participation_id: participation.id))
+
+        user.update!(france_travail_id: "12345678901")
+      end
+    end
+
+    context "when participation already has a france_travail_id" do
+      before { participation.update_column(:france_travail_id, "ft-123") }
+
+      it "does not enqueue upsert job" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+        user.update!(france_travail_id: "12345678901")
+      end
+    end
+
+    context "when organisation is not eligible (france_travail type)" do
+      before { organisation.update_column(:organisation_type, "france_travail") }
+
+      it "does not enqueue upsert job" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+        user.update!(france_travail_id: "12345678901")
+      end
+    end
+
+    context "when department has disable_ft_webhooks" do
+      before { department.update_column(:disable_ft_webhooks, true) }
+
+      it "does not enqueue upsert job" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+        user.update!(france_travail_id: "12345678901")
+      end
+    end
+
+    context "when user was already retrievable and all participations already transmitted" do
+      let!(:user) { create(:user, france_travail_id: "12345678901", organisations: [organisation]) }
+
+      before { participation.update_column(:france_travail_id, "ft-123") }
+
+      it "does not enqueue upsert job" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+        user.update!(france_travail_id: "98765432109")
+      end
+    end
+
+    context "when an unrelated attribute changes" do
+      it "does not enqueue upsert job" do
+        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+
+        user.update!(first_name: "Nouveau Prénom")
+      end
+    end
+  end
+end

--- a/spec/models/concerns/user/france_travail_webhooks_spec.rb
+++ b/spec/models/concerns/user/france_travail_webhooks_spec.rb
@@ -3,16 +3,13 @@ describe User::FranceTravailWebhooks, type: :concern do
     let!(:department) { create(:department) }
     let!(:organisation) { create(:organisation, department: department) }
     let!(:user) { create(:user, organisations: [organisation]) }
-    let!(:follow_up) { create(:follow_up, user: user) }
-    let!(:rdv) { create(:rdv, organisation: organisation) }
-    let!(:participation) { create(:participation, user: user, rdv: rdv, follow_up: follow_up) }
 
     context "when nir is added to a user with birth_date" do
       before { user.update!(birth_date: "1985-01-01") }
 
-      it "enqueues upsert job for participations without france_travail_id" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
-          .with(hash_including(participation_id: participation.id))
+      it "enqueues SendPendingParticipationsJob" do
+        expect(OutgoingWebhooks::FranceTravail::SendPendingParticipationsJob).to receive(:perform_later)
+          .with(user_id: user.id)
 
         user.update!(nir: "185027800608443")
       end
@@ -21,68 +18,26 @@ describe User::FranceTravailWebhooks, type: :concern do
     context "when birth_date is added to a user with nir" do
       before { user.update!(nir: "185027800608443") }
 
-      it "enqueues upsert job for participations without france_travail_id" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
-          .with(hash_including(participation_id: participation.id))
+      it "enqueues SendPendingParticipationsJob" do
+        expect(OutgoingWebhooks::FranceTravail::SendPendingParticipationsJob).to receive(:perform_later)
+          .with(user_id: user.id)
 
         user.update!(birth_date: "1985-01-01")
       end
     end
 
     context "when france_travail_id is added" do
-      it "enqueues upsert job for participations without france_travail_id" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).to receive(:perform_later)
-          .with(hash_including(participation_id: participation.id))
+      it "enqueues SendPendingParticipationsJob" do
+        expect(OutgoingWebhooks::FranceTravail::SendPendingParticipationsJob).to receive(:perform_later)
+          .with(user_id: user.id)
 
         user.update!(france_travail_id: "12345678901")
-      end
-    end
-
-    context "when participation already has a france_travail_id" do
-      before { participation.update_column(:france_travail_id, "ft-123") }
-
-      it "does not enqueue upsert job" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
-
-        user.update!(france_travail_id: "12345678901")
-      end
-    end
-
-    context "when organisation is not eligible (france_travail type)" do
-      before { organisation.update_column(:organisation_type, "france_travail") }
-
-      it "does not enqueue upsert job" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
-
-        user.update!(france_travail_id: "12345678901")
-      end
-    end
-
-    context "when department has disable_ft_webhooks" do
-      before { department.update_column(:disable_ft_webhooks, true) }
-
-      it "does not enqueue upsert job" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
-
-        user.update!(france_travail_id: "12345678901")
-      end
-    end
-
-    context "when user was already retrievable and all participations already transmitted" do
-      let!(:user) { create(:user, france_travail_id: "12345678901", organisations: [organisation]) }
-
-      before { participation.update_column(:france_travail_id, "ft-123") }
-
-      it "does not enqueue upsert job" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
-
-        user.update!(france_travail_id: "98765432109")
       end
     end
 
     context "when an unrelated attribute changes" do
-      it "does not enqueue upsert job" do
-        expect(OutgoingWebhooks::FranceTravail::UpsertParticipationJob).not_to receive(:perform_later)
+      it "does not enqueue SendPendingParticipationsJob" do
+        expect(OutgoingWebhooks::FranceTravail::SendPendingParticipationsJob).not_to receive(:perform_later)
 
         user.update!(first_name: "Nouveau Prénom")
       end


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/FT-Certains-rdvs-FT-ne-remontent-pas-dans-le-SI-Plateforme-3215f321b60480f48636ee3803ee64c1

### Problème                                                                                                                                                                        
                                                                                                                                                                                  
  Quand un usager est créé sans NIR ni identifiant France Travail, les participations à ses RDV ne sont pas transmises à FT car il n'est pas identifiable dans leur système.
  Lorsque le NIR est renseigné par la suite, rien ne déclenche l'envoi de ces participations — elles restent absentes du SI FT.                                                      
  
 ### Solution                                                                                                                                                                        
                                                            
  Ajout d'un concern `User::FranceTravailWebhooks` qui :                                                                                                                            
  - Détecte via `after_commit` quand un usager devient identifiable par FT (ajout de `nir`, `france_travail_id` ou `birth_date`)
  - Déclenche l'envoi vers FT de toutes ses participations sans `france_travail_id` et éligibles                                                                                    