### PR TITLE
Scalingo(cron): change restarter time to 3:30am

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,8 +1,8 @@
 {
   "jobs": [
     {
-      "command": "0 4 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart",
-      "description": "Restart the app once a day at 4am to prevent memory leaks"
+      "command": "30 3 * * * [[ -n \"${RESTARTER_BOT_API_TOKEN:-}\" ]] && install-scalingo-cli && scalingo login --api-token $RESTARTER_BOT_API_TOKEN && scalingo --region osc-secnum-fr1 --app $APP restart",
+      "description": "Restart the app once a day at 3:30am to prevent memory leaks"
     }
   ]
 }


### PR DESCRIPTION
 Le cron Scalingo semble appliquer un décalage de +1h (timezone), ce qui faisait tourner le reboot prévu à 4h en réalité à 5h — heure à laquelle le job Sidekiq  `StoreAllNumberOfCreneauxAvailableJob` est planifié. Pour éviter cette collision, le reboot est décalé à 3h30 (soit 4h30 UTC).