### PR TITLE
configuration(wording): change email_to_notify_rdv_changes wording

### DIFF
--- a/app/views/organisations/category_configurations/alertings/_alerting_fields.html.erb
+++ b/app/views/organisations/category_configurations/alertings/_alerting_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="mb-4">
   <label class="form-label fw-bold">Rendez-vous pris</label>
   <p class="text-muted small mb-2">
-    Recevoir un email pour chaque créneau réservé sur cette catégorie.
+    Recevoir un email pour chaque rendez-vous pris, modifié ou annulé dans cette catégorie.
   </p>
   <%= f.email_field :email_to_notify_rdv_changes,
                     class: "form-control w-35",


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Configuration-Cat-gorie-Notifications-Modifier-le-contenu-explicatif-des-notifs-Rendez-vous-pr-3175f321b6048005969cc9fdbfab62ff