### PR TITLE
fix(view): Allow unselect logos to display

### DIFF
--- a/app/models/messages_configuration.rb
+++ b/app/models/messages_configuration.rb
@@ -5,7 +5,7 @@ class MessagesConfiguration < ApplicationRecord
 
   belongs_to :organisation
 
-  before_save :remove_blank_array_fields
+  before_validation :remove_blank_array_fields
 
   delegate :department, to: :organisation
 

--- a/app/models/messages_configuration.rb
+++ b/app/models/messages_configuration.rb
@@ -14,7 +14,7 @@ class MessagesConfiguration < ApplicationRecord
                                         message: "ne doit contenir que des lettres et des chiffres" },
                               allow_nil: true
 
-  validates :logos_to_display, inclusion: { in: LOGO_TYPES }
+  validate :logos_to_display_must_be_valid
 
   nullify_blank :sms_sender_name, :letter_sender_name, :sender_city, :help_address
 
@@ -74,5 +74,12 @@ class MessagesConfiguration < ApplicationRecord
     # We don't want blank signature_lines or direction_names in the invitations
     signature_lines&.compact_blank!
     direction_names&.compact_blank!
+    logos_to_display&.compact_blank!
+  end
+
+  def logos_to_display_must_be_valid
+    return if logos_to_display.all? { |logo| LOGO_TYPES.include?(logo) }
+
+    errors.add(:logos_to_display, "doit contenir uniquement des logos valides")
   end
 end

--- a/app/views/common/_attribute_input_inline.html.erb
+++ b/app/views/common/_attribute_input_inline.html.erb
@@ -19,7 +19,7 @@
       <%= render "common/array_fields/input", attribute_name: attribute, f: f, placeholder: local_assigns[:placeholder] %>
     <% elsif local_assigns[:as] == :collection_check_boxes %>
       <div class="d-flex flex-column gap-2">
-        <%= f.collection_check_boxes attribute, collection, ->(element) { element[0] }, ->(element) { element[1] }, include_hidden: false do |b| %>
+        <%= f.collection_check_boxes attribute, collection, ->(element) { element[0] }, ->(element) { element[1] } do |b| %>
           <div class="form-check">
             <%= b.check_box(class: "form-check-input") %>
             <%= b.label(class: "form-check-label") %>

--- a/app/views/letters/_header.html.erb
+++ b/app/views/letters/_header.html.erb
@@ -1,7 +1,11 @@
 <div class="header">
   <div class="header-left">
     <div class="header-logo">
-      <%= image_tag(organisation.logo.attached? ? organisation.logo.url : department.logo.url) %>
+      <% if organisation.logo.attached? %>
+        <%= image_tag(organisation.logo.url) %>
+      <% elsif logos_to_display.include?("department") && department.logo.attached? %>
+        <%= image_tag(department.logo.url) %>
+      <% end %>
     </div>
   </div>
   <div class="header-right">

--- a/app/views/letters/invitations/atelier.html.erb
+++ b/app/views/letters/invitations/atelier.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue">

--- a/app/views/letters/invitations/atelier_enfants_ados.html.erb
+++ b/app/views/letters/invitations/atelier_enfants_ados.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue">

--- a/app/views/letters/invitations/phone_platform.html.erb
+++ b/app/views/letters/invitations/phone_platform.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue">

--- a/app/views/letters/invitations/standard.html.erb
+++ b/app/views/letters/invitations/standard.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue">

--- a/app/views/letters/notifications/by_phone_participation_created.html.erb
+++ b/app/views/letters/notifications/by_phone_participation_created.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue">Objet : Convocation à un <%= rdv_title_by_phone %> dans le cadre de votre <%= rdv_subject %></p>

--- a/app/views/letters/notifications/participation_cancelled.html.erb
+++ b/app/views/letters/notifications/participation_cancelled.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Votre <%= rdv_title %> dans le cadre de votre <%= rdv_subject %> a été annulé</span></p>

--- a/app/views/letters/notifications/presential_participation_created.html.erb
+++ b/app/views/letters/notifications/presential_participation_created.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Convocation à un <%= rdv_title %> dans le cadre de votre <%= rdv_subject %></span></p>

--- a/app/views/letters/notifications/visio_participation_created.html.erb
+++ b/app/views/letters/notifications/visio_participation_created.html.erb
@@ -1,4 +1,4 @@
-<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user %>
+<%= render "letters/header", direction_names: direction_names, sender_city: sender_city, department: department, organisation: organisation, user: user, logos_to_display: logos_to_display %>
 
 <div class="mail-object">
   <p class="bold-blue"><span class="bold-blue">Objet : Convocation à un <%= rdv_title %> par visioconférence dans le cadre de votre <%= rdv_subject %></span></p>

--- a/spec/features/admin_can_edit_messages_configuration_spec.rb
+++ b/spec/features/admin_can_edit_messages_configuration_spec.rb
@@ -186,5 +186,22 @@ describe "Admin can edit messages configuration", :js do
       expect(page).to have_content("Valence")
       expect(messages_configuration.reload.sender_city).to be_nil
     end
+
+    it "allows to unselect all logos" do
+      messages_configuration.update!(logos_to_display: %w[department europe])
+      visit organisation_configuration_messages_path(organisation)
+      within "turbo-frame#messages_configuration_#{messages_configuration.id}" do
+        click_link "Modifier"
+      end
+      uncheck "Département"
+      uncheck "Européen"
+      click_button "Enregistrer"
+
+      within "turbo-frame#messages_configuration_#{messages_configuration.id}" do
+        expect(page).to have_no_content("Département")
+        expect(page).to have_no_content("Européen")
+      end
+      expect(messages_configuration.reload.logos_to_display).to eq([])
+    end
   end
 end

--- a/spec/models/messages_configuration_spec.rb
+++ b/spec/models/messages_configuration_spec.rb
@@ -34,6 +34,31 @@ describe MessagesConfiguration do
         expect(messages_configuration.direction_names).to eq(["some_field"])
       end
     end
+
+    context "some logos_to_display fields are blank" do
+      let(:messages_configuration) do
+        create(:messages_configuration, organisation: create(:organisation), logos_to_display: [""])
+      end
+
+      it "removes blank fields" do
+        expect(messages_configuration.logos_to_display).to eq([])
+      end
+    end
+  end
+
+  describe "logos_to_display_must_be_valid validation" do
+    context "with invalid logos_to_display" do
+      let(:messages_configuration) do
+        build(:messages_configuration, organisation: create(:organisation), logos_to_display: %w[some_field invalid])
+      end
+
+      it "rejects invalid logos_to_display" do
+        expect(messages_configuration).not_to be_valid
+        expect(messages_configuration.errors.full_messages).to include(
+          "Logos affichés doit contenir uniquement des logos valides"
+        )
+      end
+    end
   end
 
   describe "signature_image attachment" do


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-Impossible-de-d-selectionner-tous-les-logos-afficher-33c5f321b604801c802fcda94d3518e5?source=copy_link

L'option `include_hidden: false` dans le formulaire faisait que l'input n'était pas inclus dans le formulaire transmis au serveur lorsque toutes les coches étaient déselectionnées. 
J'enlève donc cette option et:
* Je change la validation de `messages_configuration#logos_to_display` pour accepter un tableau vide
* Je fais en sorte de formatter l'input pour enlever les string vides
* J'ajoute des tests

La PR se lit bien commit par commit.

EDIT: j'ai fait aussi en sorte qu'on ne fallback pas automatiquement sur le logo du département dans le header de la lettre suite à [ce retour](https://gip-inclusion.slack.com/archives/C09NT86HGNM/p1775664632888199?thread_ts=1775139076.899689&cid=C09NT86HGNM)