### PR TITLE
feat(worker): Add new queue priorities mechanism

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,5 +1,5 @@
 class ApplicationJob < ActiveJob::Base
-  queue_as :default
+  queue_as :within_5min
 
   def self.perform_in(wait_time, *)
     set(wait: wait_time).perform_later(*)

--- a/app/jobs/clean_unused_follow_ups_job.rb
+++ b/app/jobs/clean_unused_follow_ups_job.rb
@@ -1,4 +1,6 @@
 class CleanUnusedFollowUpsJob < ApplicationJob
+  queue_as :whenever
+
   def perform(user_id)
     @user = User.find(user_id)
     call_service!(FollowUps::CleanUnused, user: @user)

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -1,4 +1,6 @@
 class CreateAndInviteUserJob < ApplicationJob
+  queue_as :within_30s
+
   sidekiq_options retry: 0
 
   def perform(organisation_id, user_attributes, invitation_attributes, motif_category_attributes)

--- a/app/jobs/creneaux/retrieve_and_notify_all_unavailable_creneaux_job.rb
+++ b/app/jobs/creneaux/retrieve_and_notify_all_unavailable_creneaux_job.rb
@@ -1,4 +1,6 @@
 class Creneaux::RetrieveAndNotifyAllUnavailableCreneauxJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     Department.find_each do |departement|
       departement.organisations.active.distinct.find_each do |organisation|

--- a/app/jobs/creneaux/retrieve_and_notify_unavailable_creneaux_job.rb
+++ b/app/jobs/creneaux/retrieve_and_notify_unavailable_creneaux_job.rb
@@ -1,4 +1,6 @@
 class Creneaux::RetrieveAndNotifyUnavailableCreneauxJob < ApplicationJob
+  queue_as :whenever
+
   attr_reader :organisation
 
   def perform(organisation_id)

--- a/app/jobs/creneaux/store_all_number_of_creneaux_available_job.rb
+++ b/app/jobs/creneaux/store_all_number_of_creneaux_available_job.rb
@@ -1,5 +1,7 @@
 module Creneaux
   class StoreAllNumberOfCreneauxAvailableJob < ApplicationJob
+    queue_as :whenever
+
     def perform
       CategoryConfiguration
         .joins(:organisation)

--- a/app/jobs/file_configurations/delete_unused_job.rb
+++ b/app/jobs/file_configurations/delete_unused_job.rb
@@ -1,4 +1,6 @@
 class FileConfigurations::DeleteUnusedJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     FileConfiguration.where.missing(:category_configurations).destroy_all
   end

--- a/app/jobs/follow_ups/plan_status_refresh_job.rb
+++ b/app/jobs/follow_ups/plan_status_refresh_job.rb
@@ -1,4 +1,6 @@
 class FollowUps::PlanStatusRefreshJob < ApplicationJob
+  queue_as :whenever
+
   def perform(follow_up_id)
     follow_up = FollowUp.find(follow_up_id)
     return if follow_up.refresh_status_at.blank? || follow_up.refresh_status_at < Time.zone.now

--- a/app/jobs/follow_ups/refresh_out_of_date_statuses_job.rb
+++ b/app/jobs/follow_ups/refresh_out_of_date_statuses_job.rb
@@ -1,4 +1,6 @@
 class FollowUps::RefreshOutOfDateStatusesJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     @follow_up_ids = []
     updatable_follow_ups.find_each do |follow_up|

--- a/app/jobs/monitor_inbound_emails_activity_job.rb
+++ b/app/jobs/monitor_inbound_emails_activity_job.rb
@@ -1,4 +1,6 @@
 class MonitorInboundEmailsActivityJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     return if inbound_email_received_less_than_4_days_ago?
 

--- a/app/jobs/monitor_webhook_activity_job.rb
+++ b/app/jobs/monitor_webhook_activity_job.rb
@@ -1,4 +1,6 @@
 class MonitorWebhookActivityJob < ApplicationJob
+  queue_as :whenever
+
   MONITORS = [
     { acceptable_delay: 3.hours, model: Rdv },
     { acceptable_delay: 12.hours, model: User },

--- a/app/jobs/notify_jobs_to_retry_on_slack_job.rb
+++ b/app/jobs/notify_jobs_to_retry_on_slack_job.rb
@@ -1,4 +1,6 @@
 class NotifyJobsToRetryOnSlackJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     SlackClient.send_to_sentry_channel(
       "*#{retry_set.size}* jobs ont échoué et sont à réessayer.\n" \

--- a/app/jobs/purge_api_calls_job.rb
+++ b/app/jobs/purge_api_calls_job.rb
@@ -1,4 +1,6 @@
 class PurgeApiCallsJob < ApplicationJob
+  queue_as :whenever
+
   RETENTION_PERIOD = 1.year
 
   def perform

--- a/app/jobs/rgpd_cleanup_job.rb
+++ b/app/jobs/rgpd_cleanup_job.rb
@@ -1,4 +1,6 @@
 class RgpdCleanupJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     Organisation.find_each do |organisation|
       RgpdCleanupOrganisationJob.perform_later(organisation.id)

--- a/app/jobs/rgpd_cleanup_organisation_job.rb
+++ b/app/jobs/rgpd_cleanup_organisation_job.rb
@@ -1,4 +1,6 @@
 class RgpdCleanupOrganisationJob < ApplicationJob
+  queue_as :whenever
+
   def perform(organisation_id)
     organisation = Organisation.find(organisation_id)
     call_service!(

--- a/app/jobs/send_convocation_reminders_job.rb
+++ b/app/jobs/send_convocation_reminders_job.rb
@@ -1,4 +1,6 @@
 class SendConvocationRemindersJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     NotifyParticipationsToUsersJob.perform_later(participations_to_send_reminders_to.ids, "reminder")
     notify_on_slack

--- a/app/jobs/send_invitation_reminders_job.rb
+++ b/app/jobs/send_invitation_reminders_job.rb
@@ -1,4 +1,6 @@
 class SendInvitationRemindersJob < ApplicationJob
+  queue_as :whenever
+
   def perform
     @sent_reminders_user_ids = []
 

--- a/app/jobs/user_list_upload/invite_users_job.rb
+++ b/app/jobs/user_list_upload/invite_users_job.rb
@@ -1,4 +1,6 @@
 class UserListUpload::InviteUsersJob < ApplicationJob
+  queue_as :within_30s
+
   sidekiq_options retry: 0
 
   before_perform :capture_invitations_started_at

--- a/app/jobs/user_list_upload/save_user_job.rb
+++ b/app/jobs/user_list_upload/save_user_job.rb
@@ -1,4 +1,6 @@
 class UserListUpload::SaveUserJob < ApplicationJob
+  queue_as :within_30s
+
   sidekiq_options retry: 0
 
   def perform(user_row_id, broadcast_refresh: true)

--- a/app/jobs/user_list_upload/save_users_job.rb
+++ b/app/jobs/user_list_upload/save_users_job.rb
@@ -1,4 +1,6 @@
 class UserListUpload::SaveUsersJob < ApplicationJob
+  queue_as :within_30s
+
   sidekiq_options retry: 0
 
   before_perform :capture_user_saves_started_at

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,9 @@
 ---
 :queues:
-  - default
+  - within_30s
+  - within_5min
+  - whenever
+  # stats and creneaux have specific queues (with low priority) to specify concurrency limits
   - stats
   - creneaux
 


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-les-cr-ations-invitations-l-upload-mettent-trop-de-temps-se-lancer-3415f321b60480178eb8e0e0119cfe83

## Contexte

On a reçu quelques retours d'utilisateurs se plaignant de lenteurs dans le parcours d'upload. Grâce à la table `user_list_upload_processing_logs` j'ai pu voir qu'effectivement pour certains upload le temps peut être long (parfois > à 1 minute) entre le moment où le job a été enqueued et le moment où il a commencé à être exécuté. 
C'est dû au fait que dans les périodes de fortes activités ces jobs ne sont pas priorisé par rapport à d'autres et peuvent rester un peu de temps en attente avant d'être popé par redis

## Solution

Jusqu'à présent on en a pas eu besoin mais maintenant il faut donc avoir différents niveau de priorités pour nos queues. 
En général nommer ses queues en fonctions du SLAs est une bonne pratique, je fais donc ça ici. On a donc 3 queues: 
* `within_30s`: ce sont les jobs prioritaires qui doivent être exécutés immédiatement, ceux où l'utilisateur est en attente d'un résultat. Cela concerne donc les 3 jobs liés à l'upload + le job `CreateAndInviteUserJob` qui est trigger par l'API, même si l'endpoint d'invitation asynchrone est de toute façon plus utilisé
* `within_5min`: c'est la queue par défaut. C'est les jobs qu'on a besoin d'exécuter assez rapidement mais qui sont moins prioritaires que les `within_30s`. Ça va concerner par exemple tous les process de webhooks, ou bien les générations de csv par exemple
* `whenever`: c'est les jobs qui sont le moins prioritaires, ça concerne principalement nos CRON jobs

P.S: on laisse les queues spécifiques `stats` et `creneaux` pour spécifier une concurrency limit (via la gem `sidekiq-limit-fetch`)