### PR TITLE
ui(follow_ups): rework follow_ups index, add collapse with details

### DIFF
--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -62,10 +62,12 @@ module ParticipationsHelper
       "user" => "l'usager"
     }[participation.created_by_type]
 
-    author_details = if participation.created_by_agent?
-                       author = participation.created_by
-                       " #{author} (#{author.email})" if author.present?
-                     end
+    author = if participation.created_by_agent?
+               participation.created_by
+             elsif participation.created_by_prescripteur?
+               participation.agent_prescripteur
+             end
+    author_details = " #{author} (#{author.email})" if author.present?
 
     "#{author_description}#{author_details || ''}"
   end

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -62,12 +62,8 @@ module ParticipationsHelper
       "user" => "l'usager"
     }[participation.created_by_type]
 
-    author = if participation.created_by_agent?
-               participation.created_by
-             elsif participation.created_by_prescripteur?
-               participation.agent_prescripteur
-             end
-    author_details = " #{author} (#{author.email})" if author.present?
+    agent_creator = participation.agent_creator
+    author_details = " #{agent_creator} (#{agent_creator.email})" if agent_creator
 
     "#{author_description}#{author_details}"
   end

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -55,7 +55,7 @@ module ParticipationsHelper
     end
   end
 
-  def participation_created_by_tooltip_content(participation)
+  def participation_created_by_description(participation)
     author_description = {
       "prescripteur" => "un prescripteur",
       "agent" => "l'agent",
@@ -67,7 +67,6 @@ module ParticipationsHelper
                        " #{author} (#{author.email})" if author.present?
                      end
 
-    "Rendez-vous pris par #{author_description}#{author_details || ''}" \
-      " le #{participation.created_at.strftime('%d/%m/%Y à %H:%M')}"
+    "#{author_description}#{author_details || ''}"
   end
 end

--- a/app/helpers/participations_helper.rb
+++ b/app/helpers/participations_helper.rb
@@ -69,6 +69,6 @@ module ParticipationsHelper
              end
     author_details = " #{author} (#{author.email})" if author.present?
 
-    "#{author_description}#{author_details || ''}"
+    "#{author_description}#{author_details}"
   end
 end

--- a/app/javascript/controllers/accordion_controller.js
+++ b/app/javascript/controllers/accordion_controller.js
@@ -36,6 +36,10 @@ export default class extends Controller {
     setTimeout(() => item.scrollIntoView({ block: "start" }), 0)
   }
 
+  stop(event) {
+    event.stopPropagation()
+  }
+
   toggle(event) {
     const header = event.currentTarget
     if (header.classList.contains("disabled")) return

--- a/app/javascript/stylesheets/components/_card.scss
+++ b/app/javascript/stylesheets/components/_card.scss
@@ -66,7 +66,7 @@
 }
 
 // Keep the same light-blue background on the trigger row while its collapse is open.
-tr:has(+ tr[data-accordion-target="content"]:not(.d-none)) {
+tr:has(+ tr:not(.d-none) > .participation-details-cell) {
   background-color: $light;
 }
 

--- a/app/javascript/stylesheets/components/_card.scss
+++ b/app/javascript/stylesheets/components/_card.scss
@@ -47,6 +47,29 @@
   box-shadow: 0 0 1px rgba(0,0,0,0.1);
 }
 
+// CSS Grid with minmax(0, ...) so columns can shrink below their content and
+// avoid resizing the parent table when the collapse opens.
+.participation-details-list {
+  display: grid;
+  grid-template-columns: minmax(0, 25%) minmax(0, 75%);
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+  margin: 0;
+
+  dt, dd {
+    margin: 0;
+  }
+}
+
+.participation-details-cell {
+  background-color: $light;
+}
+
+// Keep the same light-blue background on the trigger row while its collapse is open.
+tr:has(+ tr[data-accordion-target="content"]:not(.d-none)) {
+  background-color: $light;
+}
+
 @media (min-width: 576px) {
   .modal-dialog {
     max-width: 600px;

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -57,6 +57,12 @@ class Participation < ApplicationRecord
     Agent.find_by(rdv_solidarites_agent_id: rdv_solidarites_created_by_id) if created_by_agent_prescripteur?
   end
 
+  def agent_creator
+    return unless created_by_agent? || created_by_agent_prescripteur?
+
+    Agent.find_by(rdv_solidarites_agent_id: rdv_solidarites_created_by_id)
+  end
+
   def notifiable?
     convocable? && in_the_future? && status.in?(%w[unknown revoked])
   end

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -31,8 +31,6 @@
       <div>
         <% if participations.present? %>
           <% sorted_participations = participations.sort_by(&:starts_at).reverse %>
-          <% most_recent_participation = sorted_participations.first %>
-          <% historic_participations = sorted_participations.drop(1) %>
           <div class="d-flex justify-content-center">
             <table class="card-white text-center align-middle m-4 shadow table-hover" data-controller="accordion">
               <thead>
@@ -45,26 +43,19 @@
                 </tr>
               </thead>
               <tbody>
-                <%= render "follow_ups/participation_row",
-                           participation: most_recent_participation, participation_index: 0,
-                           category_configuration: category_configuration %>
-              </tbody>
-              <% if historic_participations.any? %>
-                <tbody>
-                  <tr>
-                    <td colspan="5" class="px-4 pt-4 pb-2 text-start">
-                      <h5 class="mb-0"><strong>Historique sur le suivi</strong></h5>
-                    </td>
-                  </tr>
-                  <%# index + 1 because index 0 is taken by most_recent_participation %>
-                  <% historic_participations.each_with_index do |historic_participation, index| %>
-                    <%= render "follow_ups/participation_row",
-                               participation: historic_participation,
-                               participation_index: index + 1,
-                               category_configuration: category_configuration %>
+                <% sorted_participations.each_with_index do |participation, index| %>
+                  <% if index == 1 %>
+                    <tr>
+                      <td colspan="5" class="px-4 pt-4 pb-2 text-start">
+                        <h5 class="mb-0"><strong>Historique sur le suivi</strong></h5>
+                      </td>
+                    </tr>
                   <% end %>
-                </tbody>
-              <% end %>
+                  <%= render "follow_ups/participation_row",
+                             participation: participation, participation_index: index,
+                             category_configuration: category_configuration %>
+                <% end %>
+              </tbody>
             </table>
           </div>
         <% end %>

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -30,23 +30,41 @@
     <div class="card-body bg-light">
       <div>
         <% if participations.present? %>
+          <% sorted_participations = participations.sort_by(&:starts_at).reverse %>
+          <% most_recent_participation = sorted_participations.first %>
+          <% historic_participations = sorted_participations.drop(1) %>
           <div class="d-flex justify-content-center">
-            <table class="card-white text-center align-middle m-4 shadow">
+            <table class="card-white text-center align-middle m-4 shadow table-hover" data-controller="accordion">
               <thead>
                 <tr>
-                  <th class="px-4 py-2"><h4>RDV pris le</h4></th>
                   <th class="px-4 py-2"><h4>Date du RDV</h4></th>
                   <th class="px-5 py-2"><h4>Motif</h4></th>
                   <th class="px-4 py-2"><h4>Statut RDV</h4></th>
                   <th class="px-4 py-2"><h4>Lien</h4></th>
+                  <th class="px-2 py-2"></th>
                 </tr>
               </thead>
               <tbody>
-                <%= render partial: "follow_ups/participation_row",
-                           collection: participations.sort_by(&:created_at).reverse,
-                           as: :participation,
-                           locals: { category_configuration: category_configuration } %>
+                <%= render "follow_ups/participation_row",
+                           participation: most_recent_participation, participation_index: 0,
+                           category_configuration: category_configuration %>
               </tbody>
+              <% if historic_participations.any? %>
+                <tbody>
+                  <tr>
+                    <td colspan="5" class="px-4 pt-4 pb-2 text-start">
+                      <h5 class="mb-0"><strong>Historique sur le suivi</strong></h5>
+                    </td>
+                  </tr>
+                  <%# index + 1 because index 0 is taken by most_recent_participation %>
+                  <% historic_participations.each_with_index do |historic_participation, index| %>
+                    <%= render "follow_ups/participation_row",
+                               participation: historic_participation,
+                               participation_index: index + 1,
+                               category_configuration: category_configuration %>
+                  <% end %>
+                </tbody>
+              <% end %>
             </table>
           </div>
         <% end %>

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -30,7 +30,7 @@
     <div class="card-body bg-light">
       <div>
         <% if participations.present? %>
-          <% sorted_participations = participations.sort_by(&:starts_at).reverse %>
+          <% sorted_participations = participations.sort_by(&:created_at).reverse %>
           <div class="d-flex justify-content-center">
             <table class="card-white text-center align-middle m-4 shadow table-hover" data-controller="accordion">
               <thead>

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -42,36 +42,10 @@
                 </tr>
               </thead>
               <tbody>
-                <% participations.sort_by(&:created_at).reverse.each do |participation| %>
-                  <tr>
-                    <td class="px-4 py-3">
-                      <%= format_date(participation.created_at) %>
-                      <i
-                        class="ri-information-line"
-                        <%= tooltip(content: participation_created_by_tooltip_content(participation)) %>>
-                      </i>
-                    </td>
-                    <td class="px-4 py-3"><%= format_date(participation.starts_at) %></td>
-                    <td class="px-2 py-3"><%= participation.motif.name %></td>
-                    <td class="px-4 py-3 participation_status" >
-                      <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit?  %>
-                        <%= render "participations/participation_status", participation: participation, category_configuration: category_configuration %>
-                      <% else %>
-                        <%= participation.human_status %>
-                      <% end %>
-                    </td>
-                    <td class="px-4 py-3">
-                      <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit? %>
-                        <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning do %>
-                          <%= render "common/rdvs_impersonation_warning", url: participation.rdv_solidarites_url if agent_impersonated? %>
-                          <button class="btn btn-blue" <%= agent_impersonated? ? "data-action=click->confirmation-modal#show" : "" %>>
-                            Voir sur RDV-S<i class="ri-external-link-line ms-1"></i>
-                          </button>
-                        <% end %>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
+                <%= render partial: "follow_ups/participation_row",
+                           collection: participations.sort_by(&:created_at).reverse,
+                           as: :participation,
+                           locals: { category_configuration: category_configuration } %>
               </tbody>
             </table>
           </div>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -1,0 +1,28 @@
+<tr>
+  <td class="px-4 py-3">
+    <%= format_date(participation.created_at) %>
+    <i
+      class="ri-information-line"
+      <%= tooltip(content: participation_created_by_tooltip_content(participation)) %>>
+    </i>
+  </td>
+  <td class="px-4 py-3"><%= format_date(participation.starts_at) %></td>
+  <td class="px-2 py-3"><%= participation.motif.name %></td>
+  <td class="px-4 py-3 participation_status" >
+    <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit?  %>
+      <%= render "participations/participation_status", participation: participation, category_configuration: category_configuration %>
+    <% else %>
+      <%= participation.human_status %>
+    <% end %>
+  </td>
+  <td class="px-4 py-3">
+    <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit? %>
+      <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning do %>
+        <%= render "common/rdvs_impersonation_warning", url: participation.rdv_solidarites_url if agent_impersonated? %>
+        <button class="btn btn-blue" <%= agent_impersonated? ? "data-action=click->confirmation-modal#show" : "" %>>
+          Voir sur RDV-S<i class="ri-external-link-line ms-1"></i>
+        </button>
+      <% end %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -49,10 +49,10 @@
       <% end %>
       <dt>RDV pris le</dt>
       <dd><%= participation.created_at.strftime("%d/%m/%Y à %H:%M") %></dd>
+      <dt>Dans</dt>
+      <dd><%= participation.rdv.organisation.name %></dd>
       <dt>Par</dt>
       <dd><%= participation_created_by_description(participation) %></dd>
-      <dt>Demandé par</dt>
-      <dd><%= participation.rdv.organisation.name %></dd>
     </dl>
   </td>
 </tr>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -37,7 +37,8 @@
         <% ["sms", "email", "postal"].each do |format| %>
           <% convocation = participation.last_convocation_by(format) %>
           <% next if convocation.blank? %>
-          <dt>Convocation <%= format == "sms" ? "SMS" : format %></dt>
+
+          <dt>Convocation <%= t("activerecord.attributes.invitation.formats.#{format}") %></dt>
           <dd>
             <%= format_date(convocation.created_at) %>
             <% if format != "postal" %>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -1,28 +1,61 @@
-<tr>
+<tr class="clickable" data-action="click->accordion#toggle" data-index="<%= participation_index %>">
   <td class="px-4 py-3">
-    <%= format_date(participation.created_at) %>
-    <i
-      class="ri-information-line"
-      <%= tooltip(content: participation_created_by_tooltip_content(participation)) %>>
-    </i>
+    <%= format_date(participation.starts_at) %>
   </td>
-  <td class="px-4 py-3"><%= format_date(participation.starts_at) %></td>
-  <td class="px-2 py-3"><%= participation.motif.name %></td>
-  <td class="px-4 py-3 participation_status" >
-    <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit?  %>
-      <%= render "participations/participation_status", participation: participation, category_configuration: category_configuration %>
+  <td class="px-2 py-3">
+    <%= participation.motif.name %>
+  </td>
+  <td class="px-4 py-3 participation_status">
+    <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit? %>
+      <span class="d-inline-block" data-action="click->accordion#stop">
+        <%= render "participations/participation_status", participation: participation, category_configuration: category_configuration %>
+      </span>
     <% else %>
       <%= participation.human_status %>
     <% end %>
   </td>
   <td class="px-4 py-3">
     <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit? %>
-      <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning do %>
-        <%= render "common/rdvs_impersonation_warning", url: participation.rdv_solidarites_url if agent_impersonated? %>
-        <button class="btn btn-blue" <%= agent_impersonated? ? "data-action=click->confirmation-modal#show" : "" %>>
-          Voir sur RDV-S<i class="ri-external-link-line ms-1"></i>
-        </button>
-      <% end %>
+      <span class="d-inline-block" data-action="click->accordion#stop">
+        <%= link_to participation.rdv_solidarites_url, target: "_blank", **with_rdv_solidarites_impersonation_warning do %>
+          <%= render "common/rdvs_impersonation_warning", url: participation.rdv_solidarites_url if agent_impersonated? %>
+          <button class="btn btn-blue text-nowrap" <%= agent_impersonated? ? "data-action=click->confirmation-modal#show" : "" %>>
+            Voir sur RDV-S<i class="ri-external-link-line ms-1"></i>
+          </button>
+        <% end %>
+      </span>
     <% end %>
+  </td>
+  <td class="ps-3 pe-4 py-3">
+    <i data-accordion-target="icon" class="ri-arrow-down-s-line ri-2x"></i>
+  </td>
+</tr>
+<tr class="d-none" data-accordion-target="content" id="<%= dom_id(participation, :details) %>">
+  <td colspan="5" class="px-4 py-3 bg-white text-start">
+    <dl class="row mb-0">
+      <% if participation.convocable? %>
+        <%
+          convocation_formats = ["sms", "email", "postal"].select do |format|
+            participation.last_convocation_by(format).present?
+          end
+        %>
+        <% convocation_formats.each do |format| %>
+          <% convocation = participation.last_convocation_by(format) %>
+          <dt class="col-sm-3">Convocation <%= format == "sms" ? "SMS" : format %></dt>
+          <dd class="col-sm-9">
+            <%= format_date(convocation.created_at) %>
+            <% if format != "postal" %>
+              <%= render "follow_ups/delivery_status", deliverable: convocation, format: format %>
+            <% end %>
+          </dd>
+        <% end %>
+      <% end %>
+      <dt class="col-sm-3">RDV pris le</dt>
+      <dd class="col-sm-9"><%= participation.created_at.strftime("%d/%m/%Y à %H:%M") %></dd>
+      <dt class="col-sm-3">Par</dt>
+      <dd class="col-sm-9"><%= participation_created_by_description(participation) %></dd>
+      <dt class="col-sm-3">Dans l'organisation</dt>
+      <dd class="col-sm-9 mb-0"><%= participation.rdv.organisation.name %></dd>
+    </dl>
   </td>
 </tr>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -31,8 +31,8 @@
   </td>
 </tr>
 <tr class="d-none" data-accordion-target="content" id="<%= dom_id(participation, :details) %>">
-  <td colspan="5" class="px-4 py-3 bg-white text-start">
-    <dl class="row mb-0">
+  <td colspan="5" class="px-4 py-3 text-start participation-details-cell">
+    <dl class="participation-details-list">
       <% if participation.convocable? %>
         <%
           convocation_formats = ["sms", "email", "postal"].select do |format|
@@ -41,8 +41,8 @@
         %>
         <% convocation_formats.each do |format| %>
           <% convocation = participation.last_convocation_by(format) %>
-          <dt class="col-sm-3">Convocation <%= format == "sms" ? "SMS" : format %></dt>
-          <dd class="col-sm-9">
+          <dt>Convocation <%= format == "sms" ? "SMS" : format %></dt>
+          <dd>
             <%= format_date(convocation.created_at) %>
             <% if format != "postal" %>
               <%= render "follow_ups/delivery_status", deliverable: convocation, format: format %>
@@ -50,12 +50,12 @@
           </dd>
         <% end %>
       <% end %>
-      <dt class="col-sm-3">RDV pris le</dt>
-      <dd class="col-sm-9"><%= participation.created_at.strftime("%d/%m/%Y à %H:%M") %></dd>
-      <dt class="col-sm-3">Par</dt>
-      <dd class="col-sm-9"><%= participation_created_by_description(participation) %></dd>
-      <dt class="col-sm-3">Dans l'organisation</dt>
-      <dd class="col-sm-9 mb-0"><%= participation.rdv.organisation.name %></dd>
+      <dt>RDV pris le</dt>
+      <dd><%= participation.created_at.strftime("%d/%m/%Y à %H:%M") %></dd>
+      <dt>Par</dt>
+      <dd><%= participation_created_by_description(participation) %></dd>
+      <dt>Demandé par</dt>
+      <dd><%= participation.rdv.organisation.name %></dd>
     </dl>
   </td>
 </tr>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -34,13 +34,9 @@
   <td colspan="5" class="px-4 py-3 text-start participation-details-cell">
     <dl class="participation-details-list">
       <% if participation.convocable? %>
-        <%
-          convocation_formats = ["sms", "email", "postal"].select do |format|
-            participation.last_convocation_by(format).present?
-          end
-        %>
-        <% convocation_formats.each do |format| %>
+        <% ["sms", "email", "postal"].each do |format| %>
           <% convocation = participation.last_convocation_by(format) %>
+          <% next if convocation.blank? %>
           <dt>Convocation <%= format == "sms" ? "SMS" : format %></dt>
           <dd>
             <%= format_date(convocation.created_at) %>

--- a/app/views/follow_ups/_participation_row.html.erb
+++ b/app/views/follow_ups/_participation_row.html.erb
@@ -1,6 +1,6 @@
 <tr class="clickable" data-action="click->accordion#toggle" data-index="<%= participation_index %>">
   <td class="px-4 py-3">
-    <%= format_date(participation.starts_at) %>
+    <%= format_date(participation.starts_at_in_time_zone) %>
   </td>
   <td class="px-2 py-3">
     <%= participation.motif.name %>

--- a/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
+++ b/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
@@ -37,10 +37,10 @@ describe "Agents can see RDV details on the follow up page", :js do
 
     expect(page).to have_content("RDV pris le")
     expect(page).to have_content("10/03/2024 à 14:30")
+    expect(page).to have_content("Dans")
+    expect(page).to have_content("Service RSA")
     expect(page).to have_content("Par")
     expect(page).to have_content("l'agent")
-    expect(page).to have_content("Demandé par")
-    expect(page).to have_content("Service RSA")
   end
 
   it "does not expand the details panel when clicking on the status dropdown" do

--- a/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
+++ b/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
@@ -66,7 +66,8 @@ describe "Agents can see RDV details on the follow up page", :js do
       create(:rdv, organisation: organisation, motif: older_motif, starts_at: 2.months.ago)
     end
     let!(:older_participation) do
-      create(:participation, follow_up:, user:, rdv: older_rdv, status: "seen")
+      create(:participation, follow_up:, user:, rdv: older_rdv, status: "seen",
+                             created_at: Time.zone.parse("2024-01-15 10:00"))
     end
 
     it "displays the historical RDVs under the 'Historique sur le suivi' section" do

--- a/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
+++ b/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
@@ -25,12 +25,7 @@ describe "Agents can see RDV details on the follow up page", :js do
     )
   end
 
-  before do
-    setup_agent_session(agent)
-    rdvs_participation_id = participation.rdv_solidarites_participation_id
-    stub_request(:patch, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/participations/#{rdvs_participation_id}")
-      .to_return(status: 200, body: "{}")
-  end
+  before { setup_agent_session(agent) }
 
   it "expands the details panel when clicking on the row" do
     visit organisation_user_follow_ups_path(organisation_id: organisation.id, user_id: user.id)
@@ -78,12 +73,7 @@ describe "Agents can see RDV details on the follow up page", :js do
       visit organisation_user_follow_ups_path(organisation_id: organisation.id, user_id: user.id)
 
       expect(page).to have_content("Historique sur le suivi")
-
-      history_section = find("h5", text: "Historique sur le suivi").ancestor("tbody")
-      within(history_section) do
-        expect(page).to have_content("Premier entretien d'orientation")
-        expect(page).to have_no_content("RDV d'orientation")
-      end
+      expect(page.text).to match(/RDV d'orientation.*Historique sur le suivi.*Premier entretien d'orientation/m)
     end
   end
 end

--- a/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
+++ b/spec/features/agent_can_see_rdv_details_on_follow_up_page_spec.rb
@@ -1,0 +1,89 @@
+describe "Agents can see RDV details on the follow up page", :js do
+  include_context "with all existing categories"
+
+  let(:department) { create(:department) }
+  let(:organisation) { create(:organisation, department: department, name: "Service RSA") }
+  let(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:category_configuration) do
+    create(:category_configuration, organisation:, motif_category: category_rsa_orientation)
+  end
+  let(:user) { create(:user, organisations: [organisation]) }
+  let!(:follow_up) do
+    create(:follow_up, user:, status: "rdv_pending", motif_category: category_rsa_orientation)
+  end
+  let(:motif) do
+    create(:motif, organisation: organisation, motif_category: category_rsa_orientation, name: "RDV d'orientation")
+  end
+  let(:rdv) do
+    create(:rdv, organisation: organisation, motif: motif, starts_at: 3.days.from_now)
+  end
+  let!(:participation) do
+    create(
+      :participation,
+      follow_up:, user:, rdv:, status: "unknown",
+      created_by_type: "agent", created_at: Time.zone.parse("2024-03-10 14:30")
+    )
+  end
+
+  before do
+    setup_agent_session(agent)
+    rdvs_participation_id = participation.rdv_solidarites_participation_id
+    stub_request(:patch, "#{ENV['RDV_SOLIDARITES_URL']}/api/v1/participations/#{rdvs_participation_id}")
+      .to_return(status: 200, body: "{}")
+  end
+
+  it "expands the details panel when clicking on the row" do
+    visit organisation_user_follow_ups_path(organisation_id: organisation.id, user_id: user.id)
+
+    expect(page).to have_content("Date du RDV")
+    expect(page).to have_no_content("RDV pris le :")
+
+    find("td", text: "RDV d'orientation").click
+
+    expect(page).to have_content("RDV pris le")
+    expect(page).to have_content("10/03/2024 à 14:30")
+    expect(page).to have_content("Par")
+    expect(page).to have_content("l'agent")
+    expect(page).to have_content("Demandé par")
+    expect(page).to have_content("Service RSA")
+  end
+
+  it "does not expand the details panel when clicking on the status dropdown" do
+    visit organisation_user_follow_ups_path(organisation_id: organisation.id, user_id: user.id)
+
+    expect(page).to have_content("Date du RDV")
+    expect(page).to have_no_content("RDV pris le")
+
+    click_button("RDV à venir")
+
+    within(".dropdown-menu") do
+      expect(page).to have_button("Annulé (excusé)")
+    end
+    expect(page).to have_no_content("RDV pris le")
+  end
+
+  context "when the user has multiple RDVs" do
+    let(:older_motif) do
+      create(:motif, organisation: organisation, motif_category: category_rsa_orientation,
+                     name: "Premier entretien d'orientation")
+    end
+    let(:older_rdv) do
+      create(:rdv, organisation: organisation, motif: older_motif, starts_at: 2.months.ago)
+    end
+    let!(:older_participation) do
+      create(:participation, follow_up:, user:, rdv: older_rdv, status: "seen")
+    end
+
+    it "displays the historical RDVs under the 'Historique sur le suivi' section" do
+      visit organisation_user_follow_ups_path(organisation_id: organisation.id, user_id: user.id)
+
+      expect(page).to have_content("Historique sur le suivi")
+
+      history_section = find("h5", text: "Historique sur le suivi").ancestor("tbody")
+      within(history_section) do
+        expect(page).to have_content("Premier entretien d'orientation")
+        expect(page).to have_no_content("RDV d'orientation")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Lié à : https://www.notion.so/gip-inclusion/R-entrant-Permettre-aux-agents-de-savoir-dans-quelle-organisation-le-RDV-a-eu-lieu-33b5f321b6048011bdf1f3c3c860f24d


**Collapse ajouté sous chaque ligne de RDV** — au clic, affichage de :                                                                     
                                                                                                                                             
  - Convocations envoyées (SMS / Email / Postal) avec date + statut de délivrance (pour l'instant on garde le bloc de convocation existant)                                                           
  - Date et heure de prise du RDV (`RDV pris le`)                                                                                            
  - Auteur de la prise de RDV (`Par` — usager / agent / prescripteur, avec nom et email quand c'est un agent **ou un prescripteur**)             
  - Organisation d'origine du RDV (`Demandé par`)                                                                                            
                                                                                                                                             
  Séparation visuelle d'un RDV principal (le plus récent par `starts_at`) et d'une section `Historique sur le suivi` pour les RDVs antérieurs.   

https://github.com/user-attachments/assets/17b51eef-701d-4d31-97aa-4282f797ed5a

