### PR TITLE
fix(archive): Archived user counter

### DIFF
--- a/app/controllers/concerns/users/sortable.rb
+++ b/app/controllers/concerns/users/sortable.rb
@@ -32,7 +32,10 @@ module Users::Sortable
   end
 
   def archived_order
-    @users = @users.joins(:archives).group("users.id").order("MAX(archives.created_at) DESC")
+    @users = @users.joins(:archives)
+                   .group("users.id")
+                   .select("users.*, MAX(archives.created_at) AS latest_archive_date")
+                   .order(latest_archive_date: :desc)
     @users = @users.where(archives: { organisation_id: @organisation.id }) unless department_level?
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -244,7 +244,7 @@ class UsersController < ApplicationController
     @users = policy_scope(User)
              .preload(:archives, :invitations, :participations)
              .where(id: archived_user_ids_in_organisations(current_organisations))
-             .active
+             .active.distinct
   end
 
   def set_follow_ups


### PR DESCRIPTION
* Dans #3273 on a enlevé le `.distinct` quand on set les usagers ce qui donnait un bug sur les compteurs
* J'en profite pour résoudre [cette erreur](https://sentry.incubateur.net/organizations/betagouv/issues/269198/?project=16&referrer=webhooks_plugin) qui apparait quand on combine certains filtres sur les usagers archivés 