### PR TITLE
fix(archives): Change archiving reasons wording

### DIFF
--- a/app/helpers/archives_helper.rb
+++ b/app/helpers/archives_helper.rb
@@ -18,13 +18,17 @@ module ArchivesHelper
   end
 
   def archived_banner_message(archives)
-    names = archives.map(&:organisation).sort.map(&:name).join(", ")
+    org_names = archives.map(&:organisation).sort.map(&:name).join(", ")
     wording = archives.size > 1 ? "les organisations" : "l'organisation"
-    "Cet usager est archivé sur #{wording} #{names} (#{format_archives_reason(archives)})"
+    message = "Cet usager est archivé sur #{wording} #{org_names}"
+    reason = format_archives_reason(archives)
+    reason.present? ? "#{message} (#{reason})" : message
   end
 
   def format_archives_reason(archives)
-    reason = archives.map(&:archiving_reason).uniq.join(", ")
-    "#{'motif'.pluralize(archives.size)} d'archivage : #{reason}"
+    reasons = archives.map(&:archiving_reason).compact_blank.uniq
+    return if reasons.empty?
+
+    "#{'motif'.pluralize(archives.size)} d'archivage : #{reasons.join(', ')}"
   end
 end

--- a/app/helpers/organisations_badges_helper.rb
+++ b/app/helpers/organisations_badges_helper.rb
@@ -12,8 +12,11 @@ module OrganisationsBadgesHelper
     content_array = ["Archivé le #{format_date(archive.created_at)}"]
 
     if policy(archive).show?
-      content_array << tag.br
-      content_array << "Motif : #{strip_tags(archive.archiving_reason.to_s)}"
+      reason = archive.archiving_reason.to_s
+      if reason.present?
+        content_array << tag.br
+        content_array << "Motif : #{strip_tags(reason)}"
+      end
     end
 
     tooltip(content: safe_join(content_array))

--- a/app/helpers/user_list_upload/user_list_upload_helper.rb
+++ b/app/helpers/user_list_upload/user_list_upload_helper.rb
@@ -111,24 +111,27 @@ module UserListUpload::UserListUploadHelper
   # rubocop:disable Metrics/AbcSize
   def tooltip_content_for_user_row_archived(user_row)
     if user_row.department_level?
-      safe_join(
-        [
-          tag.b("Dossier archivé sur #{strip_tags(user_row.archives.map(&:organisation).map(&:name).join(', '))}."),
-          tag.br,
-          "Motifs d'archivage : #{strip_tags(user_row.archiving_reasons.join(', '))}",
-          tag.br,
-          "Si mis à jour dans l'organisation d'archivage, le dossier sera désarchivé dans cette organisation."
-        ]
-      )
+      reasons = user_row.archiving_reasons.compact_blank
+      parts = [
+        tag.b("Dossier archivé sur #{strip_tags(user_row.archives.map(&:organisation).map(&:name).join(', '))}.")
+      ]
+      if reasons.any?
+        parts << tag.br
+        parts << "Motifs d'archivage : #{strip_tags(reasons.join(', '))}"
+      end
+      parts << tag.br
+      parts << "Si mis à jour dans l'organisation d'archivage, le dossier sera désarchivé dans cette organisation."
     else
-      safe_join([
-                  tag.b("Dossier archivé sur cette organisation."),
-                  tag.br,
-                  "Motif d'archivage : \"#{strip_tags(user_row.archiving_reasons.first)}\"",
-                  tag.br,
-                  "Si coché, le dossier sera désarchivé lors de la mise à jour."
-                ])
+      reason = user_row.archiving_reasons.first.presence
+      parts = [tag.b("Dossier archivé sur cette organisation.")]
+      if reason
+        parts << tag.br
+        parts << "Motif d'archivage : \"#{strip_tags(reason)}\""
+      end
+      parts << tag.br
+      parts << "Si coché, le dossier sera désarchivé lors de la mise à jour."
     end
+    safe_join(parts)
   end
   # rubocop:enable Metrics/AbcSize
 

--- a/app/helpers/user_list_upload/user_list_upload_helper.rb
+++ b/app/helpers/user_list_upload/user_list_upload_helper.rb
@@ -111,7 +111,7 @@ module UserListUpload::UserListUploadHelper
   # rubocop:disable Metrics/AbcSize
   def tooltip_content_for_user_row_archived(user_row)
     if user_row.department_level?
-      reasons = user_row.archiving_reasons.compact_blank
+      reasons = user_row.archiving_reasons
       parts = [
         tag.b("Dossier archivé sur #{strip_tags(user_row.archives.map(&:organisation).map(&:name).join(', '))}.")
       ]
@@ -122,7 +122,7 @@ module UserListUpload::UserListUploadHelper
       parts << tag.br
       parts << "Si mis à jour dans l'organisation d'archivage, le dossier sera désarchivé dans cette organisation."
     else
-      reason = user_row.archiving_reasons.first.presence
+      reason = user_row.archiving_reasons.first
       parts = [tag.b("Dossier archivé sur cette organisation.")]
       if reason
         parts << tag.br

--- a/app/models/user_list_upload/user_row.rb
+++ b/app/models/user_list_upload/user_row.rb
@@ -146,7 +146,7 @@ class UserListUpload::UserRow < ApplicationRecord
   end
 
   def archiving_reasons
-    archives.map(&:archiving_reason)
+    archives.map(&:archiving_reason).compact_blank
   end
 
   def matching_user_follow_up

--- a/app/views/user_list_uploads/user_list_uploads/_user_row_details.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_user_row_details.html.erb
@@ -5,7 +5,7 @@
         <p class="fw-bold text-dark-blue mb-0"><%= user_row.user.full_name_stripped %></p>
         <% if user_row.archived? %>
           <div class="ms-3">
-            <span class="badge rounded-pill background-brown-light text-brown fs-archived-badge">Archivé <%= "(motif: #{user_row.archiving_reasons.first})" if user_row.archiving_reasons.length == 1 && user_row.archiving_reasons.first.present? %></span>
+            <span class="badge rounded-pill background-brown-light text-brown fs-archived-badge">Archivé <%= "(motif: #{user_row.archiving_reasons.first})" if user_row.archives.length == 1 && user_row.archiving_reasons.any? %></span>
           </div>
         <% end %>
       </div>

--- a/app/views/user_list_uploads/user_list_uploads/_user_row_details.html.erb
+++ b/app/views/user_list_uploads/user_list_uploads/_user_row_details.html.erb
@@ -5,7 +5,7 @@
         <p class="fw-bold text-dark-blue mb-0"><%= user_row.user.full_name_stripped %></p>
         <% if user_row.archived? %>
           <div class="ms-3">
-            <span class="badge rounded-pill background-brown-light text-brown fs-archived-badge">Archivé <%= "(motif: #{user_row.archiving_reasons.first})" if user_row.archiving_reasons.length == 1 %></span>
+            <span class="badge rounded-pill background-brown-light text-brown fs-archived-badge">Archivé <%= "(motif: #{user_row.archiving_reasons.first})" if user_row.archiving_reasons.length == 1 && user_row.archiving_reasons.first.present? %></span>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-Ne-pas-mentionner-Motif-d-archivage-lorsqu-il-n-est-pas-renseign-33d5f321b60480b0b249e0ede4e8ab3a?source=copy_link

Je fais en sorte de ne jamais mentionner les motifs d'archivage lorsqu'il n'y en a pas de renseigné. Cela pouvait arriver sur:  *
* La page show (banner et tooltip)
* La page upload