### PR TITLE
bug(sidekiq): handle scheduled and broadcast default queue behavior

### DIFF
--- a/app/models/sidekiq/scheduler.rb
+++ b/app/models/sidekiq/scheduler.rb
@@ -3,7 +3,7 @@ class Sidekiq::Scheduler
     new(job_class, *, at: at).schedule_uniq_job
   end
 
-  def initialize(job_class, *args, at:, queue: "default")
+  def initialize(job_class, *args, at:, queue: "whenever")
     @job_class = job_class
     @args = args
     @at = at

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module RdvInsertion
 
     # Use Sidekiq as the ActiveJob queue adapter
     config.active_job.queue_adapter = :sidekiq
+    config.active_job.default_queue_name = :within_5min
 
     # specify redis url
     config.x.redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379" }

--- a/config/initializers/turbo.rb
+++ b/config/initializers/turbo.rb
@@ -1,0 +1,7 @@
+Rails.application.config.after_initialize do
+  [
+    Turbo::Streams::BroadcastStreamJob,
+    Turbo::Streams::ActionBroadcastJob,
+    Turbo::Streams::BroadcastJob
+  ].each { |job| job.queue_as :within_30s }
+end

--- a/config/initializers/turbo.rb
+++ b/config/initializers/turbo.rb
@@ -1,7 +1,0 @@
-Rails.application.config.after_initialize do
-  [
-    Turbo::Streams::BroadcastStreamJob,
-    Turbo::Streams::ActionBroadcastJob,
-    Turbo::Streams::BroadcastJob
-  ].each { |job| job.queue_as :within_30s }
-end

--- a/spec/models/sidekiq/scheduler_spec.rb
+++ b/spec/models/sidekiq/scheduler_spec.rb
@@ -20,7 +20,7 @@ describe Sidekiq::Scheduler do
         expect(scheduled_set.size).to eq(1)
         expect(scheduled_set.first.display_class).to eq(job_class.to_s)
         expect(scheduled_set.first.display_args).to eq(args)
-        expect(scheduled_set.first.queue).to eq("default")
+        expect(scheduled_set.first.queue).to eq("whenever")
         expect(scheduled_set.first.at.to_i).to eq(at.to_i)
       end
     end
@@ -29,7 +29,7 @@ describe Sidekiq::Scheduler do
       let!(:old_time) { 30.minutes.from_now }
 
       before do
-        job_class.set(wait_until: old_time, queue: "default")
+        job_class.set(wait_until: old_time, queue: "whenever")
                  .perform_later(*args)
       end
 
@@ -43,7 +43,7 @@ describe Sidekiq::Scheduler do
         expect(scheduled_set.size).to eq(1)
         expect(scheduled_set.first.display_class).to eq(job_class.to_s)
         expect(scheduled_set.first.display_args).to eq(args)
-        expect(scheduled_set.first.queue).to eq("default")
+        expect(scheduled_set.first.queue).to eq("whenever")
         expect(scheduled_set.first.at.to_i).to eq(at.to_i)
       end
     end


### PR DESCRIPTION
 ## Problème                                                                                                                                
                                                                                                                                             
  Depuis #3275, la queue Sidekiq `default` n'est plus consommée par les workers, mais deux sources continuent d'y enqueuer des jobs, ce qui fait grossir la queue indéfiniment :                                                                                                                             
                                                                                                                                             
  - `Sidekiq::Scheduler` force `queue: "default"` et écrase le `queue_as` du job via `.set(queue: ...)`. Impacte `FollowUps::RefreshStatusesJob` planifié par `FollowUps::PlanStatusRefreshJob`.                                                                                                       
  - Les jobs `Turbo::Streams::*` héritent de `ActiveJob::Base` (pas de `ApplicationJob`), donc ils partent sur la queue `default` par défaut.                                                                   
                                                                                                                                             
  ## Correctif                                                                                                                               
                  
  - `config.active_job.default_queue_name = :within_5min` pour couvrir tous les jobs héritant directement de `ActiveJob::Base` (Turbo, ActiveStorage, mailers éventuels, etc.).                                                                                                                        
  - Queue par défaut du `Sidekiq::Scheduler` → `whenever`.                                                                                           
                  
  ## Suite                                                                                                                                   
                  
Les jobs en attente dans la queue `default` devront être vidés manuellement en prod (déplacer les`FollowUps::RefreshStatusesJob` vers `whenever`, les jobs Turbo peuvent être supprimés car obsolètes)