### PR TITLE
fix(upload): Fix matching user priorization

### DIFF
--- a/app/models/concerns/user_list_upload/user_row/matching_user.rb
+++ b/app/models/concerns/user_list_upload/user_row/matching_user.rb
@@ -10,13 +10,32 @@ module UserListUpload::UserRow::MatchingUser
   end
 
   def find_matching_user
-    potential_matching_users_in_department.find do |user|
-      matches_nir?(user.nir) ||
-        matches_department_internal_id?(user.department_internal_id) ||
-        matches_email?(user.email, user.first_name) ||
-        matches_phone_number?(user.phone_number, user.first_name) ||
-        matches_affiliation_number_and_role?(user.affiliation_number, user.role)
-    end
+    users = potential_matching_users_in_department
+    find_by_nir(users) ||
+      find_by_department_internal_id(users) ||
+      find_by_email(users) ||
+      find_by_phone_number(users) ||
+      find_by_affiliation_number_and_role(users)
+  end
+
+  def find_by_nir(users)
+    users.find { |user| matches_nir?(user.nir) }
+  end
+
+  def find_by_department_internal_id(users)
+    users.find { |user| matches_department_internal_id?(user.department_internal_id) }
+  end
+
+  def find_by_email(users)
+    users.find { |user| matches_email?(user.email, user.first_name) }
+  end
+
+  def find_by_phone_number(users)
+    users.find { |user| matches_phone_number?(user.phone_number, user.first_name) }
+  end
+
+  def find_by_affiliation_number_and_role(users)
+    users.find { |user| matches_affiliation_number_and_role?(user.affiliation_number, user.role) }
   end
 
   def matches_nir?(candidate_nir)

--- a/spec/models/concerns/user_list_upload/user_row/matching_user_spec.rb
+++ b/spec/models/concerns/user_list_upload/user_row/matching_user_spec.rb
@@ -146,14 +146,13 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
         let(:org_in_department) { create(:organisation, department: department) }
 
         context "NIR has highest priority" do
-          let!(:nir_match) do
-            create(:user, nir: "1234567890123", first_name: "Different", organisations: [org_in_department])
-          end
-          let!(:internal_id_match) do
-            create(:user, department_internal_id: "ABC123", first_name: "John", organisations: [org_in_department])
-          end
-          let!(:email_match) do
-            create(:user, email: "john@example.com", first_name: "John", organisations: [org_in_department])
+          let(:nir_match) { build(:user, nir: "1234567890123") }
+          let(:internal_id_match) { build(:user, department_internal_id: "ABC123", first_name: "John") }
+          let(:email_match) { build(:user, email: "john@example.com", first_name: "John") }
+
+          before do
+            allow(user_row).to receive(:potential_matching_users_in_department)
+              .and_return([internal_id_match, email_match, nir_match])
           end
 
           it "matches by NIR even when other criteria would match" do
@@ -163,15 +162,13 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
         end
 
         context "department internal ID has second priority" do
-          # No NIR match
-          let!(:internal_id_match) do
-            create(:user, department_internal_id: "ABC123", first_name: "Different", organisations: [org_in_department])
-          end
-          let!(:email_match) do
-            create(:user, email: "john@example.com", first_name: "John", organisations: [org_in_department])
-          end
-          let!(:phone_match) do
-            create(:user, phone_number: "+33612345678", first_name: "John", organisations: [org_in_department])
+          let(:internal_id_match) { build(:user, department_internal_id: "ABC123") }
+          let(:email_match) { build(:user, email: "john@example.com", first_name: "John") }
+          let(:phone_match) { build(:user, phone_number: "+33612345678", first_name: "John") }
+
+          before do
+            allow(user_row).to receive(:potential_matching_users_in_department)
+              .and_return([email_match, phone_match, internal_id_match])
           end
 
           it "matches by department internal ID when NIR doesn't match" do
@@ -181,15 +178,13 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
         end
 
         context "email has third priority" do
-          # No NIR match or internal ID match
-          let!(:email_match) do
-            create(:user, email: "john@example.com", first_name: "John", organisations: [org_in_department])
-          end
-          let!(:phone_match) do
-            create(:user, phone_number: "+33612345678", first_name: "John", organisations: [org_in_department])
-          end
-          let!(:affiliation_match) do
-            create(:user, affiliation_number: "1234567890", role: "demandeur", organisations: [org_in_department])
+          let(:email_match) { build(:user, email: "john@example.com", first_name: "John") }
+          let(:phone_match) { build(:user, phone_number: "+33612345678", first_name: "John") }
+          let(:affiliation_match) { build(:user, affiliation_number: "1234567890", role: "demandeur") }
+
+          before do
+            allow(user_row).to receive(:potential_matching_users_in_department)
+              .and_return([phone_match, affiliation_match, email_match])
           end
 
           it "matches by email when higher priority criteria don't match" do
@@ -199,12 +194,12 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
         end
 
         context "phone number has fourth priority" do
-          # No NIR, internal ID, or email match
-          let!(:phone_match) do
-            create(:user, phone_number: "+33612345678", first_name: "John", organisations: [org_in_department])
-          end
-          let!(:affiliation_match) do
-            create(:user, affiliation_number: "1234567890", role: "demandeur", organisations: [org_in_department])
+          let(:phone_match) { build(:user, phone_number: "+33612345678", first_name: "John") }
+          let(:affiliation_match) { build(:user, affiliation_number: "1234567890", role: "demandeur") }
+
+          before do
+            allow(user_row).to receive(:potential_matching_users_in_department)
+              .and_return([affiliation_match, phone_match])
           end
 
           it "matches by phone number when higher priority criteria don't match" do
@@ -214,9 +209,11 @@ RSpec.describe UserListUpload::UserRow::MatchingUser, type: :concern do
         end
 
         context "affiliation number and role has lowest priority" do
-          # Only affiliation number match exists
-          let!(:affiliation_match) do
-            create(:user, affiliation_number: "1234567890", role: "demandeur", organisations: [org_in_department])
+          let(:affiliation_match) { build(:user, affiliation_number: "1234567890", role: "demandeur") }
+
+          before do
+            allow(user_row).to receive(:potential_matching_users_in_department)
+              .and_return([affiliation_match])
           end
 
           it "matches by affiliation number when all other criteria don't match" do


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Investigation-erreurs-matching-33b5f321b60480948b3dce4b8c46be04?source=copy_link

Dans #3243 j'avais fait une erreur en refactorant la méthode `user_row#find_matching_user`: on récupérait le premier usagers dans la liste qui match un des critères, et non pas celui qui match le critère prioritaire en premier.
Cela a pour conséquence qu'on a eu quelques erreurs "Un usager avec le même Numéro de sécurité sociale se trouve au sein du département" puisque la règle d'unicité du `nir` est toujours valable et que l'on matchait pas forcément le bon usager.

Je fix ça ici en parcourant tous les match potentiel par critère de priorité.