### PR TITLE
feat(app): Add rdvs time zone

### DIFF
--- a/app/blueprints/participation_blueprint.rb
+++ b/app/blueprints/participation_blueprint.rb
@@ -1,6 +1,11 @@
 class ParticipationBlueprint < ApplicationBlueprint
   identifier :id
-  fields :status, :created_at, :starts_at
+  fields :status, :created_at
+
+  field :starts_at do |participation, _options|
+    participation.starts_at_in_time_zone
+  end
+
   association :user, blueprint: UserBlueprint
 
   # Retrocompatibility with the old API format for created_by

--- a/app/blueprints/rdv_blueprint.rb
+++ b/app/blueprints/rdv_blueprint.rb
@@ -1,7 +1,11 @@
 class RdvBlueprint < ApplicationBlueprint
   identifier :id
-  fields :starts_at, :duration_in_min, :cancelled_at, :address, :uuid, :created_by,
+  fields :duration_in_min, :cancelled_at, :address, :uuid, :created_by,
          :status, :users_count, :max_participants_count, :rdv_solidarites_rdv_id
+
+  field :starts_at do |rdv, _options|
+    rdv.starts_at_in_time_zone
+  end
 
   view :extended do
     association :agents, blueprint: AgentBlueprint

--- a/app/models/concerns/participation/france_travail_payload.rb
+++ b/app/models/concerns/participation/france_travail_payload.rb
@@ -8,7 +8,7 @@ module Participation::FranceTravailPayload
     {
       id: france_travail_id,
       adresse: address,
-      date: starts_at.to_datetime,
+      date: starts_at_in_time_zone,
       duree: duration_in_min,
       information: motif.instruction_for_rdv,
       initiateur: france_travail_initiateur,

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -31,7 +31,7 @@ class Participation < ApplicationRecord
 
   enum :created_by_type, { agent: "Agent", user: "User", prescripteur: "Prescripteur" }, prefix: true
 
-  delegate :starts_at, :motif, :lieu, :collectif?, :by_phone?, :duration_in_min,
+  delegate :starts_at, :starts_at_in_time_zone, :motif, :lieu, :collectif?, :by_phone?, :duration_in_min,
            :rdv_solidarites_url, :rdv_solidarites_rdv_id, :instruction_for_rdv, :address,
            to: :rdv
   delegate :department, :department_id, to: :organisation

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -1,7 +1,7 @@
 class Rdv < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
     :address, :cancelled_at, :context, :created_by, :duration_in_min, :starts_at, :status, :uuid,
-    :users_count, :max_participants_count, :visio_url
+    :users_count, :max_participants_count, :visio_url, :time_zone
   ].freeze
 
   include Notificable
@@ -31,7 +31,7 @@ class Rdv < ApplicationRecord
   # Needed to build participations in process_rdv_job
   accepts_nested_attributes_for :participations, allow_destroy: true, reject_if: :new_participation_already_created?
 
-  validates :starts_at, :duration_in_min, presence: true
+  validates :starts_at, :duration_in_min, :time_zone, presence: true
   validates :rdv_solidarites_rdv_id, uniqueness: true, allow_nil: true
   validates :visio_url, presence: true, if: :visio?
 

--- a/app/models/rdv.rb
+++ b/app/models/rdv.rb
@@ -62,15 +62,20 @@ class Rdv < ApplicationRecord
       "#{organisation.rdv_solidarites_organisation_id}/rdvs/#{rdv_solidarites_rdv_id}"
   end
 
+  def starts_at_in_time_zone
+    starts_at.in_time_zone(time_zone)
+  end
+
   def formatted_start_date
-    starts_at.to_datetime.strftime("%d/%m/%y")
+    starts_at_in_time_zone.strftime("%d/%m/%y")
   end
 
   def formatted_start_time
-    hour = starts_at.to_datetime.strftime("%-H")
-    minutes = starts_at.to_datetime.strftime("%M")
-
-    minutes == "00" ? "#{hour}h" : "#{hour}h#{minutes}"
+    if starts_at_in_time_zone.min.zero?
+      starts_at_in_time_zone.strftime("%-Hh")
+    else
+      starts_at_in_time_zone.strftime("%-Hh%M")
+    end
   end
 
   def phone_number

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -185,7 +185,7 @@ module Exporters
     end
 
     def last_rdv_starts_at(user)
-      last_rdv(user)&.starts_at
+      last_rdv(user)&.starts_at_in_time_zone
     end
 
     def last_participation_created_at(user)

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -72,8 +72,8 @@ module Exporters
     def csv_row(participation) # rubocop:disable Metrics/AbcSize
       user = participation.user
 
-      [display_date(participation.starts_at),
-       display_time(participation.starts_at),
+      [display_date(participation.starts_at_in_time_zone),
+       display_time(participation.starts_at_in_time_zone),
        rdv_motif(participation),
        rdv_type(participation),
        rdv_taken_in_autonomy?(participation),

--- a/app/views/follow_ups/_follow_up.html.erb
+++ b/app/views/follow_ups/_follow_up.html.erb
@@ -51,7 +51,7 @@
                         <%= tooltip(content: participation_created_by_tooltip_content(participation)) %>>
                       </i>
                     </td>
-                    <td class="px-4 py-3"><%= format_date(participation.starts_at) %></td>
+                    <td class="px-4 py-3"><%= format_date(participation.starts_at_in_time_zone) %></td>
                     <td class="px-2 py-3"><%= participation.motif.name %></td>
                     <td class="px-4 py-3 participation_status" >
                       <% if participation.rdv.rdv_solidarites_rdv_id && policy(participation).edit?  %>

--- a/app/views/follow_ups/_follow_up_status_cell.html.erb
+++ b/app/views/follow_ups/_follow_up_status_cell.html.erb
@@ -6,8 +6,8 @@
   <%= display_follow_up_status(follow_up) %>
   <%# We need to check the participations presence on top of the statuses since the follow_up status is updated asynchronously, so for a brief period of time the follow_up can be in status rdv_pending whereas the rdv status has been updated and is not pending anymore %>
   <% if follow_up.rdv_pending? && follow_up.pending_rdv %>
-    <span><%= " (le #{format_date(follow_up.pending_rdv.starts_at)})" %></span>
+    <span><%= " (le #{format_date(follow_up.pending_rdv.starts_at_in_time_zone)})" %></span>
   <% elsif follow_up.rdv_seen? && follow_up.last_seen_participation %>
-    <span><%= " (le #{format_date(follow_up.last_seen_participation.starts_at)})" %></span>
+    <span><%= " (le #{format_date(follow_up.last_seen_participation.starts_at_in_time_zone)})" %></span>
   <% end %>
 </td>

--- a/app/views/letters/notifications/by_phone_participation_created.html.erb
+++ b/app/views/letters/notifications/by_phone_participation_created.html.erb
@@ -8,7 +8,7 @@
 <div class="main-content">
   <p><%= user.title_in_letter %>,</p>
   <p>Vous êtes <%= user_designation %> et à ce titre vous êtes <%= user.conjugate("convoqué") %> à un <%= rdv_title %> pour <%= rdv_purpose %>.</p>
-  <p>Un conseiller d'insertion<%= " (#{agents_names})" if agents_names.present? %> vous appellera le <strong><%= I18n.l(rdv.starts_at, format: :human) %></strong> sur votre numéro de téléphone&nbsp;: <strong><%= user.phone_number %></strong>.</p>
+  <p>Un conseiller d'insertion<%= " (#{agents_names})" if agents_names.present? %> vous appellera le <strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong> sur votre numéro de téléphone&nbsp;: <strong><%= user.phone_number %></strong>.</p>
   <%= tag.p tag.strong("#{mandatory_warning}.") if mandatory_warning %>
   <%= tag.p tag.span(instruction_for_rdv) if instruction_for_rdv.present? %>
   <%= tag.p tag.strong("En cas d'absence, #{punishable_warning}.") if punishable_warning.present? %>

--- a/app/views/letters/notifications/participation_cancelled.html.erb
+++ b/app/views/letters/notifications/participation_cancelled.html.erb
@@ -7,7 +7,7 @@
 
 <div class="main-content">
   <p><%= user.title_in_letter %>,</p>
-  <p>Votre <%= rdv_title %>, prévu le <%= I18n.l(rdv.starts_at, format: :human) %> dans le cadre de votre <%= rdv_subject %> a été annulé.</p>
+  <p>Votre <%= rdv_title %>, prévu le <%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %> dans le cadre de votre <%= rdv_subject %> a été annulé.</p>
   <p>Pour plus d'informations, veuillez appeler le <%= rdv.phone_number %>.</p>
   <%= render "letters/salutation", user: user %>
   <br/>

--- a/app/views/letters/notifications/presential_participation_created.html.erb
+++ b/app/views/letters/notifications/presential_participation_created.html.erb
@@ -10,7 +10,7 @@
 <div class="main-content">
   <p><%= user.title_in_letter %>,</p>
   <p>Vous êtes <%= user_designation %> et à ce titre vous êtes <%= user.conjugate("convoqué") %> à un <%= rdv_title %> pour <%= rdv_purpose %>.</p>
-  <p>Vous êtes <%= user.conjugate("attendu") %> le <strong><%= I18n.l(rdv.starts_at, format: :human) %></strong>, à l'adresse suivante&nbsp;:</p>
+  <p>Vous êtes <%= user.conjugate("attendu") %> le <strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong>, à l'adresse suivante&nbsp;:</p>
   <div class="rdv-address">
     <div class="text-center">
       <%= pdf_clock_icon %> <strong><%= rdv.lieu.name %></strong>

--- a/app/views/letters/notifications/visio_participation_created.html.erb
+++ b/app/views/letters/notifications/visio_participation_created.html.erb
@@ -8,7 +8,7 @@
 <div class="main-content">
   <p><%= user.title_in_letter %>,</p>
   <p>Vous êtes <%= user_designation %> et à ce titre vous êtes <%= user.conjugate("convoqué") %> à un <%= rdv_title %> par visioconférence pour <%= rdv_purpose %>.</p>
-  <p>Vous devez vous connecter le <strong><%= I18n.l(rdv.starts_at, format: :human) %></strong> sur le lien suivant&nbsp;:</p>
+  <p>Vous devez vous connecter le <strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong> sur le lien suivant&nbsp;:</p>
   <div class="rdv-address">
     <div class="text-center">
       <strong class="bold-blue"><%= rdv.visio_url %></strong>

--- a/app/views/mailers/notification_mailer/_by_phone_rdv_infos.html.erb
+++ b/app/views/mailers/notification_mailer/_by_phone_rdv_infos.html.erb
@@ -4,7 +4,7 @@
   <div>🕐</div>
   <div>
     Votre rendez-vous téléphonique
-    <p><strong><%= I18n.l(rdv.starts_at, format: :human) %></strong></p>
+    <p><strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong></p>
   </div>
 </div>
 

--- a/app/views/mailers/notification_mailer/_cancelled_rdv_infos.html.erb
+++ b/app/views/mailers/notification_mailer/_cancelled_rdv_infos.html.erb
@@ -3,7 +3,7 @@
 <div class="info-block">
   <div>🕐</div>
   <div>
-    <p class="text-line-through text-light-grey"><%= I18n.l(rdv.starts_at, format: :human) %></p>
+    <p class="text-line-through text-light-grey"><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></p>
     <p>Votre rendez-vous est annulé</p>
   </div>
 </div>

--- a/app/views/mailers/notification_mailer/_presential_rdv_infos.html.erb
+++ b/app/views/mailers/notification_mailer/_presential_rdv_infos.html.erb
@@ -4,7 +4,7 @@
   <div>🕐</div>
   <div>
     Vous êtes <%= user.conjugate("attendu") %> :
-    <p><strong><%= I18n.l(rdv.starts_at, format: :human) %></strong></p>
+    <p><strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong></p>
   </div>
 </div>
 

--- a/app/views/mailers/notification_mailer/_visio_rdv_infos.html.erb
+++ b/app/views/mailers/notification_mailer/_visio_rdv_infos.html.erb
@@ -4,7 +4,7 @@
   <div>🕐</div>
   <div>
     Votre rendez-vous par visioconférence
-    <p><strong><%= I18n.l(rdv.starts_at, format: :human) %></strong></p>
+    <p><strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong></p>
   </div>
 </div>
 

--- a/app/views/mailers/organisation_mailer/notify_rdv_changes.html.erb
+++ b/app/views/mailers/organisation_mailer/notify_rdv_changes.html.erb
@@ -6,7 +6,7 @@
 
 <p>
   <b>Évènement : <%= I18n.t("external_notifications.events_description.#{@event}") %></b><br />
-  Date du rdv : <%= I18n.l(@rdv.starts_at, format: :human) %><br />
+  Date du rdv : <%= I18n.l(@rdv.starts_at_in_time_zone, format: :human) %><br />
   Usager(s) concerné(s) :
 </p>
 <ul>

--- a/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
+++ b/app/views/mailers/reply_transfer_mailer/forward_notification_reply_to_organisation.html.erb
@@ -10,7 +10,7 @@
   <%= tag.p(@user.phone_number) if @user&.phone_number %>
   <br />
   <h4>Message envoyé par rdv-insertion</h4>
-  <p>Convocation pour un rdv le <%= I18n.l(@rdv.starts_at, format: :human) %></p>
+  <p>Convocation pour un rdv le <%= I18n.l(@rdv.starts_at_in_time_zone, format: :human) %></p>
   <p>Motif : <%= @rdv.motif_name %> </p>
   <%= tag.p("Lieu : #{@rdv.lieu.name}") if @rdv.lieu.present? %>
   <%= tag.p("Adresse : #{@rdv.lieu.address}") if @rdv.lieu.present? %>

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -373,6 +373,7 @@ tables:
       - lieu_id
       - users_count
       - max_participants_count
+      - time_zone
 
   - table_name: referent_assignations
     non_anonymized_column_names:

--- a/db/migrate/20260420154821_add_time_zone_to_rdvs.rb
+++ b/db/migrate/20260420154821_add_time_zone_to_rdvs.rb
@@ -1,0 +1,6 @@
+class AddTimeZoneToRdvs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :rdvs, :time_zone, :string
+    up_only { Rdv.update_all(time_zone: "Europe/Paris") }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_18_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_154821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -465,6 +465,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_000000) do
     t.bigint "rdv_solidarites_rdv_id"
     t.datetime "starts_at", precision: nil
     t.string "status"
+    t.string "time_zone"
     t.datetime "updated_at", null: false
     t.integer "users_count", default: 0
     t.string "uuid"

--- a/spec/factories/rdv.rb
+++ b/spec/factories/rdv.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     motif
     status { "unknown" }
     created_by { "user" }
+    time_zone { "Europe/Paris" }
     address { "2O avenue de Ségur, 75007 Paris" }
     lieu
     agents { [create(:agent)] }

--- a/spec/models/rdv_spec.rb
+++ b/spec/models/rdv_spec.rb
@@ -207,4 +207,51 @@ describe Rdv do
       rdv.update!(starts_at: 1.day.from_now)
     end
   end
+
+  describe "#starts_at_in_time_zone" do
+    context "when time_zone is Europe/Paris" do
+      let(:rdv) { build(:rdv, starts_at: Time.zone.parse("2026-04-09 08:30:00"), time_zone: "Europe/Paris") }
+
+      it "returns starts_at in Paris timezone" do
+        expect(rdv.starts_at_in_time_zone).to eq(rdv.starts_at.in_time_zone("Europe/Paris"))
+        expect(rdv.starts_at_in_time_zone.strftime("%H:%M")).to eq("08:30")
+      end
+    end
+
+    context "when time_zone is Indian/Reunion" do
+      let(:rdv) { build(:rdv, starts_at: Time.zone.parse("2026-04-09 08:30:00"), time_zone: "Indian/Reunion") }
+
+      it "returns starts_at converted to Reunion timezone" do
+        expect(rdv.starts_at_in_time_zone.strftime("%H:%M")).to eq("10:30")
+      end
+    end
+  end
+
+  describe "#formatted_start_time" do
+    context "when time_zone is Indian/Reunion" do
+      let(:rdv) { build(:rdv, starts_at: Time.zone.parse("2026-04-09 08:30:00"), time_zone: "Indian/Reunion") }
+
+      it "formats the time in the RDV timezone" do
+        expect(rdv.formatted_start_time).to eq("10h30")
+      end
+    end
+
+    context "when minutes are 00" do
+      let(:rdv) { build(:rdv, starts_at: Time.zone.parse("2026-04-09 08:00:00"), time_zone: "Indian/Reunion") }
+
+      it "omits minutes" do
+        expect(rdv.formatted_start_time).to eq("10h")
+      end
+    end
+  end
+
+  describe "#formatted_start_date" do
+    context "when time_zone is Indian/Reunion" do
+      let(:rdv) { build(:rdv, starts_at: Time.zone.parse("2026-04-09 08:30:00"), time_zone: "Indian/Reunion") }
+
+      it "formats the date in the RDV timezone" do
+        expect(rdv.formatted_start_date).to eq("09/04/26")
+      end
+    end
+  end
 end

--- a/spec/services/upsert_record_spec.rb
+++ b/spec/services/upsert_record_spec.rb
@@ -31,7 +31,7 @@ describe UpsertRecord, type: :service do
     let!(:rdv_solidarites_rdv_id) { 12 }
     let!(:rdv_solidarites_attributes) do
       { id: 12, starts_at: starts_at, duration_in_min: duration_in_min,
-        status: status, created_by_type: created_by_type }
+        status: status, created_by_type: created_by_type, time_zone: time_zone }
     end
     let!(:user) { create(:user, id: user_id) }
     let!(:follow_up) { create(:follow_up) }
@@ -41,6 +41,7 @@ describe UpsertRecord, type: :service do
     let!(:duration_in_min) { 45 }
     let!(:status) { "unknown" }
     let!(:created_by_type) { "user" }
+    let!(:time_zone) { "Europe/Paris" }
 
     describe "#call" do
       context "when the record exists" do


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-Timezone-3445f321b604808290dbe31862abd9bc?source=copy_link

Lié à [cette PR](https://github.com/betagouv/rdv-service-public/pull/6340) côté RDV-S.

## Contexte

On a un souci sur les rdvs qui sont dans d'autres fuseaux horaires que celui de Paris (qui est celui de nos serveurs).
En effet depuis [ce changement](https://github.com/betagouv/rdv-service-public/pull/6207) côté RDV-S, on reçoit les heures de rdvs dans la timezone correspondante à celle de l'orga, or lorsque l'on va les sauvegarder en BDD Rails va les convertir dans la timezone de notre serveur 
=> Les heures de rdvs qui sont affichés à nos usagers pour les convocations ne sont pas bonnes car dans le mauvais fuseau horaire

## Solution

Après discussion avec RDV-S, l'idée est de récupérer le fuseau horaire du rdv et de le sauvegarder côté rdv-i. Ainsi même si l'heure du rdv est sauvegardé dans le fuseau horaire de notre serveur, on peut faire en sorte de l'afficher à l'usager dans le fuseau du rdv.
Pour cela: 
* RDV-S nous renvoie maintenant la `time_zone` du rdv: https://github.com/betagouv/rdv-service-public/pull/6340
* Je fais en sorte de cette PR de:
  * Ajouter une colonne `time_zone` à notre table `rdvs`
  * Sauvegarder cette `time_zone` à la réception des webhooks
  * Afficher les heures de rdvs dans la time zone concernée pour les notifications

⚠️ À faire après le merge: j'ai fait en sorte que tous les rdvs soient sur la `time_zone` par défaut `Europe/Paris`, mais il faudra les changer manuellement pour les rdvs des  **4** organisations rdv insertion dont la `time_zone` n'est pas `Europe/Paris`