### PR TITLE
fix(migration): Increase timeout for db migration

### DIFF
--- a/db/migrate/20260420154821_add_time_zone_to_rdvs.rb
+++ b/db/migrate/20260420154821_add_time_zone_to_rdvs.rb
@@ -1,4 +1,7 @@
 class AddTimeZoneToRdvs < ActiveRecord::Migration[8.1]
+  set_lock_timeout(60_000)
+  set_statement_timeout(120_000)
+
   def change
     add_column :rdvs, :time_zone, :string
     up_only { Rdv.update_all(time_zone: "Europe/Paris") }


### PR DESCRIPTION
J'augmente le timeout pour la migration dans #3282 parce qu'elle prend plus de 5 secondes en prod.
Je fais le déploiement en soirée donc ça ne devrait pas avoir d'incidence sur nos utilisateurs