### PR TITLE
matomo(user index): add id on intervention necessaire button for analytics

### DIFF
--- a/app/views/users/filters/_by_action_required_checkbox.html.erb
+++ b/app/views/users/filters/_by_action_required_checkbox.html.erb
@@ -1,7 +1,7 @@
 <div class="mx-2">
   <div class="w-100">
     <%= link_to structure_users_path(url_params.merge(action_required: params[:action_required] == "true" ? nil : "true")) do %>
-      <button class="btn btn-grey w-100">
+      <button class="btn btn-grey w-100" id="rdvi_index-nav_filter-action-required-button">
         Intervention nécessaire
         <% if params[:action_required] == "true" %>
           <span class="filter-active ms-1">1</span>


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/V-rifier-le-tracking-du-bouton-Intervention-n-cessaire-3435f321b60480c4b508f97a25ce0d2c