### PR TITLE
fix(csv exports): avoid OOM crashes on high-volume CSV exports

### DIFF
--- a/app/jobs/exporters/create_users_csv_export_job.rb
+++ b/app/jobs/exporters/create_users_csv_export_job.rb
@@ -1,5 +1,12 @@
 module Exporters
   class CreateUsersCsvExportJob < ApplicationJob
+    sidekiq_options retry: 0
+
+    rescue_from(StandardError) do |exception|
+      notify_failure
+      raise exception
+    end
+
     attr_reader :user_ids, :structure, :agent, :request_params
 
     def perform(user_ids, structure_type, structure_id, agent_id, request_params = nil)
@@ -13,6 +20,12 @@ module Exporters
     end
 
     private
+
+    def notify_failure
+      return if @agent.nil?
+
+      CsvExportMailer.notify_export_failure(@agent.email).deliver_now
+    end
 
     def create_export
       ActiveRecord::Base.transaction do

--- a/app/mailers/csv_export_mailer.rb
+++ b/app/mailers/csv_export_mailer.rb
@@ -7,6 +7,10 @@ class CsvExportMailer < ApplicationMailer
     mail(to: email, subject: "[rdv-insertion] Export CSV")
   end
 
+  def notify_export_failure(email)
+    mail(to: email, subject: "[rdv-insertion] Échec de votre export CSV")
+  end
+
   private
 
   def set_request_filters

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -35,26 +35,26 @@ module Exporters
     end
 
     def each_element(&)
-      @users.each(&)
+      @users_scope.find_each(batch_size: 500, &)
     end
 
     def preload_associations
-      @users =
+      @users_scope =
         if @motif_category
-          User.preload(
-            :archives, :organisations, :tags, :referents, :rdvs, :address_geocoding,
+          User.where(id: @user_ids).preload(
+            :archives, :organisations, :tags, :referents, :address_geocoding,
             participations: [:organisation, :follow_up],
-            follow_ups: [:invitations, :motif_category, :notifications, { rdvs: [:motif, :participations, :users] }],
+            follow_ups: [:invitations, :motif_category, :notifications, { rdvs: [:motif, :participations] }],
             orientations: [:orientation_type, :organisation]
-          ).find(@user_ids)
+          )
         else
-          User.preload(
+          User.where(id: @user_ids).preload(
             :invitations, :notifications, :archives, :organisations, :tags, :referents, :address_geocoding,
             follow_ups: [:motif_category, :participations, :rdvs],
             participations: [:organisation, :rdv, { follow_up: :motif_category }],
             rdvs: [:motif, :participations],
             orientations: [:orientation_type, :organisation]
-          ).find(@user_ids)
+          )
         end
     end
 

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -42,14 +42,16 @@ module Exporters
       @users_scope =
         if @motif_category
           User.where(id: @user_ids).preload(
-            :archives, :organisations, :tags, :referents, :address_geocoding,
-            participations: [:organisation, :follow_up],
+            :archives, :organisations, :referents, :address_geocoding,
+            { tags: :organisations },
+            participations: [:organisation, { follow_up: :motif_category }],
             follow_ups: [:invitations, :motif_category, :notifications, { rdvs: [:motif, :participations] }],
             orientations: [:orientation_type, :organisation]
           )
         else
           User.where(id: @user_ids).preload(
-            :invitations, :notifications, :archives, :organisations, :tags, :referents, :address_geocoding,
+            :invitations, :notifications, :archives, :organisations, :referents, :address_geocoding,
+            { tags: :organisations },
             follow_ups: [:motif_category, :participations, :rdvs],
             participations: [:organisation, :rdv, { follow_up: :motif_category }],
             rdvs: [:motif, :participations],
@@ -230,9 +232,13 @@ module Exporters
 
     def scoped_user_tags(tags)
       if department_level?
-        tags.joins(:organisations).where(organisations: { id: @agent.organisation_ids, department_id: })
+        tags.select do |tag|
+          tag.organisations.any? do |org|
+            @agent.organisation_ids.include?(org.id) && org.department_id == department_id
+          end
+        end
       else
-        tags.joins(:organisations).where(organisations: @structure)
+        tags.select { |tag| tag.organisations.include?(@structure) }
       end
     end
 

--- a/app/services/exporters/generate_users_csv.rb
+++ b/app/services/exporters/generate_users_csv.rb
@@ -43,7 +43,7 @@ module Exporters
         if @motif_category
           User.where(id: @user_ids).preload(
             :archives, :organisations, :referents, :address_geocoding,
-            { tags: :organisations },
+            { tags: [:organisations, :tag_organisations] },
             participations: [:organisation, { follow_up: :motif_category }],
             follow_ups: [:invitations, :motif_category, :notifications, { rdvs: [:motif, :participations] }],
             orientations: [:orientation_type, :organisation]
@@ -51,7 +51,7 @@ module Exporters
         else
           User.where(id: @user_ids).preload(
             :invitations, :notifications, :archives, :organisations, :referents, :address_geocoding,
-            { tags: :organisations },
+            { tags: [:organisations, :tag_organisations] },
             follow_ups: [:motif_category, :participations, :rdvs],
             participations: [:organisation, :rdv, { follow_up: :motif_category }],
             rdvs: [:motif, :participations],
@@ -233,9 +233,8 @@ module Exporters
     def scoped_user_tags(tags)
       if department_level?
         tags.select do |tag|
-          tag.organisations.any? do |org|
-            @agent.organisation_ids.include?(org.id) && org.department_id == department_id
-          end
+          Pundit.policy!(@agent, tag).show? &&
+            tag.organisations.any? { |org| org.department_id == department_id }
         end
       else
         tags.select { |tag| tag.organisations.include?(@structure) }

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -6,7 +6,7 @@ module Exporters
       # find_each doesn't support custom ordering: pluck sorted IDs first in SQL,
       # then reload records in batches while preserving the order.
       filtered_participations.pluck(:id).each_slice(500) do |ids|
-        @participations.where(id: ids).in_order_of(:id, ids).each(&)
+        filtered_participations.where(id: ids).each(&) # rubocop:disable Rails/FindEach
       end
     end
 

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -3,8 +3,10 @@ module Exporters
     private
 
     def each_element(&)
-      # find_each doesn't support custom ordering: pluck sorted IDs first in SQL,
-      # then reload records in batches while preserving the order.
+      # find_each doesn't support custom ordering, so we stream manually in two steps:
+      # 1. pluck the sorted IDs — raw SQL SELECT, no AR instantiation, no preloads triggered.
+      # 2. reload each batch via where(id: ids) — AR instances + preloads fire here, and the
+      #    ORDER BY from filtered_participations still applies so records come back in order.
       filtered_participations.pluck(:id).each_slice(500) do |ids|
         filtered_participations.where(id: ids).each(&) # rubocop:disable Rails/FindEach
       end
@@ -25,13 +27,14 @@ module Exporters
     def preload_associations
       @participations =
         if @motif_category
-          Participation.preload(user: [:tags, :referents, :organisations, :address_geocoding])
+          Participation.preload(user: [{ tags: :organisations }, :referents, :organisations, :address_geocoding])
         else
-          Participation.preload(user: [:tags, :referents, :organisations, :invitations, :notifications,
-                                       :address_geocoding])
+          Participation.preload(user: [{ tags: :organisations }, :referents, :organisations, :invitations,
+                                       :notifications, :address_geocoding])
         end
 
       @participations = @participations.preload(
+        :organisation,
         rdv: [:motif, :organisation],
         follow_up: [
           :invitations,

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -2,8 +2,12 @@ module Exporters
   class GenerateUsersParticipationsCsv < GenerateUsersCsv
     private
 
-    def each_element(&)
-      filtered_participations.each(&)
+    def each_element(&block)
+      # find_each doesn't support custom ordering: pluck sorted IDs first in SQL,
+      # then reload records in batches while preserving the order.
+      filtered_participations.pluck(:id).each_slice(500) do |ids|
+        @participations.where(id: ids).in_order_of(:id, ids).each(&block)
+      end
     end
 
     def filtered_participations
@@ -32,7 +36,7 @@ module Exporters
         follow_up: [
           :invitations,
           :notifications,
-          { rdvs: [:motif, :organisation, :participations, :users] }
+          { rdvs: [:motif, :organisation, :participations] }
         ]
       )
     end

--- a/app/services/exporters/generate_users_participations_csv.rb
+++ b/app/services/exporters/generate_users_participations_csv.rb
@@ -2,11 +2,11 @@ module Exporters
   class GenerateUsersParticipationsCsv < GenerateUsersCsv
     private
 
-    def each_element(&block)
+    def each_element(&)
       # find_each doesn't support custom ordering: pluck sorted IDs first in SQL,
       # then reload records in batches while preserving the order.
       filtered_participations.pluck(:id).each_slice(500) do |ids|
-        @participations.where(id: ids).in_order_of(:id, ids).each(&block)
+        @participations.where(id: ids).in_order_of(:id, ids).each(&)
       end
     end
 

--- a/app/views/mailers/csv_export_mailer/notify_export_failure.html.erb
+++ b/app/views/mailers/csv_export_mailer/notify_export_failure.html.erb
@@ -1,0 +1,4 @@
+<h1>Bonjour</h1>
+<p>L'export CSV que vous avez demandé n'a pas pu être généré.</p>
+<p>Notre équipe technique a été informée de l'erreur. Vous pouvez réessayer plus tard.</p>
+<p>L'équipe rdv-insertion</p>

--- a/spec/mailers/csv_export_mailer_spec.rb
+++ b/spec/mailers/csv_export_mailer_spec.rb
@@ -90,4 +90,19 @@ RSpec.describe CsvExportMailer do
       end
     end
   end
+
+  describe "#notify_export_failure" do
+    subject { described_class.notify_export_failure(agent.email) }
+
+    it "renders the headers" do
+      expect(subject.to).to eq([agent.email])
+      expect(subject.subject).to eq("[rdv-insertion] Échec de votre export CSV")
+    end
+
+    it "renders the body" do
+      body_string = unescape_html(subject.body.encoded)
+      expect(body_string).to match("L'export CSV que vous avez demandé n'a pas pu être généré.")
+      expect(body_string).to match("Notre équipe technique a été informée")
+    end
+  end
 end

--- a/spec/services/exporters/generate_users_csv_spec.rb
+++ b/spec/services/exporters/generate_users_csv_spec.rb
@@ -368,5 +368,39 @@ describe Exporters::GenerateUsersCsv, type: :service do
         end
       end
     end
+
+    context "N+1 detection" do
+      let!(:user2_rdv) do
+        create(:rdv, starts_at: Time.zone.parse("2022-05-26"),
+                     created_by: "user", organisation: organisation,
+                     participations: [user2_participation])
+      end
+      let!(:user2_participation) { create(:participation, user: user2, status: "seen") }
+      let!(:user2_invitation) do
+        create(:invitation, user: user2, format: "email", created_at: Time.zone.parse("2022-05-21"))
+      end
+      let!(:user2_notification) do
+        create(:notification, participation: user2_participation, format: "email",
+                              created_at: Time.zone.parse("2022-06-22"))
+      end
+      let!(:user2_follow_up) do
+        create(:follow_up, invitations: [user2_invitation], motif_category: motif_category,
+                           participations: [user2_participation], user: user2,
+                           status: "rdv_needs_status_update")
+      end
+
+      it "does not trigger N+1 queries" do
+        Prosopite.enabled = true
+        Prosopite.raise = true
+        Prosopite.scan
+        begin
+          described_class.call(user_ids: users.ids, structure:, motif_category_id: motif_category.id, agent:)
+          Prosopite.finish
+        ensure
+          Prosopite.enabled = false
+          Prosopite.raise = false
+        end
+      end
+    end
   end
 end

--- a/spec/services/exporters/generate_users_participations_csv_spec.rb
+++ b/spec/services/exporters/generate_users_participations_csv_spec.rb
@@ -255,6 +255,27 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
       end
     end
 
+    context "when the user has several rdvs at different dates" do
+      let!(:users) { User.where(id: [user1]) }
+
+      let!(:older_rdv) do
+        create(:rdv, starts_at: Time.zone.parse("2022-01-01"),
+                     created_by: "user", organisation: organisation, motif: motif)
+      end
+      let!(:older_participation) { create(:participation, rdv: older_rdv, user: user1, status: "seen") }
+
+      let!(:middle_rdv) do
+        create(:rdv, starts_at: Time.zone.parse("2022-03-15"),
+                     created_by: "user", organisation: organisation, motif: motif)
+      end
+      let!(:middle_participation) { create(:participation, rdv: middle_rdv, user: user1, status: "seen") }
+
+      it "orders CSV lines by rdv.starts_at descending" do
+        rows = CSV.parse(subject.csv.delete_prefix("﻿"), col_sep: ";", headers: true)
+        expect(rows.pluck("Date du RDV")).to eq(["25/05/2022", "15/03/2022", "01/01/2022"])
+      end
+    end
+
     context "when the user has multiple rdvs in multiple orgs" do
       let!(:other_organisation) { create(:organisation, department:, users: [user1]) }
       let!(:other_rdv) do
@@ -322,6 +343,35 @@ describe Exporters::GenerateUsersParticipationsCsv, type: :service do
           expect(subject.csv).to include("cacahuète")
           expect(subject.csv).not_to include("pistache")
           expect(subject.csv).to include("chips")
+        end
+      end
+    end
+
+    context "N+1 detection" do
+      let!(:user2_invitation) do
+        create(:invitation, user: user2, format: "email", created_at: Time.zone.parse("2022-05-21"))
+      end
+      let!(:user2_notification) do
+        create(:notification, participation: participation_rdv_prescrit, format: "email",
+                              created_at: Time.zone.parse("2022-06-22"))
+      end
+      let!(:user2_follow_up) do
+        create(:follow_up, invitations: [user2_invitation], motif_category: motif_category,
+                           participations: [participation_rdv_prescrit], user: user2,
+                           status: "rdv_needs_status_update")
+      end
+
+      it "does not trigger N+1 queries" do
+        Prosopite.enabled = true
+        Prosopite.raise = true
+        Prosopite.scan
+        begin
+          described_class.call(user_ids: users.ids, structure: structure, motif_category_id: motif_category.id,
+                               agent:)
+          Prosopite.finish
+        ensure
+          Prosopite.enabled = false
+          Prosopite.raise = false
         end
       end
     end


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-export-volumineux-3415f321b604805c9a3ade815bcda6fd                                                                                                                                                                                                                  
     
  ## Contexte                                                                                                                                                                                                                           
                                                                                                                                                                                                                                        
  Un export CSV à 22k+ dossiers crashait en prod sans que l'agent soit averti : pas de mail, aucune trace applicative. La cause vraisemblable : le worker consommait trop de mémoire et se faisait tuer par Scalingo.                   
                                                                       
  ## Changements                                                                                                                                                                                                                        
                                                                       
  ### Mémoire (cause racine)                                                                                                                                                                                                            
  
  Avant, les services chargeaient **d'un coup** tous les users (ou participations) et leurs associations en mémoire via `preload(...).find(ids)`, puis itéraient. Comme tout restait référencé dans une variable d'instance le temps de 
  l'itération, rien ne pouvait être libéré : la mémoire grimpait avec le nombre de lignes et finissait par dépasser la taille allouée au worker.
                                                                                                                                                                                                                                        
  Le fix, avec `find_each(batch_size: 500)` :                          

  - 500 records sont chargés, passés un par un au générateur CSV
  - Fin du batch : ils ne sont plus référencés → la mémoire peut être récupérée par le garbage collector
  - Le batch suivant réutilise cette mémoire libérée                                                                                                                                                                                    
  
  Résultat : la mémoire max utilisée correspond à **un seul batch**, peu importe la taille totale de l'export.                                                                                                                          
                                                                       
  ### Visibilité                                                                                                                                                                                                                        
                                                                       
  Je mets en place un mail d'erreur avec un `rescue_from` dans les jobs concernés. Si le problème de mémoire se reproduit, ce `rescue_from` ne sera pas suffisant et on ne sera toujours pas averti.                                    
  
  Ce n'est pas directement lié à l'issue d'origine, mais c'est pour pallier les autres erreurs qui pourraient advenir et prévenir l'agent dans ces cas.                                                                                  
                                                                       
  Pour régler le problème de notification en cas de dépassement mémoire, il faudrait mettre en place un système de vérification externe au job, puisque le job lui-même est tué par Scalingo avant de pouvoir notifier. Ça me semble    
  assez complexe à faire pour peu de gain, d'autant que le problème est résolu par cette PR.
                                                                                                                                                                                                                                        
  ## Résultats (benchmark local à 5k users)                            

  Mémoire utilisée par le worker pendant l'export :

  - `GenerateUsersCsv` : 283 Mo → **91 Mo** (-68%)                                                                                                                                                                                      
  - `GenerateUsersParticipationsCsv` : 283 Mo → **57 Mo** (-80%)
                                                                                                                                                                                                                                        
La mémoire ne grandit plus avec le nombre de lignes : elle plafonne à la taille d'un batch. 
Avec 22k users (et 2 participation par user) on est à moins de 100 Mo, très en dessous de la limite du worker Scalingo (~1 Go).                                             
                                                                                                                                                                                                                                        
  Je n'ai pas inclus les specs de benchmark dans la PR, mais je peux les pusher si besoin. 