### PR TITLE
feat(api): push geocoding info on rdv-solidarités user upsert

### DIFF
--- a/app/services/users/push_to_rdv_solidarites.rb
+++ b/app/services/users/push_to_rdv_solidarites.rb
@@ -86,6 +86,7 @@ module Users
       @user.attributes
            .symbolize_keys
            .slice(*User::SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES)
+           .merge(post_code: @user.post_code, city_code: @user.city_code, city_name: @user.city)
            .transform_values(&:presence)
            .compact
     end

--- a/spec/services/users/push_to_rdv_solidarites_spec.rb
+++ b/spec/services/users/push_to_rdv_solidarites_spec.rb
@@ -20,7 +20,8 @@ describe Users::PushToRdvSolidarites, type: :service do
     {
       first_name: "john", last_name: "doe",
       address: "16 rue de la tour", email: "johndoe@example.com",
-      birth_date: Date.new(1989, 3, 17), affiliation_number: "aff123", phone_number: "+33612459567"
+      birth_date: Date.new(1989, 3, 17), affiliation_number: "aff123", phone_number: "+33612459567",
+      post_code: "75001", city_code: "75101", city_name: "Paris"
     }
   end
   let!(:user) do
@@ -28,6 +29,9 @@ describe Users::PushToRdvSolidarites, type: :service do
       :user,
       user_attributes.merge(organisations: [organisation], rdv_solidarites_user_id: rdv_solidarites_user_id)
     )
+  end
+  let!(:address_geocoding) do
+    create(:address_geocoding, user: user, post_code: "75001", city_code: "75101", city: "Paris")
   end
 
   let!(:rdv_solidarites_user) { instance_double(RdvSolidarites::User) }


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Sectorisation-rdvsp-Am-liorer-la-secto-en-remplissant-le-g-ocoding-quand-on-cr-un-usager-dans-rdv-2b05f321b60480a3846bc63a1c6fce1f
Fait suite à https://github.com/betagouv/rdv-service-public/pull/6337 coté rdvsp

  ## Description                                                                                                                                                                                                                            
  - Inclut `post_code`, `city_code` et `city_name` dans le payload envoyé à RDV-Solidarités lors de la création/mise à jour d'un user, en s'appuyant sur les champs déjà délégués à `address_geocoding`.                                
  - Mapping du naming côté RDV-I (`city`) vers celui de l'API RDV-S (`city_name`).     