### PR TITLE
fix(user_upload): reject blank items from import

### DIFF
--- a/app/models/user_list_upload.rb
+++ b/app/models/user_list_upload.rb
@@ -21,7 +21,7 @@ class UserListUpload < ApplicationRecord
 
   validates :category_configuration_id, presence: true, if: :handle_invitation_only?
 
-  accepts_nested_attributes_for :user_rows
+  accepts_nested_attributes_for :user_rows, reject_if: :all_blank
 
   delegate :user_rows_enriched_with_cnaf_data, :update_rows, :user_rows_selected_for_invitation,
            :user_rows_selected_for_user_save, :user_rows_with_errors, :user_rows_archived,

--- a/spec/models/user_list_upload_spec.rb
+++ b/spec/models/user_list_upload_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe UserListUpload do
       expect(user_list_upload.user_rows.count).to eq(2)
       expect(user_list_upload.user_rows.pluck(:email)).to contain_exactly("user1@example.com", "user2@example.com")
     end
+
+    context "when some rows are entirely blank" do
+      let(:user_list_upload) do
+        create(
+          :user_list_upload,
+          user_rows_attributes: [
+            { "first_name" => "Jean", "email" => "jean@example.com" },
+            { "first_name" => nil, "email" => nil, "tag_values" => [], "address" => "" },
+            { "first_name" => "", "last_name" => "" }
+          ]
+        )
+      end
+
+      it "does not create rows with only blank values" do
+        expect(user_list_upload.user_rows.count).to eq(1)
+        expect(user_list_upload.user_rows.first.email).to eq("jean@example.com")
+      end
+    end
   end
 
   describe "#restricted_user_attributes" do


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-Emp-cher-les-lignes-vides-dans-l-import-usager-3525f321b604803a9de8ea0aeec4c7c1

Une fois cette PR passée on nettoie l'historique des row vides (afin de pouvoir calculer des données de décrochage fiable) : 

  ### Colonnes d'identification d'une row "non vide"                                                                                                                                                                
  STRING_COLS = %w[                                                                                                                                                                                               
    first_name last_name email phone_number role title nir                                                                                                                                                        
    department_internal_id france_travail_id affiliation_number                                                                                                                                                   
    birth_name address organisation_search_terms referent_email
  ].freeze                                                                                                                                                                                                        
  DATE_COLS = %w[rights_opening_date birth_date].freeze                                                                                                                                                           
  
  ### Toutes les colonnes scalaires sont vides (NULL ou '')                                                                                                                                                         
  empty_sql = (                                             
    STRING_COLS.map { |c| "NULLIF(#{c}, '') IS NULL" } +                                                                                                                                                          
    DATE_COLS.map   { |c| "#{c} IS NULL" }                                                                                                                                                                        
  ).join(" AND ")
                                                                                                                                                                                                                  
  ### Rows totalement vides (aucune info exploitable, aucune association)                                                                                                                                           
  empty_rows = UserListUpload::UserRow
    .where(empty_sql)                                                                                                                                                                                             
    .where(matching_user_id: nil)                           
    .where(assigned_organisation_id: nil)                                                                                                                                                                         
    .where(tag_values: [])                                  
    .where("cnaf_data::text = '{}'")
                                                                                                                                                                                                                  
  ### 1. Audit AVANT destruction
  empty_rows.count                  # combien on s'apprête à supprimer                                                                                                                                            
  empty_rows.pluck(:id).first(10)   # coup d'oeil sur un échantillon                                                                                                                                              
                                                                                                                                                                                                                  
  ### 2. Vérifier qu'elles n'ont pas d'attempts en cascade                                                                                                                                                          
  empty_rows.joins(:user_save_attempts).count    # devrait être 0                                                                                                                                                 
  empty_rows.joins(:invitation_attempts).count   # devrait être 0                                                                                                                                                 
                                                                                                                                                                                                                  
  ### 3. Suppression                                                                                                                                                                                                                                                                 
  empty_rows.destroy_all    