### PR TITLE
fix(users): Archived recap wording and empty reason parentheses

### DIFF
--- a/app/views/users/_all_users_table.html.erb
+++ b/app/views/users/_all_users_table.html.erb
@@ -28,7 +28,8 @@
         <td><%= display_attribute user.first_name %></td>
         <td><%= display_attribute format_date(user.created_at) %></td>
         <% if user_archived_in?(user, current_organisations) %>
-          <td colspan=<%= @all_configurations.count %>>Archivé (<%= format_archives_reason(user_archives(user, current_organisations)) %>)</td>
+          <% archives_reason = format_archives_reason(user_archives(user, current_organisations)) %>
+          <td colspan=<%= @all_configurations.count %>>Archivé<%= " (#{archives_reason})" if archives_reason.present? %></td>
         <% else %>
           <% @all_configurations.each do |category_configuration| %>
             <% if follow_up = user.follow_up_for(category_configuration.motif_category) %>

--- a/app/views/users/_users_count.html.erb
+++ b/app/views/users/_users_count.html.erb
@@ -5,6 +5,8 @@
     <% else %>
       <%= custom_pluralize(users_count, "dossier") %> <%= custom_pluralize(users_count, "usager", with_count: false) %>
     <% end %>
+  <% elsif archived_scope?(@users_scope) %>
+    <%= custom_pluralize(users_count, "dossier") %> <%= custom_pluralize(users_count, "usager", with_count: false) %> archivés
   <% elsif motif_category %>
     <%= custom_pluralize(users_count, "dossier") %> <%= custom_pluralize(users_count, "usager", with_count: false) %> dans « <strong><%= motif_category.name %></strong> »
   <% else %>


### PR DESCRIPTION
Liè à : https://www.notion.so/gip-inclusion/Bug-Corriger-la-phrase-indiquant-le-nombre-de-dossiers-archiv-s-3585f321b60480c19e47f2d3fff9e7cd

<img width="1501" height="311" alt="Capture d’écran 2026-05-13 à 14 58 18" src="https://github.com/user-attachments/assets/0fdba39d-dc3c-458d-8b79-bda54c65d51e" />


J'en ai profité pour résoudre un autre bug de wording : 

Avant | Après
:- | -:
<img width="1501" height="311" alt="Capture d’écran 2026-05-13 à 14 57 58" src="https://github.com/user-attachments/assets/b89d3d3d-ac66-493f-ac4a-0d6a2a0ef2d8" />|<img width="1501" height="311" alt="Capture d’écran 2026-05-13 à 14 58 09" src="https://github.com/user-attachments/assets/f0b71c4e-5ac6-48c5-8869-947725498c39" />
