### PR TITLE
fix(file_configurations): Disable edit-template button when agent lacks rights

### DIFF
--- a/app/views/file_configurations/_file_configuration.html.erb
+++ b/app/views/file_configurations/_file_configuration.html.erb
@@ -5,11 +5,17 @@
     <div class="fw-bold h3-title mb-1">Nom de l'onglet Excel</div>
     <p class="text-dark-blue mb-0"><%= file_configuration.sheet_name %></p>
   </div>
-  <div class="d-flex gap-2">
-    <%= link_to edit_file_configuration_path(file_configuration),
-                data: { turbo_frame: "remote_modal" },
-                class: "btn btn-blue-out" do %>
-      <i class="ri-pencil-line"></i> Modifier le modèle
+  <div class="d-flex gap-2 align-items-center">
+    <% if policy(file_configuration).edit? %>
+      <%= link_to edit_file_configuration_path(file_configuration),
+                  data: { turbo_frame: "remote_modal" },
+                  class: "btn btn-blue-out" do %>
+        <i class="ri-pencil-line"></i> Modifier le modèle
+      <% end %>
+    <% else %>
+      <div <%= tooltip(content: "Vous n'avez pas les droits pour modifier ce template de fichier car vous n'êtes pas administrateur de toutes les organisations qui l'utilisent") %>>
+        <button class="btn btn-blue-out" disabled>Modifier le modèle</button>
+      </div>
     <% end %>
     <%= link_to file_configuration_download_template_path(file_configuration),
                 download: true,

--- a/spec/controllers/file_configurations_controller_spec.rb
+++ b/spec/controllers/file_configurations_controller_spec.rb
@@ -17,13 +17,33 @@ describe FileConfigurationsController do
   describe "#show" do
     let!(:show_params) { { id: file_configuration.id } }
 
-    it "displays the file_configuration" do
+    it "displays the file_configuration with an actionable edit button for an authorized admin" do
       get :show, params: show_params
 
       expect(response).to be_successful
       expect(unescaped_response_body).to match(/Nom de l'onglet Excel/)
       expect(unescaped_response_body).to match(/#{file_configuration.sheet_name}/)
       expect(unescaped_response_body).to match(/Colonnes obligatoires/)
+      expect(response.body).to include(%(href="#{edit_file_configuration_path(file_configuration)}"))
+      expect(unescaped_response_body).not_to include("Vous n'avez pas les droits pour modifier ce template")
+    end
+
+    context "when the agent can view but not edit (basic role in the organisation)" do
+      let!(:basic_agent) { create(:agent, basic_role_in_organisations: [organisation]) }
+
+      before do
+        sign_in(basic_agent)
+      end
+
+      it "displays the file_configuration with a disabled edit button and an explanatory tooltip" do
+        get :show, params: show_params
+
+        expect(response).to be_successful
+        expect(unescaped_response_body).to match(/Nom de l'onglet Excel/)
+        expect(response.body).not_to include(%(href="#{edit_file_configuration_path(file_configuration)}"))
+        expect(response.body).to match(/<button[^>]*\bdisabled\b[^>]*>\s*Modifier le modèle/)
+        expect(unescaped_response_body).to include("Vous n'avez pas les droits pour modifier ce template")
+      end
     end
 
     context "when not authorized because does not belong to the organisation" do


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Bug-Modification-du-fichier-d-import-3485f321b6048001ac5cc96ccf8201c2

On vérifie les droits sur le bouton 'Modifier le modèle' de la même façon que dans `_file_configuration_selection_form_input.html.erb`. Si l'agent n'a pas les droits on disable le bouton et on affiche le tooltip.