### PR TITLE
feat(users): add available créneaux banner on user index

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -216,8 +216,7 @@ class UsersController < ApplicationController
     return if @current_category_configuration.blank?
     return if @current_category_configuration.rdv_with_referents?
 
-    @latest_creneau_availability = @current_category_configuration.creneau_availabilities
-                                                                  .order(created_at: :desc).first
+    @latest_creneau_availability = @current_category_configuration.last_creneau_availability
   end
 
   def set_users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,7 @@ class UsersController < ApplicationController
 
   before_action :set_organisation, :set_department, :set_all_configurations,
                 :set_users_scope, :set_current_category_configuration, :set_current_motif_category,
+                :set_creneau_availability,
                 :set_users, :set_follow_ups, :set_orientation_types, :set_filterable_tags,
                 :set_referents_list, :set_skip_pagination, :filter_users, :order_users,
                 for: :index
@@ -208,6 +209,14 @@ class UsersController < ApplicationController
 
   def set_current_motif_category
     @current_motif_category = @current_category_configuration&.motif_category
+  end
+
+  def set_creneau_availability
+    return if department_level?
+    return if @current_category_configuration.blank?
+    return if @current_category_configuration.rdv_with_referents?
+
+    @creneau_availability = @current_category_configuration.creneau_availabilities.order(created_at: :desc).first
   end
 
   def set_users

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
 
   before_action :set_organisation, :set_department, :set_all_configurations,
                 :set_users_scope, :set_current_category_configuration, :set_current_motif_category,
-                :set_creneau_availability,
+                :set_latest_creneau_availability,
                 :set_users, :set_follow_ups, :set_orientation_types, :set_filterable_tags,
                 :set_referents_list, :set_skip_pagination, :filter_users, :order_users,
                 for: :index
@@ -211,12 +211,13 @@ class UsersController < ApplicationController
     @current_motif_category = @current_category_configuration&.motif_category
   end
 
-  def set_creneau_availability
+  def set_latest_creneau_availability
     return if department_level?
     return if @current_category_configuration.blank?
     return if @current_category_configuration.rdv_with_referents?
 
-    @creneau_availability = @current_category_configuration.creneau_availabilities.order(created_at: :desc).first
+    @latest_creneau_availability = @current_category_configuration.creneau_availabilities
+                                                                  .order(created_at: :desc).first
   end
 
   def set_users

--- a/app/models/category_configuration.rb
+++ b/app/models/category_configuration.rb
@@ -68,4 +68,8 @@ class CategoryConfiguration < ApplicationRecord
       errors.add(:base, "Les formats d'invitation ne peuvent être que : sms, email, postal")
     end
   end
+
+  def last_creneau_availability
+    creneau_availabilities.order(created_at: :desc).first
+  end
 end

--- a/app/views/users/_creneau_availability_banner.html.erb
+++ b/app/views/users/_creneau_availability_banner.html.erb
@@ -4,10 +4,10 @@
       <i class="ri-calendar-line text-dark-green"></i>
     </span>
     <span class="medium text-dark-green">
-      <%= @creneau_availability.number_of_creneaux_available %> créneaux disponibles
+      <%= @latest_creneau_availability.number_of_creneaux_available %> créneaux disponibles
     </span>
     <span class="text-muted small">
-      Calculé le <%= @creneau_availability.created_at.strftime("%d/%m à %Hh%M") %>
+      Calculé le <%= @latest_creneau_availability.created_at.strftime("%d/%m à %Hh%M") %>
     </span>
   </div>
   <div class="position-absolute end-0 d-flex align-items-center gap-3 pe-3">

--- a/app/views/users/_creneau_availability_banner.html.erb
+++ b/app/views/users/_creneau_availability_banner.html.erb
@@ -1,0 +1,18 @@
+<div class="alert alert-info d-flex justify-content-center align-items-center mt-3 mb-1" role="alert">
+  <div class="rounded bg-white p-2 d-inline-flex align-items-center gap-2">
+    <span class="background-green-light rounded-circle p-1">
+      <i class="ri-calendar-line text-dark-green"></i>
+    </span>
+    <span class="medium text-dark-green">
+      <%= @creneau_availability.number_of_creneaux_available %> créneaux disponibles
+    </span>
+    <span class="text-muted small">
+      Calculé le <%= @creneau_availability.created_at.strftime("%d/%m à %Hh%M") %>
+    </span>
+  </div>
+  <div class="position-absolute end-0 d-flex align-items-center gap-3 pe-3">
+    <%= link_to "Donnez-nous votre avis",
+                request.params.merge(tally_form_id: ENV["CRENEAU_AVAILABILITY_BANNER_TALLY_ID"]) %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+  </div>
+</div>

--- a/app/views/users/_creneau_availability_banner.html.erb
+++ b/app/views/users/_creneau_availability_banner.html.erb
@@ -12,6 +12,7 @@
   </div>
   <div class="position-absolute end-0 d-flex align-items-center gap-3 pe-3">
     <%= link_to "Donnez-nous votre avis",
-                request.params.merge(tally_form_id: ENV["CRENEAU_AVAILABILITY_BANNER_TALLY_ID"]) %>
+                request.params.merge(tally_form_id: ENV["CRENEAU_AVAILABILITY_BANNER_TALLY_ID"]),
+                class: "text-underline" %>
   </div>
 </div>

--- a/app/views/users/_creneau_availability_banner.html.erb
+++ b/app/views/users/_creneau_availability_banner.html.erb
@@ -13,6 +13,5 @@
   <div class="position-absolute end-0 d-flex align-items-center gap-3 pe-3">
     <%= link_to "Donnez-nous votre avis",
                 request.params.merge(tally_form_id: ENV["CRENEAU_AVAILABILITY_BANNER_TALLY_ID"]) %>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,6 +2,7 @@
   <%= render "users_list_header" %>
   <div class="row card-white justify-content-center">
     <%= render "users_list_tabs" %>
+    <%= render "creneau_availability_banner" if @creneau_availability %>
     <%= render "users_list_table" %>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
   <%= render "users_list_header" %>
   <div class="row card-white justify-content-center">
     <%= render "users_list_tabs" %>
-    <%= render "creneau_availability_banner" if @creneau_availability %>
+    <%= render "creneau_availability_banner" if @latest_creneau_availability %>
     <%= render "users_list_table" %>
   </div>
 </div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -957,6 +957,50 @@ describe UsersController do
         end
       end
     end
+
+    describe "creneau availability banner" do
+      let!(:creneau_availability) do
+        create(:creneau_availability, category_configuration: category_configuration,
+                                      number_of_creneaux_available: 11)
+      end
+
+      it "displays the banner at organisation level" do
+        get :index, params: index_params
+
+        expect(response.body).to include("11 créneaux disponibles")
+                             .and include("Calculé le")
+      end
+
+      context "when at department level" do
+        let!(:index_params) { { department_id: department.id, motif_category_id: category_orientation.id } }
+
+        it "does not display the banner" do
+          get :index, params: index_params
+
+          expect(response.body).not_to include("créneaux disponibles")
+        end
+      end
+
+      context "when the category has rdv_with_referents" do
+        before { category_configuration.update!(rdv_with_referents: true) }
+
+        it "does not display the banner" do
+          get :index, params: index_params
+
+          expect(response.body).not_to include("créneaux disponibles")
+        end
+      end
+
+      context "when no CreneauAvailability exists for the category" do
+        before { CreneauAvailability.destroy_all }
+
+        it "does not display the banner" do
+          get :index, params: index_params
+
+          expect(response.body).not_to include("créneaux disponibles")
+        end
+      end
+    end
   end
 
   describe "#edit" do


### PR DESCRIPTION
Lié à https://www.notion.so/gip-inclusion/Afficher-le-nombre-de-cr-neaux-disponibles-sur-l-index-3665f321b60480e58a91d912446d5a29

<img width="1503" height="1156" alt="Capture d’écran 2026-05-28 à 09 28 50" src="https://github.com/user-attachments/assets/033b4d82-d2df-4a7c-95a4-4b4082347510" />


  Ajoute un bandeau sur l'index des dossiers usagers indiquant le nombre de créneaux disponibles pour la catégorie courante, avec date du dernier calcul et lien Tally pour feedback agent.

  Affiché uniquement au niveau organisation, sur une catégorie sans `rdv_with_referents`, et si un `CreneauAvailability` existe pour la `CategoryConfiguration`.