### PR TITLE
feat(app): Show creneaux available before user list uploads invites

### DIFF
--- a/app/controllers/concerns/notification_center_concern.rb
+++ b/app/controllers/concerns/notification_center_concern.rb
@@ -10,7 +10,7 @@ module NotificationCenterConcern
   private
 
   def set_has_important_unread_notifications
-    @has_important_unread_notifications = CreneauAvailability
+    @has_important_unread_notifications = CategoryConfiguration::CreneauAvailability
                                           .with_rsa_related_motif
                                           .joins(:category_configuration)
                                           .where(category_configuration: { organisation_id: current_organisation_id })

--- a/app/controllers/notification_center_controller.rb
+++ b/app/controllers/notification_center_controller.rb
@@ -28,7 +28,7 @@ class NotificationCenterController < ApplicationController
   end
 
   def creneaux_availabilities
-    @creneaux_availabilities ||= CreneauAvailability
+    @creneaux_availabilities ||= CategoryConfiguration::CreneauAvailability
                                  .joins(:category_configuration)
                                  .preload(category_configuration: :motif_category)
                                  .where(category_configuration: { organisation_id: current_organisation_id })

--- a/app/controllers/user_list_uploads/invitation_attempts_controller.rb
+++ b/app/controllers/user_list_uploads/invitation_attempts_controller.rb
@@ -10,6 +10,7 @@ module UserListUploads
       @user_rows = @user_collection.user_rows_eligible_for_invitation
       @number_of_user_rows_selected = @user_list_upload.user_rows_selected_for_invitation.length
       @total_number_of_user_rows = @user_list_upload.user_rows.length
+      @creneaux_snapshot = @user_list_upload.last_creneaux_snapshot
     end
 
     def create_many

--- a/app/controllers/user_list_uploads/invitation_attempts_controller.rb
+++ b/app/controllers/user_list_uploads/invitation_attempts_controller.rb
@@ -11,7 +11,7 @@ module UserListUploads
       @user_rows = @user_collection.user_rows_eligible_for_invitation
       @number_of_user_rows_selected = @user_list_upload.user_rows_selected_for_invitation.length
       @total_number_of_user_rows = @user_list_upload.user_rows.length
-      @creneaux_snapshot = @user_list_upload.last_creneaux_snapshot
+      @creneaux_snapshot = @user_list_upload.creneaux_snapshot
     end
 
     def create_many
@@ -41,7 +41,7 @@ module UserListUploads
     end
 
     def should_redirect_with_tally_form?
-      params[:tally_form_id].nil? && @user_list_upload.last_creneaux_snapshot &&
+      params[:tally_form_id].nil? && @user_list_upload.creneaux_snapshot &&
         ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"].present?
     end
 

--- a/app/controllers/user_list_uploads/invitation_attempts_controller.rb
+++ b/app/controllers/user_list_uploads/invitation_attempts_controller.rb
@@ -1,6 +1,7 @@
 module UserListUploads
   class InvitationAttemptsController < BaseController
     before_action :set_user_list_upload, only: [:index, :select_rows, :create_many]
+    before_action :redirect_with_tally_form_if_creneaux_snapshot_exists, only: [:select_rows]
     before_action :capture_invitations_triggered_at, only: [:create_many]
 
     def select_rows
@@ -29,6 +30,20 @@ module UserListUploads
     end
 
     private
+
+    def redirect_with_tally_form_if_creneaux_snapshot_exists
+      return unless should_redirect_with_tally_form?
+
+      redirect_to select_rows_user_list_upload_invitation_attempts_path(
+        user_list_upload_id: @user_list_upload.id,
+        tally_form_id: ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"]
+      )
+    end
+
+    def should_redirect_with_tally_form?
+      params[:tally_form_id].nil? && @user_list_upload.last_creneaux_snapshot &&
+        ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"].present?
+    end
 
     def set_user_list_upload
       @user_list_upload = UserListUpload.find(params[:user_list_upload_id])

--- a/app/helpers/user_list_upload/creneaux_snapshots_helper.rb
+++ b/app/helpers/user_list_upload/creneaux_snapshots_helper.rb
@@ -1,10 +1,5 @@
 module UserListUpload::CreneauxSnapshotsHelper
-  def rdv_solidarites_planning_url(organisation)
-    "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/" \
-      "#{organisation.rdv_solidarites_organisation_id}/planning/agenda"
-  end
-
-  def creneaux_snapshot_refresh_delay_in_ms(user_list_upload)
-    ((user_list_upload.creneaux_snapshot_retrieval_expires_at - Time.current) * 1000).to_i
+  def creneaux_snapshot_refresh_delay_in_ms(expires_at)
+    ((expires_at - Time.current) * 1000).to_i
   end
 end

--- a/app/helpers/user_list_upload/creneaux_snapshots_helper.rb
+++ b/app/helpers/user_list_upload/creneaux_snapshots_helper.rb
@@ -1,0 +1,6 @@
+module UserListUpload::CreneauxSnapshotsHelper
+  def rdv_solidarites_planning_url(organisation)
+    "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/" \
+      "#{organisation.rdv_solidarites_organisation_id}/planning/agenda"
+  end
+end

--- a/app/helpers/user_list_upload/creneaux_snapshots_helper.rb
+++ b/app/helpers/user_list_upload/creneaux_snapshots_helper.rb
@@ -3,4 +3,8 @@ module UserListUpload::CreneauxSnapshotsHelper
     "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/" \
       "#{organisation.rdv_solidarites_organisation_id}/planning/agenda"
   end
+
+  def creneaux_snapshot_refresh_delay_in_ms(user_list_upload)
+    ((user_list_upload.creneaux_snapshot_retrieval_expires_at - Time.current) * 1000).to_i
+  end
 end

--- a/app/javascript/controllers/refresh_page_after_controller.js
+++ b/app/javascript/controllers/refresh_page_after_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { delay: Number };
+
+  connect() {
+    this.timeout = setTimeout(() => {
+      window.Turbo.visit(window.location.href, { action: "replace" });
+    }, this.delayValue);
+  }
+
+  disconnect() {
+    clearTimeout(this.timeout);
+  }
+}

--- a/app/jobs/user_list_upload/create_creneaux_snapshot_job.rb
+++ b/app/jobs/user_list_upload/create_creneaux_snapshot_job.rb
@@ -1,0 +1,15 @@
+class UserListUpload::CreateCreneauxSnapshotJob < ApplicationJob
+  queue_as :within_30s
+
+  def perform(user_list_upload_id)
+    user_list_upload = UserListUpload.find_by(id: user_list_upload_id)
+    return if user_list_upload.nil?
+
+    call_service!(
+      UserListUpload::CreateCreneauxSnapshot,
+      user_list_upload:
+    )
+
+    user_list_upload.broadcast_refresh
+  end
+end

--- a/app/models/category_configuration.rb
+++ b/app/models/category_configuration.rb
@@ -7,7 +7,7 @@ class CategoryConfiguration < ApplicationRecord
   belongs_to :file_configuration
   belongs_to :organisation
 
-  has_many :creneau_availabilities, dependent: :destroy
+  has_many :creneau_availabilities, class_name: "CategoryConfiguration::CreneauAvailability", dependent: :destroy
   has_many :user_list_uploads, dependent: :nullify
 
   validates :organisation, uniqueness: { scope: :motif_category,

--- a/app/models/category_configuration/creneau_availability.rb
+++ b/app/models/category_configuration/creneau_availability.rb
@@ -1,4 +1,6 @@
-class CreneauAvailability < ApplicationRecord
+class CategoryConfiguration::CreneauAvailability < ApplicationRecord
+  self.table_name = "category_configuration_creneau_availabilities"
+
   belongs_to :category_configuration
 
   scope :with_pending_invitations, lambda {

--- a/app/models/concerns/user_list_upload/creneaux_snapshot_retrievable.rb
+++ b/app/models/concerns/user_list_upload/creneaux_snapshot_retrievable.rb
@@ -1,0 +1,17 @@
+module UserListUpload::CreneauxSnapshotRetrievable
+  extend ActiveSupport::Concern
+
+  CRENEAUX_SNAPSHOT_RETRIEVAL_TIMEOUT = 2.minutes
+
+  def retrievable_creneaux_snapshot?
+    category_configuration_id? && !rdv_with_referents?
+  end
+
+  def creneaux_snapshot_retrieval_expires_at
+    created_at + CRENEAUX_SNAPSHOT_RETRIEVAL_TIMEOUT
+  end
+
+  def awaiting_creneaux_snapshot?
+    creneaux_snapshot_retrieval_expires_at.future?
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,7 @@ class Organisation < ApplicationRecord
 
   include Searchable
   include Organisation::Archivable
+  include Organisation::RdvSolidaritesUrls
 
   before_create { build_messages_configuration }
 
@@ -55,14 +56,6 @@ class Organisation < ApplicationRecord
   scope :displayed_in_stats, -> { where(display_in_stats: true) }
 
   ORGANISATION_TYPES_WITH_PARCOURS_ACCESS = %w[delegataire_rsa conseil_departemental france_travail].freeze
-
-  def rdv_solidarites_url
-    "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/#{rdv_solidarites_organisation_id}"
-  end
-
-  def rdv_solidarites_configuration_url
-    "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/#{rdv_solidarites_organisation_id}/configuration"
-  end
 
   def to_s
     name

--- a/app/models/organisation/rdv_solidarites_urls.rb
+++ b/app/models/organisation/rdv_solidarites_urls.rb
@@ -1,0 +1,15 @@
+module Organisation::RdvSolidaritesUrls
+  extend ActiveSupport::Concern
+
+  def rdv_solidarites_url
+    "#{ENV['RDV_SOLIDARITES_URL']}/admin/organisations/#{rdv_solidarites_organisation_id}"
+  end
+
+  def rdv_solidarites_configuration_url
+    "#{rdv_solidarites_url}/configuration"
+  end
+
+  def rdv_solidarites_planning_url
+    "#{rdv_solidarites_url}/planning/agenda"
+  end
+end

--- a/app/models/user_list_upload.rb
+++ b/app/models/user_list_upload.rb
@@ -1,6 +1,7 @@
 class UserListUpload < ApplicationRecord
   include UserListUpload::Metrics
   include UserListUpload::Navigation
+  include UserListUpload::CreneauxSnapshotRetrievable
 
   STEPS_BY_ORIGIN = {
     file_upload: %i[user_save invitation],
@@ -121,10 +122,6 @@ class UserListUpload < ApplicationRecord
 
   def last_creneaux_snapshot
     creneaux_snapshots.order(created_at: :desc).first
-  end
-
-  def retrievable_creneaux_snapshot?
-    category_configuration_id? && !rdv_with_referents?
   end
 
   private

--- a/app/models/user_list_upload.rb
+++ b/app/models/user_list_upload.rb
@@ -14,7 +14,7 @@ class UserListUpload < ApplicationRecord
 
   has_many :user_rows, class_name: "UserListUpload::UserRow", dependent: :destroy
   has_many :processing_logs, class_name: "UserListUpload::ProcessingLog", dependent: :destroy
-  has_many :creneaux_snapshots, class_name: "UserListUpload::CreneauxSnapshot", dependent: :destroy
+  has_one :creneaux_snapshot, class_name: "UserListUpload::CreneauxSnapshot", dependent: :destroy
   has_many :user_save_attempts, class_name: "UserListUpload::UserSaveAttempt", through: :user_rows
   has_many :invitation_attempts, class_name: "UserListUpload::InvitationAttempt", through: :user_rows
 
@@ -118,10 +118,6 @@ class UserListUpload < ApplicationRecord
     else
       [invitations: :follow_up]
     end
-  end
-
-  def last_creneaux_snapshot
-    creneaux_snapshots.order(created_at: :desc).first
   end
 
   private

--- a/app/models/user_list_upload.rb
+++ b/app/models/user_list_upload.rb
@@ -13,6 +13,7 @@ class UserListUpload < ApplicationRecord
 
   has_many :user_rows, class_name: "UserListUpload::UserRow", dependent: :destroy
   has_many :processing_logs, class_name: "UserListUpload::ProcessingLog", dependent: :destroy
+  has_many :creneaux_snapshots, class_name: "UserListUpload::CreneauxSnapshot", dependent: :destroy
   has_many :user_save_attempts, class_name: "UserListUpload::UserSaveAttempt", through: :user_rows
   has_many :invitation_attempts, class_name: "UserListUpload::InvitationAttempt", through: :user_rows
 
@@ -27,9 +28,11 @@ class UserListUpload < ApplicationRecord
            :user_rows_selected_for_user_save, :user_rows_with_errors, :user_rows_archived,
            :user_rows_with_closed_follow_up, :user_rows_with_user_save_success, :user_rows_with_successful_invitation,
            to: :user_collection
-  delegate :motif_category, :motif_category_id, :motif_category_name, :motif_category_short_name,
+  delegate :motif_category, :motif_category_id, :motif_category_name, :motif_category_short_name, :rdv_with_referents?,
            to: :category_configuration, allow_nil: true
   delegate :number, :id, to: :department, prefix: true
+
+  after_create_commit :create_creneaux_snapshot, if: :retrievable_creneaux_snapshot?
 
   def save_with_existing_users!(users)
     transaction do
@@ -116,6 +119,14 @@ class UserListUpload < ApplicationRecord
     end
   end
 
+  def last_creneaux_snapshot
+    creneaux_snapshots.order(created_at: :desc).first
+  end
+
+  def retrievable_creneaux_snapshot?
+    category_configuration_id? && !rdv_with_referents?
+  end
+
   private
 
   def user_row_attributes
@@ -138,5 +149,9 @@ class UserListUpload < ApplicationRecord
 
   def remove_duplicates!(attributes)
     attributes.uniq
+  end
+
+  def create_creneaux_snapshot
+    UserListUpload::CreateCreneauxSnapshotJob.perform_later(id)
   end
 end

--- a/app/models/user_list_upload/creneaux_snapshot.rb
+++ b/app/models/user_list_upload/creneaux_snapshot.rb
@@ -1,0 +1,14 @@
+class UserListUpload::CreneauxSnapshot < ApplicationRecord
+  self.table_name = "user_list_upload_creneaux_snapshots"
+
+  belongs_to :user_list_upload
+  delegate :user_rows_selected_for_invitation, to: :user_list_upload
+
+  def no_creneaux_available?
+    number_of_creneaux_available.zero?
+  end
+
+  def insufficient_creneaux?
+    number_of_creneaux_available < user_rows_selected_for_invitation.size
+  end
+end

--- a/app/models/user_list_upload/creneaux_snapshot.rb
+++ b/app/models/user_list_upload/creneaux_snapshot.rb
@@ -4,6 +4,8 @@ class UserListUpload::CreneauxSnapshot < ApplicationRecord
   belongs_to :user_list_upload
   delegate :user_rows_selected_for_invitation, to: :user_list_upload
 
+  validates :number_of_creneaux_available, presence: true
+
   def no_creneaux_available?
     number_of_creneaux_available.zero?
   end

--- a/app/services/creneaux/store_number_of_creneaux_available.rb
+++ b/app/services/creneaux/store_number_of_creneaux_available.rb
@@ -14,8 +14,11 @@ module Creneaux
         category_configuration.organisation
       )
 
-      save_record!(CreneauAvailability.new(category_configuration:, number_of_creneaux_available:,
-                                           number_of_pending_invitations:))
+      save_record!(
+        CategoryConfiguration::CreneauAvailability.new(
+          category_configuration:, number_of_creneaux_available:, number_of_pending_invitations:
+        )
+      )
     end
 
     private

--- a/app/services/user_list_upload/create_creneaux_snapshot.rb
+++ b/app/services/user_list_upload/create_creneaux_snapshot.rb
@@ -1,0 +1,30 @@
+class UserListUpload::CreateCreneauxSnapshot < BaseService
+  attr_reader :user_list_upload
+
+  def initialize(user_list_upload:)
+    @user_list_upload = user_list_upload
+  end
+
+  def call
+    save_record!(
+      UserListUpload::CreneauxSnapshot.new(
+        user_list_upload:, number_of_creneaux_available:
+      )
+    )
+  end
+
+  private
+
+  def number_of_creneaux_available
+    user_list_upload.agent.with_rdv_solidarites_session do
+      call_service!(
+        RdvSolidaritesApi::RetrieveCreneauAvailability,
+        link_params: {
+          motif_category_short_name: user_list_upload.motif_category_short_name,
+          organisation_ids: user_list_upload.organisations.map(&:rdv_solidarites_organisation_id)
+        },
+        total_count: true
+      ).creneau_availability_count
+    end
+  end
+end

--- a/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
@@ -1,16 +1,19 @@
 <%# locals: (user_list_upload:, creneaux_snapshot:) %>
 
-<div class="alert alert-info d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
+<div class="alert alert-info d-flex align-items-center justify-content-between mb-0" role="alert"
+     id="rdvi_upload_creneaux-before-invite_enough_banner" data-controller="flash">
   <div class="d-flex align-items-center">
     <i class="ri-information-line me-2 text-info"></i>
     <span class="text-dark">
       <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
       <%= link_to user_list_upload.organisations.first.rdv_solidarites_planning_url,
-                  target: "_blank", rel: "noopener", class: "link-blue-underlined" do %>
+                  target: "_blank", rel: "noopener", class: "link-blue-underlined",
+                  id: "rdvi_upload_creneaux-before-invite_enough_consult-planning" do %>
         Consulter le planning <i class="ri-external-link-line"></i>
       <% end %>
     </span>
   </div>
-  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
+  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"
+          id="rdvi_upload_creneaux-before-invite_enough_close"></button>
 </div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
@@ -2,12 +2,12 @@
 
 <div class="alert alert-info d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
   <div class="d-flex align-items-center">
-    <i class="ri-information-line me-2"></i>
-    <span>
+    <i class="ri-information-line me-2 text-info"></i>
+    <span class="text-dark">
       <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
       <%= link_to rdv_solidarites_planning_url(user_list_upload.organisations.first),
-                  target: "_blank", rel: "noopener", class: "alert-link" do %>
+                  target: "_blank", rel: "noopener", class: "link-blue-underlined" do %>
         Consulter le planning <i class="ri-external-link-line"></i>
       <% end %>
     </span>

--- a/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
@@ -5,7 +5,8 @@
   <div class="d-flex align-items-center">
     <i class="ri-information-line me-2 text-info"></i>
     <span class="text-dark">
-      <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
+      <strong><%= custom_pluralize(creneaux_snapshot.number_of_creneaux_available, "créneau") %>
+        <%= custom_pluralize(creneaux_snapshot.number_of_creneaux_available, "disponible", with_count: false) %></strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
       <%= link_to user_list_upload.organisations.first.rdv_solidarites_planning_url,
                   target: "_blank", rel: "noopener", class: "link-blue-underlined",

--- a/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
@@ -6,7 +6,7 @@
     <span class="text-dark">
       <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
-      <%= link_to rdv_solidarites_planning_url(user_list_upload.organisations.first),
+      <%= link_to user_list_upload.organisations.first.rdv_solidarites_planning_url,
                   target: "_blank", rel: "noopener", class: "link-blue-underlined" do %>
         Consulter le planning <i class="ri-external-link-line"></i>
       <% end %>

--- a/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_enough_creneaux.html.erb
@@ -1,0 +1,16 @@
+<%# locals: (user_list_upload:, creneaux_snapshot:) %>
+
+<div class="alert alert-info d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
+  <div class="d-flex align-items-center">
+    <i class="ri-information-line me-2"></i>
+    <span>
+      <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
+      sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
+      <%= link_to rdv_solidarites_planning_url(user_list_upload.organisations.first),
+                  target: "_blank", rel: "noopener", class: "alert-link" do %>
+        Consulter le planning <i class="ri-external-link-line"></i>
+      <% end %>
+    </span>
+  </div>
+  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
+</div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_error.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_error.html.erb
@@ -1,5 +1,3 @@
-<%# locals: () %>
-
 <div class="alert alert-danger d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
   <div class="d-flex align-items-center">
     <i class="ri-alert-line me-2 text-danger"></i>

--- a/app/views/user_list_uploads/creneaux_snapshots/_error.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_error.html.erb
@@ -1,13 +1,9 @@
-<%# locals: (user_list_upload:) %>
+<%# locals: () %>
 
 <div class="alert alert-danger d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
   <div class="d-flex align-items-center">
     <i class="ri-alert-line me-2 text-danger"></i>
-    <span class="text-dark">
-      <strong>Aucun créneau disponible</strong>
-      sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
-      <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined" %>
-    </span>
+    <span class="text-dark">Le nombre de créneaux disponibles n'a pas pu être récupéré.</span>
   </div>
   <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
 </div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_loading.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_loading.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_stream_from user_list_upload %>
 <div class="alert alert-info d-flex align-items-center mb-0" role="status"
      data-controller="refresh-page-after"
-     data-refresh-page-after-delay-value="<%= creneaux_snapshot_refresh_delay_in_ms(user_list_upload) %>">
+     data-refresh-page-after-delay-value="<%= creneaux_snapshot_refresh_delay_in_ms(user_list_upload.creneaux_snapshot_retrieval_expires_at) %>">
   <span class="spinner-border spinner-border-sm me-2 text-info" role="status" aria-hidden="true"></span>
   <span class="text-dark">Calcul du nombre de créneaux disponibles en cours...</span>
 </div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_loading.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_loading.html.erb
@@ -1,7 +1,9 @@
 <%# locals: (user_list_upload:) %>
 
 <%= turbo_stream_from user_list_upload %>
-<div class="alert alert-info d-flex align-items-center mb-0" role="status">
-  <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
-  <span>Calcul du nombre de créneaux disponibles en cours...</span>
+<div class="alert alert-info d-flex align-items-center mb-0" role="status"
+     data-controller="refresh-page-after"
+     data-refresh-page-after-delay-value="<%= creneaux_snapshot_refresh_delay_in_ms(user_list_upload) %>">
+  <span class="spinner-border spinner-border-sm me-2 text-info" role="status" aria-hidden="true"></span>
+  <span class="text-dark">Calcul du nombre de créneaux disponibles en cours...</span>
 </div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_loading.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_loading.html.erb
@@ -1,0 +1,7 @@
+<%# locals: (user_list_upload:) %>
+
+<%= turbo_stream_from user_list_upload %>
+<div class="alert alert-info d-flex align-items-center mb-0" role="status">
+  <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+  <span>Calcul du nombre de créneaux disponibles en cours...</span>
+</div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_no_creneaux_available.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_no_creneaux_available.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (user_list_upload:) %>
+
+<div class="alert alert-danger d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
+  <div class="d-flex align-items-center">
+    <i class="ri-alert-line me-2"></i>
+    <span>
+      <strong>Aucun créneau disponible</strong>
+      sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
+      <%= link_to "Demander plus de créneaux", "#", class: "alert-link" %>
+    </span>
+  </div>
+  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
+</div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_no_creneaux_available.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_no_creneaux_available.html.erb
@@ -1,13 +1,16 @@
 <%# locals: (user_list_upload:) %>
 
-<div class="alert alert-danger d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
+<div class="alert alert-danger d-flex align-items-center justify-content-between mb-0" role="alert"
+     id="rdvi_upload_creneaux-before-invite_none_banner" data-controller="flash">
   <div class="d-flex align-items-center">
     <i class="ri-alert-line me-2 text-danger"></i>
     <span class="text-dark">
       <strong>Aucun créneau disponible</strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
-      <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined" %>
+      <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined",
+                  id: "rdvi_upload_creneaux-before-invite_none_request-more" %>
     </span>
   </div>
-  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
+  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"
+          id="rdvi_upload_creneaux-before-invite_none_close"></button>
 </div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
@@ -2,11 +2,11 @@
 
 <div class="alert alert-warning d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
   <div class="d-flex align-items-center">
-    <i class="ri-error-warning-line me-2"></i>
-    <span>
+    <i class="ri-error-warning-line me-2 text-warning"></i>
+    <span class="text-dark">
       <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
-      <%= link_to "Demander plus de créneaux", "#", class: "alert-link" %>
+      <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined" %>
     </span>
   </div>
   <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>

--- a/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
@@ -1,13 +1,16 @@
 <%# locals: (user_list_upload:, creneaux_snapshot:) %>
 
-<div class="alert alert-warning d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
+<div class="alert alert-warning d-flex align-items-center justify-content-between mb-0" role="alert"
+     id="rdvi_upload_creneaux-before-invite_not-enough_banner" data-controller="flash">
   <div class="d-flex align-items-center">
     <i class="ri-error-warning-line me-2 text-warning"></i>
     <span class="text-dark">
       <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
-      <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined" %>
+      <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined",
+                  id: "rdvi_upload_creneaux-before-invite_not-enough_request-more" %>
     </span>
   </div>
-  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
+  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"
+          id="rdvi_upload_creneaux-before-invite_not-enough_close"></button>
 </div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (user_list_upload:, creneaux_snapshot:) %>
+
+<div class="alert alert-warning d-flex align-items-center justify-content-between mb-0" role="alert" data-controller="flash">
+  <div class="d-flex align-items-center">
+    <i class="ri-error-warning-line me-2"></i>
+    <span>
+      <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
+      sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
+      <%= link_to "Demander plus de créneaux", "#", class: "alert-link" %>
+    </span>
+  </div>
+  <button type="button" class="btn-close" data-action="flash#remove" aria-label="Fermer"></button>
+</div>

--- a/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
+++ b/app/views/user_list_uploads/creneaux_snapshots/_not_enough_creneaux.html.erb
@@ -5,7 +5,8 @@
   <div class="d-flex align-items-center">
     <i class="ri-error-warning-line me-2 text-warning"></i>
     <span class="text-dark">
-      <strong><%= creneaux_snapshot.number_of_creneaux_available %> créneaux disponibles</strong>
+      <strong><%= custom_pluralize(creneaux_snapshot.number_of_creneaux_available, "créneau") %>
+        <%= custom_pluralize(creneaux_snapshot.number_of_creneaux_available, "disponible", with_count: false) %></strong>
       sur les motifs de rendez-vous de « <%= user_list_upload.motif_category_name %> ».
       <%= link_to "Demander plus de créneaux", "#", class: "link-blue-underlined",
                   id: "rdvi_upload_creneaux-before-invite_not-enough_request-more" %>

--- a/app/views/user_list_uploads/invitation_attempts/_creneaux_snapshot.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_creneaux_snapshot.html.erb
@@ -1,0 +1,13 @@
+<%# locals: (user_list_upload:, creneaux_snapshot:) %>
+
+<div class="col-12 mb-4">
+  <% if creneaux_snapshot.nil? %>
+    <%= render "user_list_uploads/creneaux_snapshots/loading", user_list_upload: %>
+  <% elsif creneaux_snapshot.no_creneaux_available? %>
+    <%= render "user_list_uploads/creneaux_snapshots/no_creneaux_available", user_list_upload: %>
+  <% elsif creneaux_snapshot.insufficient_creneaux? %>
+    <%= render "user_list_uploads/creneaux_snapshots/not_enough_creneaux", user_list_upload:, creneaux_snapshot: %>
+  <% else %>
+    <%= render "user_list_uploads/creneaux_snapshots/enough_creneaux", user_list_upload:, creneaux_snapshot: %>
+  <% end %>
+</div>

--- a/app/views/user_list_uploads/invitation_attempts/_creneaux_snapshot.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/_creneaux_snapshot.html.erb
@@ -2,7 +2,11 @@
 
 <div class="col-12 mb-4">
   <% if creneaux_snapshot.nil? %>
-    <%= render "user_list_uploads/creneaux_snapshots/loading", user_list_upload: %>
+    <% if user_list_upload.awaiting_creneaux_snapshot? %>
+      <%= render "user_list_uploads/creneaux_snapshots/loading", user_list_upload: %>
+    <% else %>
+      <%= render "user_list_uploads/creneaux_snapshots/error" %>
+    <% end %>
   <% elsif creneaux_snapshot.no_creneaux_available? %>
     <%= render "user_list_uploads/creneaux_snapshots/no_creneaux_available", user_list_upload: %>
   <% elsif creneaux_snapshot.insufficient_creneaux? %>

--- a/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
@@ -19,6 +19,10 @@
         data-user-list-upload-id="<%= @user_list_upload.id %>"
         data-attribute-to-toggle="selected_for_invitation"
     >
+      <% if @user_list_upload.retrievable_creneaux_snapshot? %>
+        <%= render "creneaux_snapshot", user_list_upload: @user_list_upload, creneaux_snapshot: @creneaux_snapshot %>
+      <% end %>
+
       <div class="d-flex justify-content-between align-items-center">
         <div class="mb-4">
           <h2 class="h2-title">Inviter les usagers à prendre rendez-vous</h2>
@@ -55,7 +59,7 @@
                   <%= check_box_tag "format_sms", "SMS", checked: invitation_format_checked?("sms", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { user_list_upload__select_user_rows_target: "invitationFormatOption", action: "change->user-list-upload--select-user-rows#handleFormatOptionChange", format: "sms" } %>
                   <%= label_tag "format_sms", "SMS", class: "form-check-label" %>
                 </div>
-                <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_send-invit", disabled: @number_of_user_rows_selected.zero? %>
+                <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_send-invit", disabled: @number_of_user_rows_selected.zero? || @creneaux_snapshot&.no_creneaux_available? %>
               </div>
             <% end %>
           </div>

--- a/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
@@ -19,10 +19,6 @@
         data-user-list-upload-id="<%= @user_list_upload.id %>"
         data-attribute-to-toggle="selected_for_invitation"
     >
-      <% if @user_list_upload.retrievable_creneaux_snapshot? %>
-        <%= render "creneaux_snapshot", user_list_upload: @user_list_upload, creneaux_snapshot: @creneaux_snapshot %>
-      <% end %>
-
       <div class="d-flex justify-content-between align-items-center">
         <div class="mb-4">
           <h2 class="h2-title">Inviter les usagers à prendre rendez-vous</h2>
@@ -32,6 +28,11 @@
         </div>
         <%= render "user_list_uploads/search_form" %>
       </div>
+
+      <% if @user_list_upload.retrievable_creneaux_snapshot? %>
+        <%= render "creneaux_snapshot", user_list_upload: @user_list_upload, creneaux_snapshot: @creneaux_snapshot %>
+      <% end %>
+
       <%= render "user_rows_before_invitation", user_rows: @user_rows %>
 
       <div class="container sticky-footer">

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -624,3 +624,10 @@ tables:
       - orientation_type_id
       - created_at
       - updated_at
+  - table_name: user_list_upload_creneaux_snapshots
+    anonymized_column_names: []
+    non_anonymized_column_names:
+      - user_list_upload_id
+      - created_at
+      - updated_at
+      - number_of_creneaux_available

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -69,11 +69,11 @@ tables:
       - user_id
       - department_id
 
-  - table_name: creneau_availabilities
+  - table_name: category_configuration_creneau_availabilities
     non_anonymized_column_names:
       - number_of_creneaux_available
       - number_of_pending_invitations
-      - category_configuration
+      - category_configuration_id
       - updated_at
       - created_at
 

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,7 @@
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.irregular "lieu", "lieux"
+  inflect.irregular "créneau", "créneaux"
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/db/migrate/20260527115512_create_user_list_upload_creneaux_snapshots.rb
+++ b/db/migrate/20260527115512_create_user_list_upload_creneaux_snapshots.rb
@@ -2,7 +2,7 @@ class CreateUserListUploadCreneauxSnapshots < ActiveRecord::Migration[8.1]
   def change
     create_table :user_list_upload_creneaux_snapshots do |t|
       t.references :user_list_upload, null: false, foreign_key: true, type: :uuid
-      t.integer :number_of_creneaux_available
+      t.integer :number_of_creneaux_available, null: false
 
       t.timestamps
     end

--- a/db/migrate/20260527115512_create_user_list_upload_creneaux_snapshots.rb
+++ b/db/migrate/20260527115512_create_user_list_upload_creneaux_snapshots.rb
@@ -1,0 +1,10 @@
+class CreateUserListUploadCreneauxSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :user_list_upload_creneaux_snapshots do |t|
+      t.references :user_list_upload, null: false, foreign_key: true, type: :uuid
+      t.integer :number_of_creneaux_available
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260603091945_rename_creneau_availabilities_to_category_configuration_creneau_availabilities.rb
+++ b/db/migrate/20260603091945_rename_creneau_availabilities_to_category_configuration_creneau_availabilities.rb
@@ -1,0 +1,5 @@
+class RenameCreneauAvailabilitiesToCategoryConfigurationCreneauAvailabilities < ActiveRecord::Migration[8.1]
+  def change
+    rename_table :creneau_availabilities, :category_configuration_creneau_availabilities
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_115512) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_091945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -140,6 +140,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_115512) do
     t.index ["user_id"], name: "index_blocked_users_on_user_id"
   end
 
+  create_table "category_configuration_creneau_availabilities", force: :cascade do |t|
+    t.bigint "category_configuration_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "number_of_creneaux_available"
+    t.integer "number_of_pending_invitations"
+    t.datetime "updated_at", null: false
+    t.index ["category_configuration_id"], name: "idx_on_category_configuration_id_75b11a64f7"
+    t.index ["created_at"], name: "idx_on_created_at_88314c9144"
+  end
+
   create_table "category_configurations", force: :cascade do |t|
     t.boolean "convene_user", default: true
     t.datetime "created_at", null: false
@@ -172,16 +182,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_115512) do
     t.boolean "tracking_accepted", default: false
     t.datetime "updated_at", null: false
     t.index ["agent_id"], name: "index_cookies_consents_on_agent_id"
-  end
-
-  create_table "creneau_availabilities", force: :cascade do |t|
-    t.bigint "category_configuration_id", null: false
-    t.datetime "created_at", null: false
-    t.integer "number_of_creneaux_available"
-    t.integer "number_of_pending_invitations"
-    t.datetime "updated_at", null: false
-    t.index ["category_configuration_id"], name: "index_creneau_availabilities_on_category_configuration_id"
-    t.index ["created_at"], name: "index_creneau_availabilities_on_created_at"
   end
 
   create_table "csv_exports", force: :cascade do |t|
@@ -754,11 +754,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_115512) do
   add_foreign_key "archives", "users"
   add_foreign_key "blocked_invitations_counters", "organisations"
   add_foreign_key "blocked_users", "users"
+  add_foreign_key "category_configuration_creneau_availabilities", "category_configurations"
   add_foreign_key "category_configurations", "file_configurations"
   add_foreign_key "category_configurations", "motif_categories"
   add_foreign_key "category_configurations", "organisations"
   add_foreign_key "cookies_consents", "agents"
-  add_foreign_key "creneau_availabilities", "category_configurations"
   add_foreign_key "csv_exports", "agents"
   add_foreign_key "dpa_agreements", "agents"
   add_foreign_key "dpa_agreements", "organisations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -577,7 +577,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_091945) do
 
   create_table "user_list_upload_creneaux_snapshots", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "number_of_creneaux_available"
+    t.integer "number_of_creneaux_available", null: false
     t.datetime "updated_at", null: false
     t.uuid "user_list_upload_id", null: false
     t.index ["user_list_upload_id"], name: "idx_on_user_list_upload_id_dde82cda5f"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_144730) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_115512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -574,6 +574,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_144730) do
     t.string "user_designation"
   end
 
+  create_table "user_list_upload_creneaux_snapshots", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "number_of_creneaux_available"
+    t.datetime "updated_at", null: false
+    t.uuid "user_list_upload_id", null: false
+    t.index ["user_list_upload_id"], name: "idx_on_user_list_upload_id_dde82cda5f"
+  end
+
   create_table "user_list_upload_invitation_attempts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "format"
@@ -785,6 +793,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_144730) do
   add_foreign_key "tag_organisations", "tags"
   add_foreign_key "tag_users", "tags"
   add_foreign_key "tag_users", "users"
+  add_foreign_key "user_list_upload_creneaux_snapshots", "user_list_uploads"
   add_foreign_key "user_list_upload_invitation_attempts", "invitations"
   add_foreign_key "user_list_upload_invitation_attempts", "user_list_upload_user_rows", column: "user_row_id"
   add_foreign_key "user_list_upload_processing_logs", "user_list_uploads"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -992,7 +992,7 @@ describe UsersController do
       end
 
       context "when no CreneauAvailability exists for the category" do
-        before { CreneauAvailability.destroy_all }
+        before { CategoryConfiguration::CreneauAvailability.destroy_all }
 
         it "does not display the banner" do
           get :index, params: index_params

--- a/spec/factories/category_configuration/creneau_availability.rb
+++ b/spec/factories/category_configuration/creneau_availability.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :creneau_availability do
+  factory :creneau_availability, class: "CategoryConfiguration::CreneauAvailability" do
     number_of_creneaux_available { rand(0..30) }
     category_configuration
   end

--- a/spec/factories/user_list_upload/creneaux_snapshot.rb
+++ b/spec/factories/user_list_upload/creneaux_snapshot.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :creneaux_snapshot, class: "UserListUpload::CreneauxSnapshot" do
+    user_list_upload
+    number_of_creneaux_available { 50 }
+  end
+end

--- a/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
+++ b/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
@@ -1,0 +1,109 @@
+describe "Agents can see créneaux availability before inviting", :js do
+  let!(:department) { create(:department) }
+  let!(:rdv_solidarites_organisation_id) { 3234 }
+  let!(:organisation) do
+    create(:organisation, department:, rdv_solidarites_organisation_id:, slug: "org1")
+  end
+  let!(:agent) { create(:agent, organisations: [organisation]) }
+  let!(:motif_category) { create(:motif_category, name: "RSA orientation") }
+  let!(:category_configuration) do
+    create(:category_configuration, organisation:, motif_category:)
+  end
+
+  let!(:user_list_upload) do
+    create(:user_list_upload, agent:, category_configuration:, structure: organisation)
+  end
+
+  # the créneaux banner only compares against the number of rows selected for invitation
+  let!(:first_row) do
+    create(:user_row, user_list_upload:, email: "hernan@crespo.com", selected_for_invitation: true)
+  end
+  let!(:second_row) do
+    create(:user_row, user_list_upload:, email: "christian@vieri.com", selected_for_invitation: true)
+  end
+
+  before { setup_agent_session(agent) }
+
+  context "when there are more créneaux than users to invite" do
+    let!(:creneaux_snapshot) { create(:creneaux_snapshot, user_list_upload:, number_of_creneaux_available: 50) }
+
+    it "shows an informative banner with a link to the planning" do
+      visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+      within(".alert-info") do
+        expect(page).to have_content("50 créneaux disponibles")
+        expect(page).to have_content("RSA orientation")
+        expect(page).to have_link("Consulter le planning")
+      end
+
+      expect(page).to have_button("Envoyer les invitations", disabled: false)
+    end
+  end
+
+  context "when there are fewer créneaux than users to invite" do
+    let!(:creneaux_snapshot) { create(:creneaux_snapshot, user_list_upload:, number_of_creneaux_available: 1) }
+
+    it "shows a warning banner but still allows inviting" do
+      visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+      within(".alert-warning") do
+        expect(page).to have_content("1 créneaux disponibles")
+        expect(page).to have_link("Demander plus de créneaux")
+      end
+
+      expect(page).to have_button("Envoyer les invitations", disabled: false)
+    end
+  end
+
+  context "when there are no créneaux available" do
+    let!(:creneaux_snapshot) { create(:creneaux_snapshot, user_list_upload:, number_of_creneaux_available: 0) }
+
+    it "shows a danger banner and prevents inviting" do
+      visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+      within(".alert-danger") do
+        expect(page).to have_content("Aucun créneau disponible")
+        expect(page).to have_link("Demander plus de créneaux")
+      end
+
+      expect(page).to have_button("Envoyer les invitations", disabled: true)
+    end
+  end
+
+  context "when the snapshot has not been retrieved yet" do
+    it "shows the loading banner with a one-shot refresh" do
+      visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+      expect(page).to have_content("Calcul du nombre de créneaux disponibles en cours...")
+      expect(page).to have_css("[data-controller='refresh-page-after']")
+    end
+  end
+
+  context "when the snapshot retrieval has timed out" do
+    before { user_list_upload.update_column(:created_at, 3.minutes.ago) }
+
+    it "shows an error banner" do
+      visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+      within(".alert-danger") do
+        expect(page).to have_content("Le nombre de créneaux disponibles n'a pas pu être récupéré.")
+      end
+      expect(page).to have_no_content("Calcul du nombre de créneaux disponibles en cours...")
+    end
+  end
+
+  context "when the category configuration is set with rdv_with_referents" do
+    let!(:category_configuration) do
+      create(:category_configuration, organisation:, motif_category:, rdv_with_referents: true)
+    end
+    let!(:creneaux_snapshot) { nil }
+
+    it "does not show any créneaux banner" do
+      visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+      expect(page).to have_content("Inviter les usagers à prendre rendez-vous")
+      expect(page).to have_no_content("créneaux disponibles")
+      expect(page).to have_no_content("Calcul du nombre de créneaux disponibles en cours...")
+    end
+  end
+end

--- a/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
+++ b/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
@@ -14,7 +14,6 @@ describe "Agents can see créneaux availability before inviting", :js do
     create(:user_list_upload, agent:, category_configuration:, structure: organisation)
   end
 
-  # the créneaux banner only compares against the number of rows selected for invitation
   let!(:first_row) do
     create(:user_row, user_list_upload:, email: "hernan@crespo.com", selected_for_invitation: true)
   end

--- a/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
+++ b/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
@@ -46,7 +46,7 @@ describe "Agents can see créneaux availability before inviting", :js do
       visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
 
       within(".alert-warning") do
-        expect(page).to have_content("1 créneaux disponibles")
+        expect(page).to have_content("1 créneau disponible")
         expect(page).to have_link("Demander plus de créneaux")
       end
 

--- a/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
+++ b/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
@@ -106,4 +106,35 @@ describe "Agents can see créneaux availability before inviting", :js do
       expect(page).to have_no_content("Calcul du nombre de créneaux disponibles en cours...")
     end
   end
+
+  context "when the tally survey is enabled" do
+    before { ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"] = "creneaux_form_id" }
+    after { ENV.delete("SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID") }
+
+    context "and a snapshot exists" do
+      let!(:creneaux_snapshot) { create(:creneaux_snapshot, user_list_upload:, number_of_creneaux_available: 50) }
+
+      it "redirects to the same page with the tally form so the survey shows up" do
+        visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+        expect(page).to have_current_path(
+          select_rows_user_list_upload_invitation_attempts_path(
+            user_list_upload_id: user_list_upload.id, tally_form_id: "creneaux_form_id"
+          )
+        )
+        expect(page).to have_css("div[data-controller='tally'][data-tally-form-id='creneaux_form_id']", visible: :all)
+      end
+    end
+
+    context "and no snapshot exists yet" do
+      it "does not redirect with the tally form" do
+        visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+
+        expect(page).to have_current_path(
+          select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
+        )
+        expect(page).to have_no_css("div[data-controller='tally']", visible: :all)
+      end
+    end
+  end
 end

--- a/spec/jobs/user_list_upload/create_creneaux_snapshot_job_spec.rb
+++ b/spec/jobs/user_list_upload/create_creneaux_snapshot_job_spec.rb
@@ -1,0 +1,30 @@
+describe UserListUpload::CreateCreneauxSnapshotJob do
+  subject { described_class.new.perform(user_list_upload_id) }
+
+  let!(:user_list_upload) { create(:user_list_upload) }
+  let(:user_list_upload_id) { user_list_upload.id }
+
+  before do
+    allow(UserListUpload::CreateCreneauxSnapshot).to receive(:call).and_return(OpenStruct.new(success?: true))
+  end
+
+  context "when the user list upload exists" do
+    it "calls the create snapshot service and broadcasts a refresh" do
+      expect_any_instance_of(UserListUpload).to receive(:broadcast_refresh)
+
+      subject
+
+      expect(UserListUpload::CreateCreneauxSnapshot).to have_received(:call).with(user_list_upload:)
+    end
+  end
+
+  context "when the user list upload no longer exists" do
+    before { user_list_upload.destroy }
+
+    it "does nothing" do
+      subject
+
+      expect(UserListUpload::CreateCreneauxSnapshot).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/models/category_configuration/creneau_availability_spec.rb
+++ b/spec/models/category_configuration/creneau_availability_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe CreneauAvailability, type: :model do
+RSpec.describe CategoryConfiguration::CreneauAvailability, type: :model do
   describe "scopes" do
     describe ".with_pending_invitations" do
       let!(:creneau_with_nil_invitations) { create(:creneau_availability, number_of_pending_invitations: nil) }

--- a/spec/models/category_configuration_spec.rb
+++ b/spec/models/category_configuration_spec.rb
@@ -15,7 +15,7 @@ describe CategoryConfiguration do
       let!(:creneau_availability) { create(:creneau_availability, category_configuration: category_configuration) }
 
       it "destroys creneaux_availability" do
-        expect { category_configuration.destroy }.to change(CreneauAvailability, :count).by(-1)
+        expect { category_configuration.destroy }.to change(CategoryConfiguration::CreneauAvailability, :count).by(-1)
       end
     end
   end

--- a/spec/models/user_list_upload_spec.rb
+++ b/spec/models/user_list_upload_spec.rb
@@ -136,4 +136,36 @@ RSpec.describe UserListUpload do
       end
     end
   end
+
+  describe "créneaux snapshot retrieval on creation" do
+    let(:agent) { create(:agent) }
+
+    context "when the upload has a category configuration without rdv_with_referents" do
+      it "enqueues the créneaux snapshot job" do
+        expect do
+          create(:user_list_upload, agent:, category_configuration: create(:category_configuration))
+        end.to have_enqueued_job(UserListUpload::CreateCreneauxSnapshotJob)
+      end
+    end
+
+    context "when the upload has no category configuration" do
+      it "does not enqueue the créneaux snapshot job" do
+        expect do
+          create(:user_list_upload, agent:, category_configuration: nil, origin: "file_upload")
+        end.not_to have_enqueued_job(UserListUpload::CreateCreneauxSnapshotJob)
+      end
+    end
+
+    context "when the category configuration uses rdv_with_referents" do
+      it "does not enqueue the créneaux snapshot job" do
+        expect do
+          create(
+            :user_list_upload,
+            agent:,
+            category_configuration: create(:category_configuration, rdv_with_referents: true)
+          )
+        end.not_to have_enqueued_job(UserListUpload::CreateCreneauxSnapshotJob)
+      end
+    end
+  end
 end

--- a/spec/services/creneaux/store_number_of_creneaux_available_spec.rb
+++ b/spec/services/creneaux/store_number_of_creneaux_available_spec.rb
@@ -20,13 +20,13 @@ describe Creneaux::StoreNumberOfCreneauxAvailable, type: :service do
 
     it "stores the number of creneaux available" do
       subject
-      expect(CreneauAvailability.last.number_of_creneaux_available).to eq(3)
-      expect(CreneauAvailability.last.category_configuration).to eq(category_configuration)
+      expect(CategoryConfiguration::CreneauAvailability.last.number_of_creneaux_available).to eq(3)
+      expect(CategoryConfiguration::CreneauAvailability.last.category_configuration).to eq(category_configuration)
     end
 
     it "stores the number of pending invitations" do
       subject
-      expect(CreneauAvailability.last.number_of_pending_invitations).to eq(1)
+      expect(CategoryConfiguration::CreneauAvailability.last.number_of_pending_invitations).to eq(1)
     end
 
     context "with multiple invitations of the same follow_up" do
@@ -36,7 +36,7 @@ describe Creneaux::StoreNumberOfCreneauxAvailable, type: :service do
 
       it "stores the number of pending invitations" do
         subject
-        expect(CreneauAvailability.last.number_of_pending_invitations).to eq(1)
+        expect(CategoryConfiguration::CreneauAvailability.last.number_of_pending_invitations).to eq(1)
       end
     end
   end

--- a/spec/services/user_list_upload/create_creneaux_snapshot_spec.rb
+++ b/spec/services/user_list_upload/create_creneaux_snapshot_spec.rb
@@ -1,0 +1,54 @@
+describe UserListUpload::CreateCreneauxSnapshot, type: :service do
+  subject { described_class.call(user_list_upload:) }
+
+  let!(:organisation) { create(:organisation, rdv_solidarites_organisation_id: 3234) }
+  let!(:agent) { create(:agent, admin_role_in_organisations: [organisation]) }
+  let!(:category_configuration) { create(:category_configuration, organisation:) }
+  let!(:user_list_upload) do
+    create(:user_list_upload, agent:, category_configuration:, structure: organisation)
+  end
+
+  context "when the API call succeeds" do
+    before do
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call).and_return(
+        OpenStruct.new(success?: true, creneau_availability_count: 8)
+      )
+    end
+
+    it "succeeds" do
+      expect(subject.success?).to be(true)
+    end
+
+    it "creates a snapshot with the retrieved number of créneaux" do
+      expect { subject }.to change(UserListUpload::CreneauxSnapshot, :count).by(1)
+
+      snapshot = user_list_upload.reload.last_creneaux_snapshot
+      expect(snapshot.number_of_creneaux_available).to eq(8)
+    end
+
+    it "requests the availability for all the upload organisations" do
+      subject
+
+      expect(RdvSolidaritesApi::RetrieveCreneauAvailability).to have_received(:call).with(
+        link_params: {
+          motif_category_short_name: category_configuration.motif_category_short_name,
+          organisation_ids: [organisation.rdv_solidarites_organisation_id]
+        },
+        total_count: true
+      )
+    end
+  end
+
+  context "when the API call fails" do
+    before do
+      allow(RdvSolidaritesApi::RetrieveCreneauAvailability).to receive(:call).and_return(
+        OpenStruct.new(success?: false, errors: ["RDV-S indisponible"])
+      )
+    end
+
+    it "fails and does not create a snapshot" do
+      expect(subject.success?).to be(false)
+      expect(UserListUpload::CreneauxSnapshot.count).to eq(0)
+    end
+  end
+end

--- a/spec/services/user_list_upload/create_creneaux_snapshot_spec.rb
+++ b/spec/services/user_list_upload/create_creneaux_snapshot_spec.rb
@@ -22,7 +22,7 @@ describe UserListUpload::CreateCreneauxSnapshot, type: :service do
     it "creates a snapshot with the retrieved number of créneaux" do
       expect { subject }.to change(UserListUpload::CreneauxSnapshot, :count).by(1)
 
-      snapshot = user_list_upload.reload.last_creneaux_snapshot
+      snapshot = user_list_upload.reload.creneaux_snapshot
       expect(snapshot.number_of_creneaux_available).to eq(8)
     end
 


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/1-3-Dans-le-funnel-d-import-afficher-le-nombre-de-cr-neaux-disponibles-l-tape-d-invitation-3605f321b60480068f52f132a70ee73f

## Contexte

L'idée ici est de montrer le nombre de créneaux disponibles avant l'envoi d'invitations en masse. Le but est de comparer le nombre de créneaux dispo avec le nombre de personne que l'on veut inviter, et d'afficher différents messages de warning ou d'info à l'utilisateur en fonction de la situation, en espérant que cela réduise les situations où les usagers se retrouvent sans créneaux de disponible.

## Implémentation

### Récupération des créneaux

Pour avoir la donnée du nombre de créneaux qui est à jour et liée avec les paramètres de l'upload (en l'occurence la catégorie de motif et les organisations liées à l'upload) je lance un appel pour récupérer le nombre de créneaux à chaque création de l'upload. Les conditions pour que les créneaux puissent être retrouvables étant:
* que l'upload soit liée à une catégorie (s'il ne l'est pas on ne peut de toute façon pas envoyer d'invitations)
* que ce ne soit pas une catégorie de rdv avec référents. En effet pour ces catégories particulières le nombre de créneau dépend du référent de chaque usager, et donc l'agrégat du nombre de créneaux n'est pas forcément très parlant pour savoir si chaque usager aura un créneau dispo

Pour ce faire j'enqueue un job `UserListUpload::CreateCreneauxSnapshot` à chaque création d'upload (via un `after_commit` callback) qui va se charger de faire l'appel à l'API de RDV-S, de récupérer le nombre de créneaux et de sauvegarder ces créneaux dans une nouvelle table `user_list_upload_creneaux_snapshot` (model `UserListUpload::CreneauxSnapshot`). 

### Côté UI

L'idée est que la récupération des créneaux se fasse de manière asynchrone pendant les étapes de création/mise à jour des dossiers pour qu'on puisse afficher le nombre de créneaux au moment où on va vouloir inviter. 
Voici donc les différents cas de figures: 

#### Le nombre de créneaux n'est pas récupérable parce que c'est un rdv avec référents

Dans ce cas-là on n'affiche rien

#### Le nombre de créneaux disponible est supérieur au nombre de personne à inviter 

On affiche un bandeau informatif avec un lien pour consulter le planning 📸 : 

<img width="1520" height="521" alt="image" src="https://github.com/user-attachments/assets/7f4bb0ca-10ae-40bc-8943-c44934344b6f" />

#### Le nombre de de créneaux disponible est inférieur au nombre de personne à inviter

On affiche un bandeau de warning avec un lien pour demander l'ouverture de plus de créneaux 📸  (voir #3303):

<img width="1543" height="820" alt="image" src="https://github.com/user-attachments/assets/c0d239e4-ecf3-4ff1-bb95-4cd932b106c9" />

#### Aucun créneau de disponible 

On affiche un bandeau d'alerte et on disable l'envoi d'invitations 📸 : 

<img width="1603" height="829" alt="image" src="https://github.com/user-attachments/assets/f658dd3a-f624-47de-9604-1167476b4773" />

#### Le nombre de créneaux disponibles n'a pas encore été récupéré

Dans ce cas-là on affiche un bandeau disant que la récupération des créneaux est en cours. Après ça deux situations sont possibles: 
* Les créneaux sont récupérés et on affiche le bandeau correspondant. L'update de la page se fait automatiquement parce qu'on appel `broadcast_refresh` à la fin du `UserListUpload::CreateCreneauxSnapshotJob` et que sur la partial  du bandeau de loading du bandeau fait un `turbo_stream_from @user_list_upload` qui ouvre une connexion websocket 🎥 : 

https://github.com/user-attachments/assets/7199650c-b4bb-416c-a5a8-d40fcd68d153

* Les créneaux ne sont toujours pas récupérés 2 minutes après la création de l'upload. Dans ce cas-là on considère qu'il y a une erreur et qu'ils ne seront pas récupérés, et on affiche un bandeau en conséquence. On lance un refresh de la page au moment où on sait que les créneaux auraient dû être récupérés (via le stimulus controller `refresh_page_later`) 🎥 :

https://github.com/user-attachments/assets/7d20bacf-a27e-4cde-a3a9-b4c9a4168dd1

### Développements annexes

Pour ne pas apporter de confusion entre le model `CreneauAvailability` et `UserListUpload::CreneauxSnapshot`, je décide de namespacer également le model `CreneauAvailability` par `CategoryConfiguration::CreneauAvailability` https://github.com/gip-inclusion/rdv-insertion/pull/3306/commits/95af1957f02d33f08fffc2eb0e4f15eca8c963e5

