### PR TITLE
feat(users): hide feedback link once Tally form is answered

### DIFF
--- a/app/javascript/controllers/tally_controller.js
+++ b/app/javascript/controllers/tally_controller.js
@@ -31,6 +31,7 @@ export default class extends Controller {
       window.Tally.openPopup(this.element.dataset.tallyFormId, {
         onSubmit: () => {
           this.#hasAlreadyAnswered = true
+          this.dispatch("answered", { detail: { formId: this.element.dataset.tallyFormId } })
 
           // Give time for the user to read success message in Tally's popup
           setTimeout(() => window.Tally.closePopup(this.element.dataset.tallyFormId), 1000);

--- a/app/javascript/controllers/tally_link_controller.js
+++ b/app/javascript/controllers/tally_link_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { formId: String }
+
+  connect() {
+    if (this.#answered) this.element.remove()
+  }
+
+  hide(event) {
+    if (event.detail.formId === this.formIdValue) this.element.remove()
+  }
+
+  get #answered() {
+    return localStorage.getItem(`tally-answered-${this.formIdValue}`) === "true"
+  }
+}

--- a/app/views/users/_creneau_availability_banner.html.erb
+++ b/app/views/users/_creneau_availability_banner.html.erb
@@ -12,7 +12,10 @@
   </div>
   <div class="position-absolute end-0 d-flex align-items-center gap-3 pe-3">
     <%= link_to "Donnez-nous votre avis",
-                request.params.merge(tally_form_id: ENV["CRENEAU_AVAILABILITY_BANNER_TALLY_ID"]),
-                class: "text-underline" %>
+                request.params.merge(tally_form_id:),
+                class: "text-underline",
+                data: { controller: "tally-link",
+                        tally_link_form_id_value: ENV["CRENEAU_AVAILABILITY_BANNER_TALLY_ID"],
+                        action: "tally:answered@window->tally-link#hide" } %>
   </div>
 </div>


### PR DESCRIPTION
Le lien « Donnez-nous votre avis » de la bannière créneaux restait affiché même après que l'agent ait répondu au formulaire Tally. Cette PR le masque une fois le formulaire rempli.

  - `tally_controller` émet un événement `tally:answered` au submit (en plus d'écrire dans `localStorage`).
  - Un nouveau `tally_link_controller` retire le lien : immédiatement via cet événement (sans refresh), et dès le chargement de page lors des visites suivantes (lecture du `localStorage`).