### PR TITLE
fix(configuration): Filter deleted motifs from category configurations

### DIFF
--- a/app/controllers/organisations/configuration/categories_controller.rb
+++ b/app/controllers/organisations/configuration/categories_controller.rb
@@ -5,7 +5,7 @@ module Organisations
         @category_configurations = @organisation.category_configurations
                                                 .includes(:motif_category, :file_configuration)
                                                 .order(:position)
-        @motifs_by_category = @organisation.motifs.group_by(&:motif_category_id)
+        @motifs_by_category = @organisation.motifs.active.group_by(&:motif_category_id)
         @newly_created_category_configuration =
           if params[:newly_created_category_configuration_id]
             @category_configurations.find { |cc| cc.id == params[:newly_created_category_configuration_id].to_i }


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Configuration-Ne-plus-afficher-les-motifs-archiv-s-sur-la-page-cat-gorie-36b5f321b60480bc9d03faeaf441fae2

Je filtre les motifs affichés sur chaque catégorie pour n'afficher que les motifs actifs (= pas supprimé)