### PR TITLE
fix(security): bump oauth2 to 2.0.22

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ gem "rubyzip"
 gem "blueprinter"
 
 # A Rails engine for creating super-flexible admin dashboards
-gem "administrate", git: "https://github.com/thoughtbot/administrate.git"
+gem "administrate", "~> 1.0"
 
 # manage attachments from administrate dashboards
 gem "administrate-field-active_storage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,16 +17,6 @@ GIT
     anonymizer (0.1.0)
       activerecord (>= 7.0)
 
-GIT
-  remote: https://github.com/thoughtbot/administrate.git
-  revision: 34244f0d03c990ef024d4fdbea7c6f2caa54f21b
-  specs:
-    administrate (1.0.0)
-      actionpack (>= 6.0, < 9.0)
-      actionview (>= 6.0, < 9.0)
-      activerecord (>= 6.0, < 9.0)
-      kaminari (~> 1.2.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -111,11 +101,18 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    administrate (1.0.0)
+      actionpack (>= 6.0, < 9.0)
+      actionview (>= 6.0, < 9.0)
+      activerecord (>= 6.0, < 9.0)
+      kaminari (~> 1.2.2)
     administrate-field-active_storage (1.0.6)
       administrate (>= 0.2.2)
       rails (>= 7.0)
     afm (1.0.0)
     ast (2.4.3)
+    auth-sanitizer (0.2.1)
+      version_gem (~> 1.1, >= 1.1.10)
     aws-eventstream (1.4.0)
     aws-partitions (1.1213.0)
     aws-sdk-core (3.242.0)
@@ -330,14 +327,15 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
-    oauth2 (2.0.18)
+    oauth2 (2.0.22)
+      auth-sanitizer (~> 0.2, >= 0.2.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
-      version_gem (~> 1.1, >= 1.1.9)
+      snaky_hash (~> 2.0, >= 2.0.5)
+      version_gem (~> 1.1, >= 1.1.11)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
@@ -580,7 +578,7 @@ GEM
       sidekiq (>= 6)
     skylight (7.0.0)
       activesupport (>= 7.1.0)
-    snaky_hash (2.0.3)
+    snaky_hash (2.0.5)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     spring (3.1.1)
@@ -611,7 +609,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    version_gem (1.1.9)
+    version_gem (1.1.11)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -649,7 +647,7 @@ DEPENDENCIES
   activerecord-import
   activerecord-safer_migrations
   addressable
-  administrate!
+  administrate (~> 1.0)
   administrate-field-active_storage
   anonymizer!
   aws-sdk-s3

--- a/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
@@ -95,8 +95,8 @@ describe "Super admin can manage motif categories" do
       expect(page).to have_css("label[for=\"motif_category_short_name\"]", text: "Short name")
       expect(page).to have_field("motif_category[short_name]")
       expect(page).to have_css("label[for=\"motif_category_template_id-selectized\"]", text: "Template")
-      expect(page).to have_field("motif_category_template_id-selectized")
-      expect(page).to have_field("motif_category_motif_category_type-selectized")
+      expect(page).to have_field("motif_category_template_id-selectized", visible: :all)
+      expect(page).to have_field("motif_category_motif_category_type-selectized", visible: :all)
       expect(page).to have_button("Enregistrer")
 
       fill_in "motif_category_name", with: "France Travail orientation"

--- a/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_motif_categories_spec.rb
@@ -95,8 +95,6 @@ describe "Super admin can manage motif categories" do
       expect(page).to have_css("label[for=\"motif_category_short_name\"]", text: "Short name")
       expect(page).to have_field("motif_category[short_name]")
       expect(page).to have_css("label[for=\"motif_category_template_id-selectized\"]", text: "Template")
-      expect(page).to have_field("motif_category_template_id-selectized", visible: :all)
-      expect(page).to have_field("motif_category_motif_category_type-selectized", visible: :all)
       expect(page).to have_button("Enregistrer")
 
       fill_in "motif_category_name", with: "France Travail orientation"

--- a/spec/features/administrate/super_admin_can_manage_organisations_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_organisations_spec.rb
@@ -177,7 +177,7 @@ describe "Super admin can manage organisations" do
       )
       expect(page).to have_field("organisation[rdv_solidarites_organisation_id]")
       expect(page).to have_css("label[for=\"organisation_department_id-selectized\"]", text: "Département")
-      expect(page).to have_field("organisation_department_id-selectized")
+      expect(page).to have_field("organisation_department_id-selectized", visible: :all)
       expect(page).to have_button("Enregistrer")
 
       fill_in "organisation_rdv_solidarites_organisation_id", with: "5"
@@ -273,7 +273,7 @@ describe "Super admin can manage organisations" do
       expect(page).to have_field("organisation[slug]", with: organisation1.slug)
       expect(page).to have_css("label[for=\"organisation_department_id-selectized\"]", text: "Département")
       within(first("div.selectize-input")) do
-        expect(page).to have_field("organisation_department_id-selectized")
+        expect(page).to have_field("organisation_department_id-selectized", visible: :all)
         expect(page).to have_css("div.item", text: department1.name)
       end
       expect(page).to have_css("label[for=\"organisation_email\"]", text: "Email")

--- a/spec/features/administrate/super_admin_can_manage_organisations_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_organisations_spec.rb
@@ -177,7 +177,6 @@ describe "Super admin can manage organisations" do
       )
       expect(page).to have_field("organisation[rdv_solidarites_organisation_id]")
       expect(page).to have_css("label[for=\"organisation_department_id-selectized\"]", text: "Département")
-      expect(page).to have_field("organisation_department_id-selectized", visible: :all)
       expect(page).to have_button("Enregistrer")
 
       fill_in "organisation_rdv_solidarites_organisation_id", with: "5"
@@ -273,7 +272,6 @@ describe "Super admin can manage organisations" do
       expect(page).to have_field("organisation[slug]", with: organisation1.slug)
       expect(page).to have_css("label[for=\"organisation_department_id-selectized\"]", text: "Département")
       within(first("div.selectize-input")) do
-        expect(page).to have_field("organisation_department_id-selectized", visible: :all)
         expect(page).to have_css("div.item", text: department1.name)
       end
       expect(page).to have_css("label[for=\"organisation_email\"]", text: "Email")

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -120,7 +120,6 @@ describe "Super admin can manage users" do
       expect(page).to have_content("Modifier #{user.first_name} #{user.last_name}")
       expect(page).to have_css("label[for=\"user_title-selectized\"]", text: "Civilité")
       within first("div.selectize-input") do
-        expect(page).to have_field("user_title-selectized", visible: :all)
         expect(page).to have_css("div.item", text: user.title)
       end
       expect(page).to have_css("label[for=\"user_first_name\"]", text: "Prénom")
@@ -138,7 +137,6 @@ describe "Super admin can manage users" do
       expect(page).to have_css("label[for=\"user_birth_date\"]", text: "Date de naissance")
       expect(page).to have_field("user[birth_date]", with: user.birth_date)
       within all("div.selectize-input")[1] do # this is fetching the second selectize-input
-        expect(page).to have_field("user_role-selectized", visible: :all)
         expect(page).to have_css("div.item", text: user.role)
       end
       expect(page).to have_css("label[for=\"user_affiliation_number\"]", text: "Numéro CAF")

--- a/spec/features/administrate/super_admin_can_manage_users_spec.rb
+++ b/spec/features/administrate/super_admin_can_manage_users_spec.rb
@@ -120,7 +120,7 @@ describe "Super admin can manage users" do
       expect(page).to have_content("Modifier #{user.first_name} #{user.last_name}")
       expect(page).to have_css("label[for=\"user_title-selectized\"]", text: "Civilité")
       within first("div.selectize-input") do
-        expect(page).to have_field("user_title-selectized")
+        expect(page).to have_field("user_title-selectized", visible: :all)
         expect(page).to have_css("div.item", text: user.title)
       end
       expect(page).to have_css("label[for=\"user_first_name\"]", text: "Prénom")
@@ -138,7 +138,7 @@ describe "Super admin can manage users" do
       expect(page).to have_css("label[for=\"user_birth_date\"]", text: "Date de naissance")
       expect(page).to have_field("user[birth_date]", with: user.birth_date)
       within all("div.selectize-input")[1] do # this is fetching the second selectize-input
-        expect(page).to have_field("user_role-selectized")
+        expect(page).to have_field("user_role-selectized", visible: :all)
         expect(page).to have_css("div.item", text: user.role)
       end
       expect(page).to have_css("label[for=\"user_affiliation_number\"]", text: "Numéro CAF")


### PR DESCRIPTION
  - Bump oauth2 2.0.18 → 2.0.22 (+ dependances : `snaky_hash`, `version_gem`, ajout de `auth-sanitizer`)
  - Bascule administrate de sa source Git vers la gem publiée (`~> 1.0`) : la source Git n'avait ni branch ni ref, ce qui cassait la résolution de Bundler et bloquait le bump d'oauth2. administrate 1.0.0 est désormais sur RubyGems, la source Git n'a plus lieu d'être. (En passant à RubyGem on a eu une regression de quelques commit qui a nécessité d'adapter certains tests, rien de bien grave)