### PR TITLE
  feat(motifs): Sync booking delay attributes from RDV-Solidarités

### DIFF
--- a/app/models/motif.rb
+++ b/app/models/motif.rb
@@ -1,7 +1,7 @@
 class Motif < ApplicationRecord
   SHARED_ATTRIBUTES_WITH_RDV_SOLIDARITES = [
     :deleted_at, :location_type, :name, :bookable_by, :rdv_solidarites_service_id, :collectif,
-    :follow_up, :instruction_for_rdv, :default_duration_in_min
+    :follow_up, :instruction_for_rdv, :default_duration_in_min, :min_public_booking_delay, :max_public_booking_delay
   ].freeze
 
   enum :location_type, { public_office: "public_office", phone: "phone", home: "home", visio: "visio" }

--- a/config/anonymizer.yml
+++ b/config/anonymizer.yml
@@ -263,6 +263,8 @@ tables:
       - follow_up
       - motif_category_id
       - default_duration_in_min
+      - min_public_booking_delay
+      - max_public_booking_delay
 
   - table_name: notifications
     anonymized_column_names: []

--- a/db/migrate/20260611090000_add_booking_delays_to_motifs.rb
+++ b/db/migrate/20260611090000_add_booking_delays_to_motifs.rb
@@ -1,0 +1,6 @@
+class AddBookingDelaysToMotifs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :motifs, :min_public_booking_delay, :integer
+    add_column :motifs, :max_public_booking_delay, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_091945) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -362,6 +362,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_091945) do
     t.text "instruction_for_rdv", default: ""
     t.datetime "last_webhook_update_received_at"
     t.string "location_type"
+    t.integer "max_public_booking_delay"
+    t.integer "min_public_booking_delay"
     t.bigint "motif_category_id"
     t.string "name"
     t.bigint "organisation_id", null: false

--- a/spec/services/upsert_record_spec.rb
+++ b/spec/services/upsert_record_spec.rb
@@ -163,4 +163,29 @@ describe UpsertRecord, type: :service do
       end
     end
   end
+
+  context "for a motif" do
+    subject do
+      described_class.call(klass: Motif, rdv_solidarites_attributes: motif_attributes)
+    end
+
+    let!(:rdv_solidarites_motif_id) { 12 }
+    let!(:motif_attributes) do
+      {
+        id: rdv_solidarites_motif_id, name: "RSA orientation", location_type: "public_office",
+        default_duration_in_min: 30, min_public_booking_delay: 1800, max_public_booking_delay: 7_889_238
+      }
+    end
+
+    describe "#call" do
+      let!(:motif) { create(:motif, rdv_solidarites_motif_id: rdv_solidarites_motif_id) }
+
+      it "assigns the booking delays" do
+        subject
+        expect(motif.reload).to have_attributes(
+          min_public_booking_delay: 1800, max_public_booking_delay: 7_889_238
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ajoute min/max_public_booking_delay (en secondes) sur les motifs, synchro depuis RDV-S via le webhook motif. (fait suite à cette PR : https://github.com/betagouv/rdv-service-public/pull/6432)
Ils serviront à calculer la période de dispo des créneaux dans une prochaine PR pour l'afficher dans l'interface pour les agents. Les pr sont séparés pour pouvoir backfill les données avant (le null: false sera ajouté aux nouveaux champs dans la prochaine PR).