### PR TITLE
feat(motifs): add non-null constraint on booking delays

### DIFF
--- a/db/migrate/20260611120000_add_null_constraint_on_motif_booking_delays.rb
+++ b/db/migrate/20260611120000_add_null_constraint_on_motif_booking_delays.rb
@@ -1,0 +1,6 @@
+class AddNullConstraintOnMotifBookingDelays < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :motifs, :min_public_booking_delay, false
+    change_column_null :motifs, :max_public_booking_delay, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -362,8 +362,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_090000) do
     t.text "instruction_for_rdv", default: ""
     t.datetime "last_webhook_update_received_at"
     t.string "location_type"
-    t.integer "max_public_booking_delay"
-    t.integer "min_public_booking_delay"
+    t.integer "max_public_booking_delay", null: false
+    t.integer "min_public_booking_delay", null: false
     t.bigint "motif_category_id"
     t.string "name"
     t.bigint "organisation_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -445,7 +445,9 @@ Motif.create!(
   last_webhook_update_received_at: Time.zone.now,
   organisation_id: drome1_organisation.id,
   follow_up: false,
-  default_duration_in_min: 30
+  default_duration_in_min: 30,
+  min_public_booking_delay: 3.days.to_i,
+  max_public_booking_delay: 1.month.to_i
 )
 
 Motif.create!(
@@ -462,7 +464,9 @@ Motif.create!(
   last_webhook_update_received_at: Time.zone.now,
   organisation_id: drome1_organisation.id,
   follow_up: false,
-  default_duration_in_min: 30
+  default_duration_in_min: 30,
+  min_public_booking_delay: 3.days.to_i,
+  max_public_booking_delay: 1.month.to_i
 )
 
 Motif.create!(
@@ -479,7 +483,9 @@ Motif.create!(
   last_webhook_update_received_at: Time.zone.now,
   organisation_id: drome1_organisation.id,
   follow_up: false,
-  default_duration_in_min: 30
+  default_duration_in_min: 30,
+  min_public_booking_delay: 3.days.to_i,
+  max_public_booking_delay: 1.month.to_i
 )
 
 Lieu.create!( # Nécessaire pour la convoc
@@ -504,7 +510,9 @@ Motif.create!(
   last_webhook_update_received_at: Time.zone.now,
   organisation_id: drome2_organisation.id,
   follow_up: false,
-  default_duration_in_min: 30
+  default_duration_in_min: 30,
+  min_public_booking_delay: 3.days.to_i,
+  max_public_booking_delay: 1.month.to_i
 )
 
 Motif.create!(
@@ -521,7 +529,9 @@ Motif.create!(
   last_webhook_update_received_at: Time.zone.now,
   organisation_id: yonne_organisation.id,
   follow_up: false,
-  default_duration_in_min: 30
+  default_duration_in_min: 30,
+  min_public_booking_delay: 3.days.to_i,
+  max_public_booking_delay: 1.month.to_i
 )
 
 Motif.create!(
@@ -538,7 +548,9 @@ Motif.create!(
   last_webhook_update_received_at: Time.zone.now,
   organisation_id: yonne_organisation.id,
   follow_up: false,
-  default_duration_in_min: 30
+  default_duration_in_min: 30,
+  min_public_booking_delay: 3.days.to_i,
+  max_public_booking_delay: 1.month.to_i
 )
 
 # --------------------------------------------------------------------------------------------------------------------

--- a/spec/factories/motif.rb
+++ b/spec/factories/motif.rb
@@ -7,5 +7,7 @@ FactoryBot.define do
     organisation
     collectif { false }
     default_duration_in_min { 30 }
+    min_public_booking_delay { 3.days.to_i }
+    max_public_booking_delay { 1.month.to_i }
   end
 end


### PR DESCRIPTION
Ajoute le `null: false` sur `min/max_public_booking_delay` des motifs, (attendre que les données soient backfillées)