### PR TITLE
fix(csp): Handle pro connect dev agentconnect auth

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,7 +6,12 @@
 
 s3_bucket = "rdv-insertion-medias-#{ENV['ENVIRONMENT_NAME']}.s3.fr-par.scw.cloud"
 rdv_solidarites = ENV["RDV_SOLIDARITES_URL"]
-pro_connect_auth = ["auth.proconnect.gouv.fr", "auth.agentconnect.gouv.fr"]
+pro_connect_auth =
+  if ENV["ENVIRONMENT_NAME"] == "production"
+    ["auth.proconnect.gouv.fr", "auth.agentconnect.gouv.fr"]
+  else
+    ["*.dev-agentconnect.fr"]
+  end
 matomo = "matomo.inclusion.beta.gouv.fr"
 crisp = ["*.crisp.chat", "wss://client.relay.crisp.chat"]
 sentry = "sentry.incubateur.net"


### PR DESCRIPTION
Suite de #3320 : l'url de connexion à Pro Connect est différente en staging et en demo (c'est `dev-agentconnect.fr`), je gère donc ces différences entre les environnements dans les CSP.