### PR TITLE
feat(creneaux): Apply QA feedback before release

### DIFF
--- a/app/controllers/user_list_uploads/creneau_opening_requests_controller.rb
+++ b/app/controllers/user_list_uploads/creneau_opening_requests_controller.rb
@@ -7,6 +7,7 @@ module UserListUploads
       @users_to_invite_count = users_to_invite_count
       @missing_creneaux_count = @users_to_invite_count - @available_creneaux_count
       @recipient_agents = recipient_agents
+      @already_requested_agent_ids = @user_list_upload.creneau_opening_requests.distinct.pluck(:recipient_agent_id)
     end
 
     def create_many

--- a/app/controllers/user_list_uploads/invitation_attempts_controller.rb
+++ b/app/controllers/user_list_uploads/invitation_attempts_controller.rb
@@ -36,13 +36,22 @@ module UserListUploads
 
       redirect_to select_rows_user_list_upload_invitation_attempts_path(
         user_list_upload_id: @user_list_upload.id,
-        tally_form_id: ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"]
+        tally_form_id: ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"],
+        **tally_hidden_fields
       )
     end
 
     def should_redirect_with_tally_form?
       params[:tally_form_id].nil? && @user_list_upload.creneaux_snapshot &&
         ENV["SHOW_CRENEAUX_BEFORE_INVITATIONS_TALLY_ID"].present?
+    end
+
+    def tally_hidden_fields
+      {
+        email: current_agent.email,
+        organisation: @user_list_upload.organisation&.name,
+        department: @user_list_upload.department.name
+      }
     end
 
     def set_user_list_upload

--- a/app/models/creneau_opening_request.rb
+++ b/app/models/creneau_opening_request.rb
@@ -6,6 +6,10 @@ class CreneauOpeningRequest < ApplicationRecord
   validates :users_to_invite_count, :available_creneaux_count,
             presence: true,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :recipient_agent_id, uniqueness: {
+    scope: :user_list_upload_id,
+    message: "a déjà reçu une demande d'ouverture de créneaux pour cet import"
+  }
 
   after_commit :enqueue_send_email_job, on: :create
 

--- a/app/models/user_list_upload.rb
+++ b/app/models/user_list_upload.rb
@@ -15,6 +15,7 @@ class UserListUpload < ApplicationRecord
   has_many :user_rows, class_name: "UserListUpload::UserRow", dependent: :destroy
   has_many :processing_logs, class_name: "UserListUpload::ProcessingLog", dependent: :destroy
   has_one :creneaux_snapshot, class_name: "UserListUpload::CreneauxSnapshot", dependent: :destroy
+  has_many :creneau_opening_requests, dependent: :destroy
   has_many :user_save_attempts, class_name: "UserListUpload::UserSaveAttempt", through: :user_rows
   has_many :invitation_attempts, class_name: "UserListUpload::InvitationAttempt", through: :user_rows
 

--- a/app/views/user_list_uploads/creneau_opening_requests/new_batch.html.erb
+++ b/app/views/user_list_uploads/creneau_opening_requests/new_batch.html.erb
@@ -62,8 +62,9 @@
         </div>
         <div class="creneau-picker__list">
           <% @recipient_agents.each do |agent| %>
-            <label class="d-flex align-items-center py-1" data-dropdown--filter-options-target="item">
-              <%= check_box_tag "recipient_agent_ids[]", agent.id, false, class: "form-check-input me-2" %>
+            <% already_requested = @already_requested_agent_ids.include?(agent.id) %>
+            <label class="d-flex align-items-center py-1 <%= "opacity-50" if already_requested %>" data-dropdown--filter-options-target="item">
+              <%= check_box_tag "recipient_agent_ids[]", agent.id, already_requested, disabled: already_requested, class: "form-check-input me-2" %>
               <span>
                 <strong><%= agent %></strong>
                 <span class="text-muted ms-2"><%= agent.email %></span>

--- a/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
+++ b/app/views/user_list_uploads/invitation_attempts/select_rows.html.erb
@@ -60,7 +60,7 @@
                   <%= check_box_tag "format_sms", "SMS", checked: invitation_format_checked?("sms", @user_list_upload.id), class: "form-check-input text-dark-blue", data: { user_list_upload__select_user_rows_target: "invitationFormatOption", action: "change->user-list-upload--select-user-rows#handleFormatOptionChange", format: "sms" } %>
                   <%= label_tag "format_sms", "SMS", class: "form-check-label" %>
                 </div>
-                <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_send-invit", disabled: @number_of_user_rows_selected.zero? || @creneaux_snapshot&.no_creneaux_available? %>
+                <%= submit_tag "Envoyer les invitations", class: "btn btn-primary d-block mx-auto", id: "rdvi_upload_users-invit_send-invit", disabled: @number_of_user_rows_selected.zero? %>
               </div>
             <% end %>
           </div>

--- a/config/locales/models/creneau_opening_request.fr.yml
+++ b/config/locales/models/creneau_opening_request.fr.yml
@@ -1,0 +1,7 @@
+fr:
+  activerecord:
+    models:
+      creneau_opening_request: Demande d'ouverture de créneaux
+    attributes:
+      creneau_opening_request:
+        recipient_agent_id: Agent destinataire

--- a/db/migrate/20260618110000_add_unique_index_to_creneau_opening_requests.rb
+++ b/db/migrate/20260618110000_add_unique_index_to_creneau_opening_requests.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToCreneauOpeningRequests < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :creneau_opening_requests, :user_list_upload_id
+    add_index :creneau_opening_requests, %i[user_list_upload_id recipient_agent_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_18_110000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -195,7 +195,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_090000) do
     t.uuid "user_list_upload_id", null: false
     t.integer "users_to_invite_count", null: false
     t.index ["recipient_agent_id"], name: "index_creneau_opening_requests_on_recipient_agent_id"
-    t.index ["user_list_upload_id"], name: "index_creneau_opening_requests_on_user_list_upload_id"
+    t.index ["user_list_upload_id", "recipient_agent_id"], name: "idx_on_user_list_upload_id_recipient_agent_id_b0a0d7a122", unique: true
   end
 
   create_table "csv_exports", force: :cascade do |t|

--- a/spec/features/agent_can_request_more_creneaux_spec.rb
+++ b/spec/features/agent_can_request_more_creneaux_spec.rb
@@ -42,4 +42,16 @@ describe "Agent can request more creneaux", :js do
     expect(page).to have_content("Aucun agent destinataire sélectionné")
     expect(CreneauOpeningRequest.count).to eq(0)
   end
+
+  context "when a request was already sent to an agent for this upload" do
+    before { create(:creneau_opening_request, user_list_upload:, recipient_agent:) }
+
+    it "shows that agent already checked and disabled" do
+      visit new_batch_user_list_upload_creneau_opening_requests_path(user_list_upload, available_creneaux_count: 26)
+
+      checkbox = find("input[type=checkbox][value='#{recipient_agent.id}']", visible: :all)
+      expect(checkbox).to be_checked
+      expect(checkbox).to be_disabled
+    end
+  end
 end

--- a/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
+++ b/spec/features/agent_can_see_creneaux_availability_before_inviting_spec.rb
@@ -57,7 +57,7 @@ describe "Agents can see créneaux availability before inviting", :js do
   context "when there are no créneaux available" do
     let!(:creneaux_snapshot) { create(:creneaux_snapshot, user_list_upload:, number_of_creneaux_available: 0) }
 
-    it "shows a danger banner and prevents inviting" do
+    it "shows a danger banner but still allows inviting" do
       visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
 
       within(".alert-danger") do
@@ -65,7 +65,7 @@ describe "Agents can see créneaux availability before inviting", :js do
         expect(page).to have_link("Demander plus de créneaux")
       end
 
-      expect(page).to have_button("Envoyer les invitations", disabled: true)
+      expect(page).to have_button("Envoyer les invitations", disabled: false)
     end
   end
 
@@ -113,12 +113,13 @@ describe "Agents can see créneaux availability before inviting", :js do
     context "and a snapshot exists" do
       let!(:creneaux_snapshot) { create(:creneaux_snapshot, user_list_upload:, number_of_creneaux_available: 50) }
 
-      it "redirects to the same page with the tally form so the survey shows up" do
+      it "redirects with the tally form and the hidden fields so the survey shows up" do
         visit select_rows_user_list_upload_invitation_attempts_path(user_list_upload_id: user_list_upload.id)
 
         expect(page).to have_current_path(
           select_rows_user_list_upload_invitation_attempts_path(
-            user_list_upload_id: user_list_upload.id, tally_form_id: "creneaux_form_id"
+            user_list_upload_id: user_list_upload.id, tally_form_id: "creneaux_form_id",
+            email: agent.email, organisation: organisation.name, department: department.name
           )
         )
         expect(page).to have_css("div[data-controller='tally'][data-tally-form-id='creneaux_form_id']", visible: :all)


### PR DESCRIPTION
Ajustements suite aux retours QA (https://gip-inclusion.slack.com/archives/C09QSQ4J95F/p1781517740471339) avant mise en prod :
- Tally du funnel : pré-remplissage des hidden fields (email/organisation/department) via l'URL, comme dans le bandeau de l'index.
- On ne bloque plus le bouton d'envoi d'invitations quand il n'y a pas assez de créneaux.
- Modale « Demander plus de créneaux » : un agent déjà sollicité pour cet upload est coché + grisé (pas de double-envoi).
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/a531a6a0-88c2-4d9e-b26d-efec7c0348c9" />
