### PR TITLE
fix(api): create the follow-up even when the user has no phone nor email

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -57,6 +57,8 @@ module Api
         @user = upsert_user.user
         return render_errors(["Impossible de créer l'usager: #{upsert_user.errors.join(', ')}"]) if upsert_user.failure?
 
+        create_follow_up
+
         @invitations, @invitation_errors = [[], []]
         invite_user_by("sms") if @user.phone_number_is_mobile?
         invite_user_by("email") if @user.email?
@@ -111,6 +113,13 @@ module Api
         @upsert_user ||= Users::Upsert.call(
           user_attributes: user_attributes, organisation: @organisation
         )
+      end
+
+      def create_follow_up
+        return if motif_category_attributes.blank?
+
+        motif_category = MotifCategory.find_by(motif_category_attributes)
+        @user.find_or_create_follow_up(motif_category) if motif_category
       end
 
       def invite_user_by(format)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -118,8 +118,7 @@ module Api
       def find_or_create_follow_up
         return if motif_category_attributes.blank?
 
-        motif_category = MotifCategory.find_by(motif_category_attributes)
-        @user.find_or_create_follow_up!(motif_category) if motif_category
+        @user.find_or_create_follow_up!(MotifCategory.find_by!(motif_category_attributes))
       end
 
       def invite_user_by(format)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -57,7 +57,7 @@ module Api
         @user = upsert_user.user
         return render_errors(["Impossible de créer l'usager: #{upsert_user.errors.join(', ')}"]) if upsert_user.failure?
 
-        create_follow_up
+        find_or_create_follow_up
 
         @invitations, @invitation_errors = [[], []]
         invite_user_by("sms") if @user.phone_number_is_mobile?
@@ -115,11 +115,11 @@ module Api
         )
       end
 
-      def create_follow_up
+      def find_or_create_follow_up
         return if motif_category_attributes.blank?
 
         motif_category = MotifCategory.find_by(motif_category_attributes)
-        @user.find_or_create_follow_up(motif_category) if motif_category
+        @user.find_or_create_follow_up!(motif_category) if motif_category
       end
 
       def invite_user_by(format)

--- a/app/controllers/concerns/api/v1/params_validation_concern.rb
+++ b/app/controllers/concerns/api/v1/params_validation_concern.rb
@@ -22,6 +22,7 @@ module Api
         validate_user_params_content(user_attrs.except(:referents_to_add, :tags_to_add))
         Array(user_attrs[:referents_to_add]).each { validate_referent_exists(it[:email]) }
         Array(user_attrs[:tags_to_add]).each { validate_tag_exists(it[:value]) }
+        validate_motif_category_exists(motif_category_attributes)
 
         return if @params_validation_errors.empty?
 
@@ -42,6 +43,7 @@ module Api
           validate_user_params_content(user_params.except(:invitation, :referents_to_add, :tags_to_add), idx)
           Array(user_params[:referents_to_add]).each { validate_referent_exists(it[:email], idx) }
           Array(user_params[:tags_to_add]).each { validate_tag_exists(it[:value], idx) }
+          validate_motif_category_exists(user_params.dig(:invitation, :motif_category), idx)
         end
       end
 
@@ -60,6 +62,16 @@ module Api
         @params_validation_errors << {
           error_details: "Assignation du tag impossible car aucun tag n'a été trouvé " \
                          "avec la valeur #{tag_value} au sein de l'organisation #{@organisation.name}. "
+        }.merge(idx.present? ? { index: idx } : {})
+      end
+
+      def validate_motif_category_exists(motif_category_attributes, idx = nil)
+        return if motif_category_attributes.blank?
+        return if MotifCategory.find_by(motif_category_attributes)
+
+        @params_validation_errors << {
+          error_details: "Ouverture d'un suivi impossible car aucune catégorie de motif ne correspond " \
+                         "aux critères fournis (#{motif_category_attributes.map { |k, v| "#{k}: #{v}" }.join(', ')})."
         }.merge(idx.present? ? { index: idx } : {})
       end
 

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -11,6 +11,7 @@ class CreateAndInviteUserJob < ApplicationJob
     @motif_category_attributes = motif_category_attributes.deep_symbolize_keys
 
     upsert_user!
+    create_follow_up
     invite_user
   end
 
@@ -33,6 +34,13 @@ class CreateAndInviteUserJob < ApplicationJob
 
   def notify_department_by_email(errors)
     DepartmentMailer.create_user_error(@department, @user_attributes, errors).deliver_now
+  end
+
+  def create_follow_up
+    return if @motif_category_attributes.blank?
+
+    motif_category = MotifCategory.find_by(@motif_category_attributes)
+    @user.find_or_create_follow_up(motif_category) if motif_category
   end
 
   def invite_user

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -39,8 +39,7 @@ class CreateAndInviteUserJob < ApplicationJob
   def find_or_create_follow_up
     return if @motif_category_attributes.blank?
 
-    motif_category = MotifCategory.find_by(@motif_category_attributes)
-    @user.find_or_create_follow_up!(motif_category) if motif_category
+    @user.find_or_create_follow_up!(MotifCategory.find_by!(@motif_category_attributes))
   end
 
   def invite_user

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -11,7 +11,7 @@ class CreateAndInviteUserJob < ApplicationJob
     @motif_category_attributes = motif_category_attributes.deep_symbolize_keys
 
     upsert_user!
-    create_follow_up
+    find_or_create_follow_up
     invite_user
   end
 
@@ -36,11 +36,11 @@ class CreateAndInviteUserJob < ApplicationJob
     DepartmentMailer.create_user_error(@department, @user_attributes, errors).deliver_now
   end
 
-  def create_follow_up
+  def find_or_create_follow_up
     return if @motif_category_attributes.blank?
 
     motif_category = MotifCategory.find_by(@motif_category_attributes)
-    @user.find_or_create_follow_up(motif_category) if motif_category
+    @user.find_or_create_follow_up!(motif_category) if motif_category
   end
 
   def invite_user

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -239,12 +239,7 @@ module InboundWebhooks
       end
 
       def follow_ups
-        @follow_ups ||=
-          @users.map do |user|
-            FollowUp.with_advisory_lock "setting_follow_up_for_user_#{user.id}" do
-              FollowUp.find_or_create_by!(user: user, motif_category: motif_category)
-            end
-          end
+        @follow_ups ||= @users.map { |user| user.find_or_create_follow_up(motif_category) }
       end
 
       def follow_up_ids

--- a/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
+++ b/app/jobs/inbound_webhooks/rdv_solidarites/process_rdv_job.rb
@@ -239,7 +239,7 @@ module InboundWebhooks
       end
 
       def follow_ups
-        @follow_ups ||= @users.map { |user| user.find_or_create_follow_up(motif_category) }
+        @follow_ups ||= @users.map { |user| user.find_or_create_follow_up!(motif_category) }
       end
 
       def follow_up_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,6 +122,12 @@ class User < ApplicationRecord
     follow_ups.to_a.find { |rc| rc.motif_category_id == motif_category.id }
   end
 
+  def find_or_create_follow_up(motif_category)
+    FollowUp.with_advisory_lock("setting_follow_up_for_user_#{id}") do
+      follow_ups.find_or_create_by!(motif_category:)
+    end
+  end
+
   def department_numbers
     departments.map(&:number)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,8 +122,8 @@ class User < ApplicationRecord
     follow_ups.to_a.find { |rc| rc.motif_category_id == motif_category.id }
   end
 
-  def find_or_create_follow_up(motif_category)
-    FollowUp.with_advisory_lock("setting_follow_up_for_user_#{id}") do
+  def find_or_create_follow_up!(motif_category)
+    with_advisory_lock("setting_follow_up_for_user_#{id}") do
       follow_ups.find_or_create_by!(motif_category:)
     end
   end

--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -11,7 +11,7 @@ class InviteUser < BaseService
 
   def call
     set_current_configuration
-    find_or_create_follow_up
+    @follow_up = @user.find_or_create_follow_up(@current_configuration.motif_category)
     set_invitation_organisations
     set_invitation
     result.invitation = @invitation
@@ -46,12 +46,6 @@ class InviteUser < BaseService
       else
         @organisations
       end
-  end
-
-  def find_or_create_follow_up
-    FollowUp.with_advisory_lock "setting_follow_up_for_user_#{@user.id}" do
-      @follow_up = FollowUp.find_or_create_by!(motif_category: @current_configuration.motif_category, user: @user)
-    end
   end
 
   def motif_category

--- a/app/services/invite_user.rb
+++ b/app/services/invite_user.rb
@@ -11,7 +11,7 @@ class InviteUser < BaseService
 
   def call
     set_current_configuration
-    @follow_up = @user.find_or_create_follow_up(@current_configuration.motif_category)
+    find_or_create_follow_up
     set_invitation_organisations
     set_invitation
     result.invitation = @invitation
@@ -19,6 +19,10 @@ class InviteUser < BaseService
   end
 
   private
+
+  def find_or_create_follow_up
+    @follow_up = @user.find_or_create_follow_up!(@current_configuration.motif_category)
+  end
 
   def set_invitation
     @invitation = Invitation.new(

--- a/spec/jobs/create_and_invite_user_job_spec.rb
+++ b/spec/jobs/create_and_invite_user_job_spec.rb
@@ -84,6 +84,17 @@ describe CreateAndInviteUserJob do
     end
   end
 
+  context "when the user has neither phone nor email" do
+    let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation") }
+
+    before { user.update!(phone_number: nil, email: nil) }
+
+    it "still creates a follow up so the user is tracked in the category" do
+      expect { subject }.to change { user.follow_ups.count }.by(1)
+      expect(user.follow_ups.last.motif_category).to eq(motif_category)
+    end
+  end
+
   context "when the save fails" do
     let!(:department_mail) { instance_double("mail") }
 

--- a/spec/jobs/create_and_invite_user_job_spec.rb
+++ b/spec/jobs/create_and_invite_user_job_spec.rb
@@ -20,6 +20,7 @@ describe CreateAndInviteUserJob do
   end
   let!(:invitation_attributes) { { rdv_solidarites_lieu_id: 888 } }
   let!(:motif_category_attributes) { { short_name: "rsa_orientation" } }
+  let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation") }
   let!(:email_invitation_attributes) { invitation_attributes.merge(format: "email") }
   let!(:sms_invitation_attributes) { invitation_attributes.merge(format: "sms") }
 
@@ -85,8 +86,6 @@ describe CreateAndInviteUserJob do
   end
 
   context "when the user has neither phone nor email" do
-    let!(:motif_category) { create(:motif_category, short_name: "rsa_orientation") }
-
     before { user.update!(phone_number: nil, email: nil) }
 
     it "still creates a follow up so the user is tracked in the category" do

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -247,8 +247,9 @@ describe "Users API", swagger_doc: "v1/api.json" do
         run_test! do |response|
           expect(response.status).to eq(422)
           parsed_response = JSON.parse(response.body)
-          expect(parsed_response["errors"][0]["error_details"]).to include(
-            "aucune catégorie de motif ne correspond"
+          expect(parsed_response["errors"][0]["error_details"]).to eq(
+            "Ouverture d'un suivi impossible car aucune catégorie de motif ne correspond " \
+            "aux critères fournis (name: Catégorie inexistante)."
           )
         end
       end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -137,6 +137,8 @@ describe "Users API", swagger_doc: "v1/api.json" do
         { users: [user1_params, user2_params.merge(invitation: { motif_category: { name: "RSA orientation" } })] }
       end
 
+      let!(:motif_category) { create(:motif_category, name: "RSA orientation") }
+
       before { allow(CreateAndInviteUserJob).to receive(:perform_later) }
 
       with_authentication
@@ -231,6 +233,22 @@ describe "Users API", swagger_doc: "v1/api.json" do
           parsed_response = JSON.parse(response.body)
           expect(parsed_response["errors"][0]["error_details"]).to eq(
             "Civilité n'est pas inclus(e) dans la liste"
+          )
+        end
+      end
+
+      response 422, "la catégorie de motif n'existe pas" do
+        schema "$ref" => "#/components/schemas/error_unprocessable_entity"
+
+        let!(:users_params) do
+          { users: [user1_params.merge(invitation: { motif_category: { name: "Catégorie inexistante" } })] }
+        end
+
+        run_test! do |response|
+          expect(response.status).to eq(422)
+          parsed_response = JSON.parse(response.body)
+          expect(parsed_response["errors"][0]["error_details"]).to include(
+            "aucune catégorie de motif ne correspond"
           )
         end
       end


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Bug-API-Les-usagers-sans-t-l-phone-ni-email-ne-sont-pas-cr-s-invit-s-via-l-API-invitations-36c5f321b604807494a1faabc4580bbc

## Bug

Dans l'API (`create_and_invite` / `create_and_invite_many`), un usager sans téléphone ni email n'était pas suivi dans la catégorie : il apparaissait uniquement dans « Tous les contacts ».

 Cause : côté API, le `FollowUp` n'était créé qu'avec l'envoi d'une invitation. Sans contact joignable, aucune invitation n'est envoyée donc pas de `FollowUp` et l'usager n'apparaît pas dans la catégorie.

Les flux upload de fichier et création par fiche usager ne sont pas concernés car ils créent le suivi indépendamment de l'invitation.

  ## Solution

  Le `FollowUp` est désormais créé dès la création de l'usager, indépendamment de l'invitation.

  Au passage, le `find_or_create` du `FollowUp` (avec son advisory lock), dupliqué à 4 endroits, est centralisé sur
  `User#find_or_create_follow_up` et réutilisé par `InviteUser`, le job API, le controller API et le webhook RDV-Solidarités.