### PR TITLE
fix(orientations): add user to organisation after orientation creation validations

### DIFF
--- a/app/services/orientations/save.rb
+++ b/app/services/orientations/save.rb
@@ -9,9 +9,9 @@ module Orientations
       ActiveRecord::Base.transaction do
         validate_starts_at_presence
         fill_current_orientation_ends_at if @orientation.ends_at.nil? && posterior_orientations.any?
-        add_user_to_organisation unless @orientation.user.belongs_to_org?(@orientation.organisation_id)
         save_record!(@orientation)
         shrink_or_ensure_no_overlapping
+        add_user_to_organisation unless @orientation.user.belongs_to_org?(@orientation.organisation_id)
       end
     end
 

--- a/spec/services/orientations/save_spec.rb
+++ b/spec/services/orientations/save_spec.rb
@@ -27,6 +27,15 @@ describe Orientations::Save, type: :service do
       expect(orientation.persisted?).to eq(true)
     end
 
+    it "adds the user to the organisation" do
+      expect(Users::AddToOrganisations).to receive(:call)
+        .with(user: user, organisations: [organisation])
+        .once
+        .and_return(OpenStruct.new(success?: true))
+
+      subject
+    end
+
     context "when starts_at is not passed" do
       let!(:starts_at) { nil }
 
@@ -55,6 +64,12 @@ describe Orientations::Save, type: :service do
 
           it "outputs an error" do
             expect(subject.shrinkeable_orientation).not_to be_nil
+          end
+
+          it "does not add the user to the organisation" do
+            expect(Users::AddToOrganisations).not_to receive(:call)
+
+            subject
           end
         end
 
@@ -221,17 +236,6 @@ describe Orientations::Save, type: :service do
         it "does not set the previous ends_at" do
           subject
           expect(second_orientation.reload.ends_at).to be_nil
-        end
-      end
-
-      context "when user is not part of the organisation" do
-        it "adds the user to the organisation" do
-          expect(Users::AddToOrganisations).to receive(:call)
-            .with(user: user, organisations: [organisation])
-            .once
-            .and_return(OpenStruct.new(success?: true))
-
-          subject
         end
       end
 


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Bug-Ne-pas-ajouter-la-personne-l-orga-si-la-cr-ation-de-l-orientation-choue-3735f321b60480c1b559de8f95a82bf8

  `Orientations::Save` ajoutait l'usager à l'organisation (avec un appel synchrone à RDV-Solidarités) avant les validations de création de l'orientation. En cas d'échec de cette validation, l'usager se  retrouvait ajouté à l'organisation côté RDV-S alors que l'orientation n'était jamais persistée côté RDV-I. Le fix déplace l'ajout à l'organisation en dernière étape, une fois l'orientation validée et sauvegardée.