### PR TITLE
fix(users): improve creneau availability tooltip content

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,11 +1,12 @@
 # rubocop:disable Metrics/ModuleLength
 module UsersHelper
   def creneau_availability_tooltip_content(creneau_availability)
-    lines = ["Calculé le #{creneau_availability.created_at.strftime('%d/%m à %Hh%M')}"]
+    lines = ["Nombre de créneaux visibles par les usagers invités à prendre rendez-vous."]
     period = display_date_period(
       creneau_availability.creneaux_available_from, creneau_availability.creneaux_available_until
     )
-    lines.unshift("Pour la période #{period}") if period
+    lines << "Visibilité #{period}." if period
+    lines << "Nombre de créneaux calculé le #{creneau_availability.created_at.strftime('%d/%m à %Hh%M')}"
     tooltip(content: safe_join(lines, tag.br))
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -961,7 +961,8 @@ describe UsersController do
     describe "creneau availability banner" do
       let!(:creneau_availability) do
         create(:creneau_availability, category_configuration: category_configuration,
-                                      number_of_creneaux_available: 11)
+                                      number_of_creneaux_available: 11,
+                                      created_at: Time.zone.parse("2026-07-07 05:00:00"))
       end
       let!(:motif) do
         create(:motif, organisation:, motif_category: category_orientation,
@@ -974,8 +975,9 @@ describe UsersController do
 
         expect(response.body).to include("11 créneaux disponibles")
                              .and include("ri-information-line")
-                             .and include("Calculé le")
-                             .and include("Pour la période du")
+                             .and include("Nombre de créneaux visibles par les usagers invités à prendre rendez-vous.")
+                             .and include("Visibilité du 10 juillet au 6 août 2026.")
+                             .and include("Nombre de créneaux calculé le 07/07 à 05h00")
       end
 
       context "when at department level" do
@@ -995,7 +997,7 @@ describe UsersController do
           get :index, params: index_params
 
           expect(response.body).to include("11 créneaux disponibles")
-          expect(response.body).not_to include("Pour la période")
+          expect(response.body).not_to include("Visibilité du")
         end
       end
 


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Ajout-info-tooltip-cr-neaux-3965f321b60480a2b55cdd4d3bb55c5a
