### PR TITLE
feat(api): Reopen follow up when closed

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -18,6 +18,7 @@ module Api
       private
 
       rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+      rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
 
       def validate_rdv_solidarites_credentials!
         return if rdv_solidarites_credentials.valid?
@@ -52,6 +53,10 @@ module Api
 
       def authenticated_agent
         @authenticated_agent ||= Agent.find_by(email: rdv_solidarites_credentials.email)
+      end
+
+      def record_invalid(exception)
+        render json: { success: false, errors: exception.record.errors.full_messages }, status: :unprocessable_content
       end
 
       def record_not_found(exception)

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -58,6 +58,7 @@ module Api
         return render_errors(["Impossible de créer l'usager: #{upsert_user.errors.join(', ')}"]) if upsert_user.failure?
 
         find_or_create_follow_up
+        reopen_follow_up_if_closed
 
         @invitations, @invitation_errors = [[], []]
         invite_user_by("sms") if @user.phone_number_is_mobile?
@@ -118,7 +119,11 @@ module Api
       def find_or_create_follow_up
         return if motif_category_attributes.blank?
 
-        @user.find_or_create_follow_up!(MotifCategory.find_by!(motif_category_attributes))
+        @follow_up = @user.find_or_create_follow_up!(MotifCategory.find_by!(motif_category_attributes))
+      end
+
+      def reopen_follow_up_if_closed
+        @follow_up.reopen! if @follow_up.closed?
       end
 
       def invite_user_by(format)

--- a/app/jobs/create_and_invite_user_job.rb
+++ b/app/jobs/create_and_invite_user_job.rb
@@ -12,6 +12,7 @@ class CreateAndInviteUserJob < ApplicationJob
 
     upsert_user!
     find_or_create_follow_up
+    reopen_follow_up_if_closed
     invite_user
   end
 
@@ -39,7 +40,11 @@ class CreateAndInviteUserJob < ApplicationJob
   def find_or_create_follow_up
     return if @motif_category_attributes.blank?
 
-    @user.find_or_create_follow_up!(MotifCategory.find_by!(@motif_category_attributes))
+    @follow_up = @user.find_or_create_follow_up!(MotifCategory.find_by!(@motif_category_attributes))
+  end
+
+  def reopen_follow_up_if_closed
+    @follow_up.reopen! if @follow_up.closed?
   end
 
   def invite_user

--- a/app/models/follow_up.rb
+++ b/app/models/follow_up.rb
@@ -47,6 +47,10 @@ class FollowUp < ApplicationRecord
     closed_at.present?
   end
 
+  def reopen!
+    update!(closed_at: nil)
+  end
+
   def orientation?
     motif_category.rsa_orientation?
   end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -600,6 +600,55 @@ describe "Users API", swagger_doc: "v1/api.json" do
       end
       # rubocop:enable RSpec/EmptyExampleGroup
 
+      context "gestion du follow_up de la catégorie de motif", :skip_examples do
+        let!(:motif_category) { create(:motif_category, name: "RSA orientation") }
+
+        before { allow(MotifCategory).to receive(:find_by!).and_return(motif_category) }
+
+        it "crée un follow_up pour l'usager dans la catégorie de motif" do
+          expect do
+            post create_and_invite_api_v1_users_path(rdv_solidarites_organisation_id),
+                 params: user_params.to_json,
+                 headers: auth_headers.merge({ "Content-Type" => "application/json" })
+          end.to change { user.follow_ups.where(motif_category:).count }.from(0).to(1)
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        context "quand l'usager a déjà un follow_up fermé pour cette catégorie de motif" do
+          let!(:follow_up) { create(:follow_up, user:, motif_category:, closed_at: 1.day.ago) }
+
+          it "réouvre le follow_up" do
+            expect do
+              post create_and_invite_api_v1_users_path(rdv_solidarites_organisation_id),
+                   params: user_params.to_json,
+                   headers: auth_headers.merge({ "Content-Type" => "application/json" })
+            end.to change { follow_up.reload.closed? }.from(true).to(false)
+
+            expect(response).to have_http_status(:ok)
+          end
+
+          context "quand la réouverture du follow_up est invalide" do
+            before do
+              invalid_follow_up = build(:follow_up)
+              invalid_follow_up.errors.add(:base, "Le suivi ne peut pas être rouvert")
+              allow_any_instance_of(FollowUp).to receive(:reopen!)
+                .and_raise(ActiveRecord::RecordInvalid.new(invalid_follow_up))
+            end
+
+            it "renvoie une erreur 422 avec les messages d'erreur" do
+              post create_and_invite_api_v1_users_path(rdv_solidarites_organisation_id),
+                   params: user_params.to_json,
+                   headers: auth_headers.merge({ "Content-Type" => "application/json" })
+
+              expect(response).to have_http_status(:unprocessable_content)
+              expect(parsed_response_body["success"]).to eq(false)
+              expect(parsed_response_body["errors"]).to include("Le suivi ne peut pas être rouvert")
+            end
+          end
+        end
+      end
+
       it_behaves_like "common API errors"
 
       it_behaves_like "an endpoint that returns 422 - unprocessable_entity", "les paramètres sont incomplets", true do


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/API-78-Yvelines-3965f321b60480b1a4e0ebcf1b1dac53?source=copy_link

Dans #3329 , on avait fait en sorte d'ouvrir le suivi avant l'envoi d'invitation pour que le suivi soit ouvert même si la personne n'a pas pu être invité (car l'email ou le téléphone manquait).
Cependant on a pas géré le cas où le suivi existait déjà mais était fermé. Par cohérence avec ce qu'il se passe dans le reste de l'appli (au moment de l'upload notamment), il est cohérent de réouvrir les suivis qui ont été fermés.
Je le fais ici et je rajoute les tests associés.