### PR TITLE
fix(migration): Increase statement timeout for invitations origin migration

### DIFF
--- a/db/migrate/20260619131224_replace_invitations_trigger_with_origin.rb
+++ b/db/migrate/20260619131224_replace_invitations_trigger_with_origin.rb
@@ -1,4 +1,7 @@
 class ReplaceInvitationsTriggerWithOrigin < ActiveRecord::Migration[8.1]
+  set_lock_timeout(60_000)
+  set_statement_timeout(120_000)
+
   def up
     add_column :invitations, :origin, :string
     add_index :invitations, :origin


### PR DESCRIPTION
J'augmente le statement timeout pour la migration backfillant les `origin` que je ferai tourner en heure creuse