### PR TITLE
fix(view): remove filter selection when shortcut button clicked twice

### DIFF
--- a/app/helpers/users_list_indicators_helper.rb
+++ b/app/helpers/users_list_indicators_helper.rb
@@ -16,4 +16,12 @@ module UsersListIndicatorsHelper
   def follow_up_statuses_filter_active?(statuses)
     Array(params[:follow_up_statuses]).sort == statuses.sort
   end
+
+  def shortcut_url_params_for(statuses_filtering, active)
+    if active
+      url_params.merge(follow_up_statuses: url_params[:follow_up_statuses] - statuses_filtering)
+    else
+      url_params.merge(follow_up_statuses: statuses_filtering)
+    end.except(:page)
+  end
 end

--- a/app/views/users/_users_list_indicators.html.erb
+++ b/app/views/users/_users_list_indicators.html.erb
@@ -3,12 +3,12 @@
     <%= render "users/users_list_indicators/creneaux_count", creneau_availability: @latest_creneau_availability %>
   <% end %>
   <%= render "users/users_list_indicators/follow_up_status_filter_shortcut",
-             statuses: ["invitation_expired"],
+             statuses_filtering: ["invitation_expired"],
              count: @statuses_count["invitation_expired"].to_i,
              label: "invitations en délai dépassé",
              color: "orange" %>
   <%= render "users/users_list_indicators/follow_up_status_filter_shortcut",
-             statuses: FollowUp::RDV_CANCELLED_OR_ABSENCE_STATUSES,
+             statuses_filtering: FollowUp::RDV_CANCELLED_OR_ABSENCE_STATUSES,
              count: rdv_cancelled_or_absence_count(@statuses_count),
              label: "RDV annulés ou absence",
              color: "red" %>

--- a/app/views/users/users_list_indicators/_follow_up_status_filter_shortcut.html.erb
+++ b/app/views/users/users_list_indicators/_follow_up_status_filter_shortcut.html.erb
@@ -1,5 +1,5 @@
-<% active = follow_up_statuses_filter_active?(statuses) %>
-<%= link_to structure_users_path(url_params.except(:page).merge(follow_up_statuses: statuses)),
+<% active = follow_up_statuses_filter_active?(statuses_filtering) %>
+<%= link_to structure_users_path(shortcut_url_params_for(statuses_filtering, active)),
             class: "status-shortcut status-shortcut--#{color} rounded bg-white p-2 " \
                    "d-inline-flex align-items-center gap-2 text-decoration-none " \
                    "#{'status-shortcut--active' if active}" do %>


### PR DESCRIPTION
Suite à un  retour de ce Samantha, on veut que les filtres introduits dans #3338  soient désélectionnés lorsqu'on clique une seconde fois dessus.