### PR TITLE
chore(deps): Update rails-html-sanitizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     crack (1.0.1)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     cronex (0.15.0)
       tzinfo
       unicode (>= 0.4.4.5)
@@ -275,7 +275,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -440,8 +440,8 @@ GEM
       activesupport (>= 4.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.2.1)
       actionpack (= 8.1.2.1)
@@ -721,4 +721,4 @@ RUBY VERSION
   ruby 4.0.1p0
 
 BUNDLED WITH
-  4.0.4
+  4.0.12


### PR DESCRIPTION
Suite à une alerte de Charles sur une vulnérabilité de la dépendance `rails-html-sanitizer` (voir https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-cj75-f6xr-r4g7), je mets à jour la gem en question.