### PR TITLE
fix(letter): Format instruction for rdv on convocation letters

### DIFF
--- a/app/views/letters/notifications/by_phone_participation_created.html.erb
+++ b/app/views/letters/notifications/by_phone_participation_created.html.erb
@@ -10,7 +10,7 @@
   <p>Vous êtes <%= user_designation %> et à ce titre vous êtes <%= user.conjugate("convoqué") %> à un <%= rdv_title %> pour <%= rdv_purpose %>.</p>
   <p>Un conseiller d'insertion<%= " (#{agents_names})" if agents_names.present? %> vous appellera le <strong><%= I18n.l(rdv.starts_at_in_time_zone, format: :human) %></strong> sur votre numéro de téléphone&nbsp;: <strong><%= user.phone_number %></strong>.</p>
   <%= tag.p tag.strong("#{mandatory_warning}.") if mandatory_warning %>
-  <%= tag.p tag.span(instruction_for_rdv) if instruction_for_rdv.present? %>
+  <%= simple_format(h(instruction_for_rdv)) if instruction_for_rdv.present? %>
   <%= tag.p tag.strong("En cas d'absence, #{punishable_warning}.") if punishable_warning.present? %>
   <p>En cas d'empêchement, veuillez appeler le <%= rdv.phone_number %>.</p>
   <%= render "letters/salutation", user: user %>

--- a/app/views/letters/notifications/presential_participation_created.html.erb
+++ b/app/views/letters/notifications/presential_participation_created.html.erb
@@ -25,7 +25,7 @@
     <% end %>
   </div>
   <%= tag.p tag.strong("#{mandatory_warning}.") if mandatory_warning %>
-  <%= tag.p tag.span(instruction_for_rdv) if instruction_for_rdv.present? %>
+  <%= simple_format(h(instruction_for_rdv)) if instruction_for_rdv.present? %>
   <%= tag.p tag.strong("En cas d'absence, #{punishable_warning}.") if punishable_warning.present? %>
   <p>En cas d'empêchement, veuillez appeler le <%= rdv.phone_number %>.</p>
   <%= render "letters/salutation", user: user %>

--- a/app/views/letters/notifications/visio_participation_created.html.erb
+++ b/app/views/letters/notifications/visio_participation_created.html.erb
@@ -20,7 +20,7 @@
     <% end %>
   </div>
   <%= tag.p tag.strong("#{mandatory_warning}.") if mandatory_warning %>
-  <%= tag.p tag.span(instruction_for_rdv) if instruction_for_rdv.present? %>
+  <%= simple_format(h(instruction_for_rdv)) if instruction_for_rdv.present? %>
   <%= tag.p tag.strong("En cas d'absence, #{punishable_warning}.") if punishable_warning.present? %>
   <p>En cas d'empêchement, veuillez appeler le <%= rdv.phone_number %>.</p>
   <%= render "letters/salutation", user: user %>


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Courriers-Adapter-mise-en-page-FALC-1-3a45f321b60480638bb8d24979abd115

Les sauts de lignes que comportent les `instruction_for_rdv` configurable au niveau des motifs n'étaient pas retranscrit dans les courriers de convocations.
Je règle ça ici en utilisant le helper `simple_format` qui convertit les sauts de ligne en balise html. 
J'en profite aussi pour utiliser la méthode `h` (alias de `html_escape`) pour encoder les caractères spéciaux.