### PR TITLE
chore(deps): Upgrade websocket-driver gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.0)
+    msgpack (1.8.3)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
@@ -622,7 +622,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
Je mets la gem `websocket-driver` à jour suite à une alerte de notre dependency scan (qui fait échouer la CI).