### PR TITLE
refactor(archive): Make invitations expiration async

### DIFF
--- a/app/jobs/invalidate_invitations_after_archiving_job.rb
+++ b/app/jobs/invalidate_invitations_after_archiving_job.rb
@@ -1,0 +1,29 @@
+class InvalidateInvitationsAfterArchivingJob < ApplicationJob
+  def perform(archive_id)
+    @archive = Archive.find_by(id: archive_id)
+    return unless archive
+
+    related_invitations.find_each do |invitation|
+      next unless user_archived_in_all_invitations_organisations?(invitation)
+
+      ExpireInvitationJob.perform_later(invitation.id)
+    end
+  end
+
+  private
+
+  attr_reader :archive
+
+  def user = archive.user
+  def organisation = archive.organisation
+
+  def related_invitations
+    organisation.invitations.where(user:)
+  end
+
+  def user_archived_in_all_invitations_organisations?(invitation)
+    (invitation.organisations & user.organisations).all? do |org|
+      user.archived_in_organisation?(org)
+    end
+  end
+end

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -18,13 +18,7 @@ class Archive < ApplicationRecord
   private
 
   def invalidate_related_invitations
-    organisation.invitations.where(user: user.reload).includes(:organisations).find_each do |invitation|
-      next unless (invitation.organisations & user.organisations).all? do |organisation|
-        user.archived_in_organisation?(organisation)
-      end
-
-      ExpireInvitationJob.perform_later(invitation.id)
-    end
+    InvalidateInvitationsAfterArchivingJob.perform_later(id)
   end
 
   def user_must_belong_to_organisation

--- a/spec/jobs/invalidate_invitations_after_archiving_job_spec.rb
+++ b/spec/jobs/invalidate_invitations_after_archiving_job_spec.rb
@@ -1,0 +1,41 @@
+describe InvalidateInvitationsAfterArchivingJob do
+  subject(:perform_job) { described_class.new.perform(archive.id) }
+
+  let!(:department) { create(:department) }
+  let!(:organisation) { create(:organisation, department:) }
+  let!(:other_organisation) { create(:organisation, department:) }
+  let!(:user) { create(:user, organisations: [organisation, other_organisation]) }
+  let!(:archive) { create(:archive, user:, organisation:) }
+
+  let!(:invitation) do
+    create(:invitation, user:, department:, organisations: [organisation, other_organisation])
+  end
+
+  context "when the user is archived in every organisation shared with the invitation" do
+    before { create(:archive, user:, organisation: other_organisation, archiving_reason: "test") }
+
+    it "expires the invitation" do
+      expect(ExpireInvitationJob).to receive(:perform_later).with(invitation.id)
+      perform_job
+    end
+  end
+
+  context "when the user is still active in one of the invitation's organisations" do
+    it "does not expire the invitation" do
+      expect(ExpireInvitationJob).not_to receive(:perform_later).with(invitation.id)
+      perform_job
+    end
+  end
+
+  context "when the invitation targets an organisation the user does not belong to" do
+    let!(:foreign_organisation) { create(:organisation, department:) }
+    let!(:invitation) do
+      create(:invitation, user:, department:, organisations: [organisation, foreign_organisation])
+    end
+
+    it "ignores that organisation and expires the invitation" do
+      expect(ExpireInvitationJob).to receive(:perform_later).with(invitation.id)
+      perform_job
+    end
+  end
+end

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -71,33 +71,11 @@ describe Archive do
   end
 
   describe "invitation invalidations" do
-    let!(:department) { create(:department) }
-    let!(:organisation) { create(:organisation, department:) }
     let!(:archive) { build(:archive, user:, organisation:) }
-    let!(:user) { create(:user, organisations: [organisation, other_organisation]) }
-    let!(:other_organisation) { create(:organisation, department:) }
-    let!(:invitation) do
-      create(:invitation, user:, department:,
-                          organisations: [organisation, other_organisation, organisation_user_does_not_belong_to])
-    end
-    let!(:organisation_user_does_not_belong_to) { create(:organisation, department:) }
 
-    context "when the user is not archived in all the organisations he shares with the invitation" do
-      it "does not invalidate the invitation" do
-        expect(ExpireInvitationJob).not_to receive(:perform_later).with(invitation.id)
-        archive.save!
-      end
-    end
-
-    context "when the user is archived in all the organisations he shares with the invitation" do
-      let!(:archive_in_other_organisation) do
-        create(:archive, user:, organisation: other_organisation, archiving_reason: "test")
-      end
-
-      it "invalidates the invitation" do
-        expect(ExpireInvitationJob).to receive(:perform_later).with(invitation.id)
-        archive.save!
-      end
+    it "enqueues a job to invalidate related invitations on creation" do
+      expect(InvalidateInvitationsAfterArchivingJob).to receive(:perform_later)
+      archive.save!
     end
   end
 end


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Juillet-Am-liorer-le-temps-de-r-ponse-des-endpoints-tr-s-utilis-s-3835f321b6048021971edf438e3cb03a?source=copy_link

J'ai remarqué sur skylight que l'archivage d'un usager prenait parfois plus d'une seconde. C'est dû en majeur partie au callback `invalidate_related_invitations` qui faisait plusieurs requêtes pour récupérer les invitations et les organisations associées. 
Je fais en sorte de rendre cette logique asynchrone pour améliorer le temps de réponse de l'archivage.