### PR TITLE
refactor(perf): Improve users index endpoint speed

### DIFF
--- a/app/controllers/concerns/users/filterable.rb
+++ b/app/controllers/concerns/users/filterable.rb
@@ -40,7 +40,7 @@ module Users::Filterable
   def filter_users_by_follow_up_statuses
     return if params[:follow_up_statuses].blank?
 
-    @users = @users.joins(:follow_ups).where(follow_ups: @follow_ups.status(params[:follow_up_statuses]))
+    @users = @users.joins(:follow_ups).where(follow_ups: { status: params[:follow_up_statuses] })
   end
 
   def filter_users_by_orientation_types
@@ -59,7 +59,7 @@ module Users::Filterable
   def filter_users_by_action_required
     return unless params[:action_required] == "true"
 
-    @users = @users.joins(:follow_ups).where(follow_ups: @follow_ups.action_required)
+    @users = @users.joins(:follow_ups).where(follow_ups: { status: FollowUp::STATUSES_WITH_ACTION_REQUIRED })
   end
 
   def filter_users_by_referents

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -101,8 +101,11 @@ class UsersController < ApplicationController
   end
 
   def generate_csv
+    # reorder(nil) is needed because plucking ids keeps the ORDER BY on a column that is no longer
+    # selected, which Postgres rejects for DISTINCT queries. Order is irrelevant here anyway:
+    # the export job refetches users by id.
     csv_exporter.perform_later(
-      @users.map(&:id),
+      @users.reorder(nil).ids,
       department_level? ? "Department" : "Organisation",
       department_level? ? @department.id : @organisation.id,
       current_agent.id,
@@ -232,21 +235,27 @@ class UsersController < ApplicationController
   def set_all_users
     @users = policy_scope(User)
              .active.distinct
-             .preload(:organisations).where(organisations: current_organisations)
-    return if request.format == "csv"
+             .where(organisations: current_organisations)
+    return if only_ids_needed?
 
-    @users = @users.preload(:archives, follow_ups: [:invitations])
+    @users = @users.preload(:organisations, :archives, follow_ups: [:invitations])
   end
 
   def set_users_for_motif_category
     @users = policy_scope(User)
-             .preload(:organisations, follow_ups: [:notifications, :invitations, { participations: :rdv }])
              .active.distinct
              .where(organisations: current_organisations)
              .where.not(id: archived_user_ids_in_organisations(current_organisations))
              .joins(:follow_ups)
              .where(follow_ups: { motif_category: @current_motif_category })
              .where.not(follow_ups: { status: "closed" })
+    return if only_ids_needed?
+
+    @users = @users.preload(:organisations, follow_ups: [:notifications, :invitations, { participations: :rdv }])
+  end
+
+  def only_ids_needed?
+    request.format == "csv" || params[:ids_only] == "true"
   end
 
   def set_archived_users


### PR DESCRIPTION
Lié à https://app.notion.com/p/gip-inclusion/Juillet-Am-liorer-le-temps-de-r-ponse-des-endpoints-tr-s-utilis-s-3835f321b6048021971edf438e3cb03a

Je tente deux choses pour améliorer les perfs sur `users#index`: 
* Je ne load que les ids des users et sans leurs associations pour les requêtes csv (qui génèrent le csv en asynchrone): https://github.com/gip-inclusion/rdv-insertion/commit/0e1dcaa34d954b30b22875195bb9b6ae0ca7c8b8
* Je ne filtre pas les `@follow_ups` déjà loadés lorsqu'on filtre les usagers  par statuts pour éviter les requêtes imbriquées qui peuvent être coûteuses. À la place je faire directement le filtre sur les `@users` https://github.com/gip-inclusion/rdv-insertion/commit/a3de1627b7e484142d65e4ada82b7a56b1736190